### PR TITLE
Add unit test for evaluation metrics

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8,6 +8,7 @@ import pytest
 from casanovo import casanovo
 from casanovo import utils
 from casanovo.denovo.model import Spec2Pep
+from casanovo.denovo.evaluate import aa_match_batch, aa_match_metrics
 
 
 def test_version():
@@ -104,3 +105,44 @@ def test_tensorboard():
 
     model = Spec2Pep()
     assert model.tb_summarywriter is None
+
+
+def test_eval_metrics():
+    """
+    Test that peptide and amino acid-level evaluation metrics.
+    Predicted AAs are considered correct match if they're <0.1Da from
+    the corresponding ground truth (GT) AA with either a suffix or
+    prefix <0.5Da from GT. A peptide prediction is correct if all
+    its AA are correct matches.
+    """
+    model = Spec2Pep()
+
+    preds = [
+        "SPEIK",
+        "SPAEL",
+        "SPAEKL",
+        "ASPEKL",
+        "SPEKL",
+        "SPELQ",
+        "PSEKL",
+        "SPEK",
+    ]
+    gt = len(preds) * ["SPELK"]
+
+    aa_matches, n_pred_aa, n_gt_aa = aa_match_batch(
+        peptides1=preds,
+        peptides2=gt,
+        aa_dict=model.decoder._peptide_mass.masses,
+        mode="best",
+    )
+
+    assert n_pred_aa == 41
+    assert n_gt_aa == 40
+
+    aa_precision, aa_recall, pep_precision = aa_match_metrics(
+        aa_matches, n_gt_aa, n_pred_aa
+    )
+
+    assert round(2 / 8, 3) == round(pep_precision, 3)
+    assert round(26 / 40, 3) == round(aa_recall, 3)
+    assert round(26 / 41, 3) == round(aa_precision, 3)


### PR DESCRIPTION
Added a unit test for for peptide and amino acid-level evaluation metrics after reviewing `evaluate.py`.