### PR TITLE
Add sphinx documentation site

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+../CODE_OF_CONDUCT.md

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,78 @@
+from importlib.metadata import version
+
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath("."))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "Casanovo"
+copyright = "2022, The Casanovo Team"
+author = "The Casanovo Team"
+release = version("casanovo")
+version = ".".join(release.split(".")[:2])
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named "sphinx.ext.*") or your custom
+# ones.
+extensions = ["myst_parser"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# The format for each file suffix:
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_book_theme"
+html_title = "Casanovo"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+html_theme_options = {"repository_url": "https//github.com/Noble-Lab/casanovo"}
+
+# -- MyST configuration ------------------------------------------------------
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "fieldlist",
+    "html_admonition",
+    "html_image",
+    "replacements",
+    "smartquotes",
+    "strikethrough",
+    "substitution",
+    "tasklist",
+]
+myst_heading_anchors = 3

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -1,0 +1,10 @@
+name: casanovo-docs
+channels:
+  - bioconda
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+      - ..[docs]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,46 @@
+# Frequently Asked Questions
+
+**I installed Casanovo and it worked before, but I after reopening Anaconda it says that Casanovo is not installed.**
+
+Make sure you are in the `casanovo_env` environment. You can ensure this by typing:
+
+```
+conda activate casanovo_env
+```
+
+**Which command-line options are available?**
+
+Run the following command in your command prompt to see all possible command-line configuration options:
+```
+casanovo --help
+```
+
+Additionally, you can use a configuration file to fully customize Casanovo.
+You can find the `config.yaml` configuration file that is used by default [here](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml).
+
+**I get a "CUDA out of memory" error when trying to run Casanovo. Help!**
+
+This means that there was not enough (free) memory available on your GPU to run Casanovo, which is especially likely to happen when you are using a smaller, consumer-grade GPU.
+We recommend trying to decrease the `train_batch_size` or `predict_batch_size` options in the [config file](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) (depending on whether the error occurred during `train` or `denovo` mode) to reduce the number of spectra that are processed simultaneously.
+Additionally, we recommend shutting down any other processes that may be running on the GPU, so that Casanovo can exclusively use the GPU.
+
+**How do I solve a "PermissionError: GitHub API rate limit exceeded" error when trying to run Casanovo?**
+
+When running Casanovo in `denovo` or `eval` mode, Casanovo needs compatible pretrained model weights to make predictions.
+If no model weights file is specified using the `--model` command-line parameter, Casanovo will automatically try to download the latest compatible model file from GitHub and save it to its cache for subsequent use.
+However, the GitHub API is limited to maximum 60 requests per hour per IP address.
+Consequently, if Casanovo has been executed multiple times already, it might temporarily not be able to communicate with GitHub.
+You can avoid this error by explicitly specifying the model file using the `--model` parameter.
+
+**I see "NotImplementedError: The operator 'aten::index.Tensor'..." when using a Mac with an Apple Silicon chip.**
+
+Casanovo can leverage Apple's Metal Performance Shaders (MPS) on newer Mac computers, which requires that the `PYTORCH_ENABLE_MPS_FALLBACK` is set to `1`:
+
+``` sh
+export PYTORCH_ENABLE_MPS_FALLBACK=1
+```
+
+This will need to be set with each new shell session, or you can add it to your `.bashrc` / `.zshrc` to set this environment variable by default.
+
+
+

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,125 @@
+# Getting Started
+
+## Installation
+
+We recommend to run Casanovo in a dedicated [conda environment](https://docs.conda.io/en/latest/).
+This helps keep your environment for Casanovo and its dependencies separate from your other Python environments.
+
+```{Note}
+Don't know what conda is?
+Conda is a package manager for Python packages and many others.
+We recommend installing the Anaconda Python distribution which includes conda.
+Check out the [Windows](https://docs.anaconda.com/anaconda/install/windows/#), [MacOS](https://docs.anaconda.com/anaconda/install/mac-os/), and [Linux](https://docs.anaconda.com/anaconda/install/linux/) installation instructions.
+```
+
+Once you have conda installed, you can use this helpful [cheat sheet](https://docs.conda.io/projects/conda/en/4.6.0/_downloads/52a95608c49671267e40c689e0bc00ca/conda-cheatsheet.pdf) to see common commands and what they do.
+
+### Create a conda environment
+
+Fist, open the terminal (MacOS and Linux) or the Anaconda Prompt (Windows).
+All of the commands that follow should be entered this terminal or Anaconda Prompt window---that is, your *shell*. 
+To create a new conda environment for Casanovo, run the following:
+```
+conda create --name casanovo_env python=3.10
+```
+
+This will create an anaconda environment called `casanovo_env` that has Python 3.10 installed.
+
+Activate this environment by running:
+```
+conda activate casanovo_env
+```
+
+Your shell should now say **(casanovo_env)** instead of **(base)**.
+If this is the case, then you have set up conda and the environment correctly.
+
+```{note}
+Be sure to retype in the activation command into your terminal when you reopen anaconda and want to use Casanovo.
+```
+
+### *Optional:* Install PyTorch
+
+If you have a graphics processing unit (GPU) that you want Casanovo to use, we recommend installing PyTorch manually.
+This will ensure that the version of PyTorch used by Casanovo will be compatible with your CPU.
+For installation instructions, see the [PyTorch documentation](https://pytorch.org/get-started/locally/#start-locally)
+
+### Install Casanovo
+
+You can now install the Casanovo Python package (dependencies will be installed automatically as needed):
+
+``` sh
+pip install casanovo
+```
+
+After installation, test that it was successful by viewing the Casanovo command line interface help:
+```sh
+casanovo --help
+```
+
+All auxiliary data, model, and training-related parameters can be specified in a user created `.yaml` configuration file.
+See [`casanovo/config.yaml`](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) for the default configuration that was used to obtain the reported results.
+
+
+### Download model weights
+
+When running Casanovo in `denovo` or `eval` mode, Casanovo needs compatible pretrained model weights to make predictions.
+Our model weights are uploaded with new Casanovo versions on the [Releases page](https://github.com/Noble-Lab/casanovo/releases) under the "Assets" for each release (file extension: .ckpt).
+The model file can then be specified using the `--model` command-line parameter when executing Casanovo.
+To assist users, if no model file is specified Casanovo will try to download and use a compatible model file automatically.
+
+Not all releases might have a model file included on the [Releases page](https://github.com/Noble-Lab/casanovo/releases), in which case model weights for alternative releases with the same major version number can be used.
+
+## Running Casanovo
+
+### Sequence new mass spectra
+To sequence your own mass spectra with Casanovo, use the `denovo` mode:
+```
+casanovo --mode=denovo --peak_path=path/to/predict/spectra.mgf --output=path/to/output
+```
+
+Casanovo can predict peptide sequences for MS/MS spectra in mzML, mzXML, and MGF files.
+This will write peptide predictions for the given MS/MS spectra to the specified output file in mzTab format.
+
+### Evaluate *de novo* sequenceing performance
+
+To evaluate _de novo_ sequencing performance based on known mass spectrum annotations, run:
+```
+casanovo --mode=eval --peak_path=path/to/test/annotated_spectra.mgf
+```
+
+To evaluate the peptide predictions, ground truth peptide labels must to be provided as an annotated MGF file where the peptide sequence is denoted in the `SEQ` field.
+
+### Train a new model
+To train a model from scratch, run:
+```
+casanovo --mode=train --peak_path=path/to/train/annotated_spectra.mgf --peak_path_val=path/to/validation/annotated_spectra.mgf
+```
+
+Training and validation MS/MS data need to be provided as annotated MGF files, where the peptide sequence is denoted in the `SEQ` field.
+
+If a training is continued for a previously trained model, specify the starting model weights using `--model`.
+
+## Try Casanovo on a small example
+
+Here, we demonstrate how to use Casanovo using a small collection of mass spectra in an MGF file (~100 MS/MS spectra).
+The example MGF file is available at [`sample_data/sample_preprocessed_spectra.mgf`](https://github.com/Noble-Lab/casanovo/blob/main/sample_data/sample_preprocessed_spectra.mgf`).
+
+To obtain *de novo* sequencing predictions for these spectra:
+1. Download the example MGF above.
+2. [Install Casanovo](#installation).
+3. Ensure your Casanovo conda environment is activated by typing `conda activate casanovo_env`. (If you named your environment differently, type in that name instead.)
+4. Sequence the mass spectra with Casanovo, replacing `[PATH_TO]` with the path to the example MGF file that you downloaded:
+```
+casanovo --mode=denovo --peak_path=[PATH_TO]/sample_preprocessed_spectra.mgf
+```
+
+```{note}
+If you want to store the output mzTab file in a different location than the current working directory, specify an alternative output location using the `--output` parameter.
+```
+
+This job should complete in < 1 minute.
+
+Congratulations! Casanovo is installed and running.
+
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# Casanovo
+
+**_De Novo_ Mass Spectrometry Peptide Sequencing with a Transformer Model**
+
+![image](https://user-images.githubusercontent.com/32707537/152622912-ca87da20-a64c-4e3f-9ca1-721c6b0d9c64.png)
+
+If you use Casanovo in your work, please cite the following publication:
+
+- Yilmaz, M., Fondrie, W. E., Bittremieux, W., Oh, S. & Noble, W. S. *De novo* mass spectrometry peptide sequencing with a transformer model. in *Proceedings of the 39th International Conference on Machine Learning - ICML '22* vol. 162 25514–25522 (PMLR, 2022). [https://proceedings.mlr.press/v162/yilmaz22a.html](https://proceedings.mlr.press/v162/yilmaz22a.html)
+
+```{toctree}
+---
+hidden: true
+maxdepth: 1
+---
+Getting Started <getting_started.md>
+FAQs <faq.md>
+Contributing <CONTRIBUTING.md>
+Code of Conduct <CODE_OF_CONDUCT.md>
+Changelog <CHANGELOG.md>
+```

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
 
 [options.extras_require]
 docs =
+    sphinx>=4.5.0
     myst-parser>=0.18.1
     sphinx-book-theme>=0.3.3
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,12 +39,8 @@ install_requires =
 
 [options.extras_require]
 docs =
-    ipykernel>=5.3.0
-    nbsphinx>=0.7.1
-    numpydoc>=1.0.0
-    pydata-sphinx-theme>=0.4.3
-    recommonmark>=0.5.0
-    sphinx-argparse>=0.2.5
+    myst-parser>=0.18.1
+    sphinx-book-theme>=0.3.3
 dev =
     black>=19.10b0
     pre-commit>=2.7.1


### PR DESCRIPTION
This PR creates a Sphinx documentation site for deployment on the ReadTheDocs.

To build it locally:
1. Install the docs environment:
```
conda env create -f docs/environment.yaml
```
2. Activate the environment:
```
conda activate casanovo-docs
```
3. Navigate to the docs directory:
```
cd docs
```
4. Build the docs:
```
make html
```
5. To view the docs, open `_build/html/index.html`.