### PR TITLE
Align printed metrics with published terminology

### DIFF
--- a/casanovo/denovo/evaluate.py
+++ b/casanovo/denovo/evaluate.py
@@ -266,7 +266,7 @@ def aa_match_metrics(
         AAs.
     aa_recall: float
         The number of correct AA predictions divided by the number of true AAs.
-    pep_recall: float
+    pep_precision: float
         The number of correct peptide predictions divided by the number of
         peptides.
     """
@@ -275,10 +275,10 @@ def aa_match_metrics(
     )
     aa_precision = n_aa_correct / (n_aa_pred + 1e-8)
     aa_recall = n_aa_correct / (n_aa_true + 1e-8)
-    pep_recall = sum([aa_matches[1] for aa_matches in aa_matches_batch]) / (
+    pep_precision = sum([aa_matches[1] for aa_matches in aa_matches_batch]) / (
         len(aa_matches_batch) + 1e-8
     )
-    return aa_precision, aa_recall, pep_recall
+    return aa_precision, aa_recall, pep_precision
 
 
 def aa_precision_recall(

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -801,15 +801,14 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                 if "$" not in peptide_pred and len(peptide_pred) > 0:
                     peptides_pred.append(peptide_pred)
                     peptides_true.append(peptide_true)
-        aa_precision, aa_recall, pep_recall = evaluate.aa_match_metrics(
+        aa_precision, _, pep_precision = evaluate.aa_match_metrics(
             *evaluate.aa_match_batch(
                 peptides_pred, peptides_true, self.decoder._peptide_mass.masses
             )
         )
         log_args = dict(on_step=False, on_epoch=True, sync_dist=True)
-        self.log("aa_precision", {"valid": aa_precision}, **log_args)
-        self.log("aa_recall", {"valid": aa_recall}, **log_args)
-        self.log("pep_recall", {"valid": pep_recall}, **log_args)
+        self.log("peptide precision at coverage=1", {"valid": pep_precision}, **log_args)
+        self.log("aa precision at coverage=1", {"valid": aa_precision}, **log_args)
 
         return loss
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -807,8 +807,14 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             )
         )
         log_args = dict(on_step=False, on_epoch=True, sync_dist=True)
-        self.log("peptide precision at coverage=1", {"valid": pep_precision}, **log_args)
-        self.log("aa precision at coverage=1", {"valid": aa_precision}, **log_args)
+        self.log(
+            "Peptide precision at coverage=1",
+            {"valid": pep_precision},
+            **log_args,
+        )
+        self.log(
+            "AA precision at coverage=1", {"valid": aa_precision}, **log_args
+        )
 
         return loss
 


### PR DESCRIPTION
Minor PR addressing #112 which updates the printed evaluation metrics in the `eval` mode to agree with terms such as precision and coverage we use in the preprint and ICML paper.