### PR TITLE
Check for stop token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Don't use model weights with incorrect major version number.
+- Verify that the final predicted amino acid is the stop token.
 
 ## [3.1.0] - 2022-11-03
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -953,7 +953,10 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             Amino acid-level confidence scores for the predicted sequence.
         """
         # Omit stop token.
-        aa_tokens = aa_tokens[1:] if self.decoder.reverse else aa_tokens[:-1]
+        if self.decoder.reverse and aa_tokens[0] == "$":
+            aa_tokens = aa_tokens[1:]
+        elif not self.decoder.reverse and aa_tokens[-1] == "$":
+            aa_tokens = aa_tokens[:-1]
         peptide = "".join(aa_tokens)
 
         # If this is a non-finished beam (after exceeding `max_length`), return


### PR DESCRIPTION
Because beams can be terminated when the precursor mass is exceeded, peptide sequences might not necessarily end with a stop token.

Reported in #122.