### PR TITLE
Add MANIFEST.in to include config.yaml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include casanovo/config.yaml


### PR DESCRIPTION
Adds a MANIFEST.in file that allows config.yaml to be included in the pip install.

Fixes #42 