### PR TITLE
Pass folder path to initialize Tensorboard object

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,4 +40,5 @@ jobs:
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -7,6 +7,7 @@ import depthcharge.masses
 import numpy as np
 import pytorch_lightning as pl
 import torch
+from torch.utils.tensorboard import SummaryWriter
 from depthcharge.components import ModelMixin, PeptideDecoder, SpectrumEncoder
 
 from . import evaluate
@@ -63,9 +64,9 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         fit the specified isotope error: `abs(calc_mz - (precursor_mz - isotope * 1.00335 / precursor_charge)) < precursor_mass_tol`
     n_log : int
         The number of epochs to wait between logging messages.
-    tb_summarywriter: Optional[torch.utils.tensorboard.SummaryWriter]
-        Object to record performance metrics during training. If ``None``, don't
-        use a ``SummarWriter``.
+    tb_summarywriter: Optional[str]
+        Folder path to record performance metrics during training. If ``None``, don't
+        use a ``SummaryWriter``.
     warmup_iters: int
         The number of warm up iterations for the learning rate scheduler.
     max_iters: int
@@ -142,7 +143,10 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         # Logging.
         self.n_log = n_log
         self._history = []
-        self.tb_summarywriter = tb_summarywriter
+        if tb_summarywriter is not None:
+            self.tb_summarywriter = SummaryWriter(tb_summarywriter)
+        else:
+            self.tb_summarywriter = tb_summarywriter
 
         # Output writer during predicting.
         self.out_writer = out_writer

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,17 +1,19 @@
 """Test that setuptools-scm is working correctly"""
 import casanovo
-from ..denovo.model import Spec2Pep
+from casanovo.denovo.model import Spec2Pep
+
 
 def test_version():
     """Check that the version is not None"""
     assert casanovo.__version__ is not None
-    
+
+
 def test_tensorboard():
     """Check that the version is not None"""
     model = Spec2Pep(
         tb_summarywriter="test_path",
     )
     assert model.tb_summarywriter is not None
-    
+
     model = Spec2Pep()
     assert model.tb_summarywriter is None

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,7 +1,17 @@
 """Test that setuptools-scm is working correctly"""
 import casanovo
-
+from ..denovo.model import Spec2Pep
 
 def test_version():
     """Check that the version is not None"""
     assert casanovo.__version__ is not None
+    
+def test_tensorboard():
+    """Check that the version is not None"""
+    model = Spec2Pep(
+        tb_summarywriter="test_path",
+    )
+    assert model.tb_summarywriter is not None
+    
+    model = Spec2Pep()
+    assert model.tb_summarywriter is None


### PR DESCRIPTION
Changed `tb_summarywriter` from `torch.utils.tensorboard.SummaryWriter` to `str` because we used to initialize the object in **config.py** but can't do this in **config.yaml**. Initialization now happens inside `Spec2Pep` if a folder path is passed. 