### PR TITLE
Prevents divide by zero error caused when n_gpus == 0

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -187,7 +187,9 @@ def main(
     if mode == "denovo":
         logger.info("Predict peptide sequences with Casanovo.")
         writer = ms_io.MztabWriter(f"{output}.mztab")
-        writer.set_metadata(peak_path, config, model=model, config_filename=config_fn)
+        writer.set_metadata(
+            peak_path, config, model=model, config_filename=config_fn
+        )
         model_runner.predict(peak_path, model, config, writer)
         writer.save()
     elif mode == "eval":

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -163,7 +163,7 @@ def main(
     }
     # Add extra configuration options and scale by the number of GPUs.
     n_gpus = torch.cuda.device_count()
-    if (n_gpus != 0):
+    if n_gpus != 0:
         config["n_workers"] = len(psutil.Process().cpu_affinity()) // n_gpus
         config["train_batch_size"] = config["train_batch_size"] // n_gpus
     else:
@@ -187,9 +187,7 @@ def main(
     if mode == "denovo":
         logger.info("Predict peptide sequences with Casanovo.")
         writer = ms_io.MztabWriter(f"{output}.mztab")
-        writer.set_metadata(
-            peak_path, config, model=model, config_filename=config_fn
-        )
+        writer.set_metadata(peak_path, config, model=model, config_filename=config_fn)
         model_runner.predict(peak_path, model, config, writer)
         writer.save()
     elif mode == "eval":

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -163,8 +163,12 @@ def main(
     }
     # Add extra configuration options and scale by the number of GPUs.
     n_gpus = torch.cuda.device_count()
-    config["n_workers"] = len(psutil.Process().cpu_affinity()) // n_gpus
-    config["train_batch_size"] = config["train_batch_size"] // n_gpus
+    if (n_gpus != 0):
+        config["n_workers"] = len(psutil.Process().cpu_affinity()) // n_gpus
+        config["train_batch_size"] = config["train_batch_size"] // n_gpus
+    else:
+        config["n_workers"] = len(psutil.Process().cpu_affinity())
+        config["train_batch_size"] = config["train_batch_size"]
 
     pl.utilities.seed.seed_everything(seed=config["random_seed"], workers=True)
 


### PR DESCRIPTION
Error was on line 166 of casanovo.py (```config["n_workers"] = len(psutil.Process().cpu_affinity()) // n_gpus```) and caused the error: ```ZeroDivisionError: integer division or modulo by zero```. Added a safety net if ```n_gpus```  is zero.