### PR TITLE
Add documentation for config.yaml

### DIFF
--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -1,8 +1,9 @@
 ###
 # Casanovo configuration.
-# Blank entries are interpreted as "None"
-# Parameters that can be modified when running inference with Casanovo are marked with "(I)".
-# Other parameters should not be changed unless a new Casanovo model is being trained.
+# Blank entries are interpreted as "None".
+# Parameters that can be modified when running inference with Casanovo,
+# i.e. denovo and eval modes in CLI, are marked with "(I)". Other parameters
+# shouldn't be changed unless a new Casanovo model is being trained.
 ###
 
 # Random seed to ensure reproducible results.
@@ -17,7 +18,7 @@ min_mz: 50.0
 max_mz: 2500.0
 # Min peak intensity allowed
 min_intensity: 0.01
-# m/z tolerance to use when removing the precursor peak 
+# m/z tolerance to use when removing the precursor peak
 remove_precursor_tol: 2.0  # Da
 # Max precursor charge allowed
 max_charge: 10

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -1,27 +1,43 @@
 ###
 # Casanovo configuration.
 # Blank entries are interpreted as "None"
+# Parameters that can be modified when running inference with Casanovo are marked with "(I)".
+# Other parameters should not be changed unless a new Casanovo model is being trained.
 ###
 
 # Random seed to ensure reproducible results.
 random_seed: 454
 
 # Spectrum processing options.
+# Max number of peaks in spectrum
 n_peaks: 150
+# Min peak m/z allowed
 min_mz: 50.0
+# Max peak m/z allowed
 max_mz: 2500.0
+# Min peak intensity allowed
 min_intensity: 0.01
+# m/z tolerance to use when removing the precursor peak 
 remove_precursor_tol: 2.0  # Da
+# Max precursor charge allowed
 max_charge: 10
+# Tolerance for precursor m/z filtering (I)
 precursor_mass_tol: 50  # ppm
+# Isotope error range for precursor m/z filtering (I)
 isotope_error_range: [0, 1]
 
 # Model architecture options.
+# Dimentionality of latent representations, i.e. peak embeddings
 dim_model: 512
+# Number of attention heads
 n_head: 8
+# Dimensionality of fully connected layers
 dim_feedforward: 1024
+# Number of transformer layers in spectrum encoder and peptide decoder
 n_layers: 9
+# Dropout rate for model weights
 dropout: 0.0
+# Number of dimensions to use for encoding peak intensity
 dim_intensity:
 custom_encoder:
 max_length: 100

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -30,7 +30,7 @@ precursor_mass_tol: 50  # ppm
 isotope_error_range: [0, 1]
 
 # Model architecture options.
-# Dimentionality of latent representations, i.e. peak embeddings
+# Dimensionality of latent representations, i.e. peak embeddings
 dim_model: 512
 # Number of attention heads
 n_head: 8

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -39,8 +39,11 @@ n_layers: 9
 dropout: 0.0
 # Number of dimensions to use for encoding peak intensity
 dim_intensity:
+# Option to provide a pre-trained spectrum encoder
 custom_encoder:
+# Max decoded peptide length
 max_length: 100
+# Amino acid and modification vocabulary to use
 residues:
   "G": 57.021464
   "A": 71.037114
@@ -71,25 +74,39 @@ residues:
   "+43.006": 43.005814      # Carbamylation
   "-17.027": -17.026549     # NH3 loss
   "+43.006-17.027": 25.980265
+# Logging frequency in training steps
 n_log: 1
+# Tensorboard object to keep track of training metrics
 tb_summarywriter:
+# Number of warmup iterations for learning rate scheduler
 warmup_iters: 100_000
+# Max number of iterations for learning rate scheduler
 max_iters: 600_000
+# Learning rate for weight updates during training
 learning_rate: 5e-4
+# Regularization term for weight updates
 weight_decay: 1e-5
 
 # Training/inference options.
+# Number of spectra in one training batch
 train_batch_size: 32
+# Number of spectra in one inference batch
 predict_batch_size: 1024
+# Number of beams used in beam search
 n_beams: 5
-
+# Object for logging training progress
 logger:
+# Max number of training epochs
 max_epochs: 30
+# Number of validation steps to run before training begins
 num_sanity_val_steps: 0
-
+# Set to "False" to further train a pre-trained Casanovo model
 train_from_scratch: True
-
+# Save model checkpoints during training
 save_model: True
+# Path to saved checkpoints
 model_save_folder_path: ""
+# Set to "False" to save the PyTorch model instance
 save_weights_only: True
+# Model checkpointing frequency in training steps
 every_n_train_steps: 50_000

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -91,9 +91,9 @@ weight_decay: 1e-5
 # Training/inference options.
 # Number of spectra in one training batch
 train_batch_size: 32
-# Number of spectra in one inference batch
+# Number of spectra in one inference batch (I)
 predict_batch_size: 1024
-# Number of beams used in beam search
+# Number of beams used in beam search (I)
 n_beams: 5
 # Object for logging training progress
 logger:

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -2,29 +2,31 @@
 # Casanovo configuration.
 # Blank entries are interpreted as "None".
 # Parameters that can be modified when running inference with Casanovo,
-# i.e. denovo and eval modes in CLI, are marked with "(I)". Other parameters
-# shouldn't be changed unless a new Casanovo model is being trained.
+# i.e. denovo and eval modes in the command line interface, are marked with
+# "(I)". Other parameters shouldn't be changed unless a new Casanovo model
+# is being trained.
 ###
 
 # Random seed to ensure reproducible results.
 random_seed: 454
 
 # Spectrum processing options.
-# Max number of peaks in spectrum
+# Number of the most intense peaks to retain, any remaining peaks are discarded
 n_peaks: 150
-# Min peak m/z allowed
+# Min peak m/z allowed, peaks with smaller m/z are discarded
 min_mz: 50.0
-# Max peak m/z allowed
+# Max peak m/z allowed, peaks with larger m/z are discarded
 max_mz: 2500.0
-# Min peak intensity allowed
+# Min peak intensity allowed, less intense peaks are discarded
 min_intensity: 0.01
-# m/z tolerance to use when removing the precursor peak
+# Max absolute m/z difference allowed when removing the precursor peak
 remove_precursor_tol: 2.0  # Da
-# Max precursor charge allowed
+# Max precursor charge allowed, spectra with larger charge are skipped
 max_charge: 10
-# Tolerance for precursor m/z filtering (I)
+# Max absolute difference allowed with respect to observed precursor m/z (I)
+# Predictions outside the tolerance range are assinged a negative peptide score
 precursor_mass_tol: 50  # ppm
-# Isotope error range for precursor m/z filtering (I)
+# Isotopes to consider when comparing predicted and observed precursor m/z's (I)
 isotope_error_range: [0, 1]
 
 # Model architecture options.
@@ -39,8 +41,10 @@ n_layers: 9
 # Dropout rate for model weights
 dropout: 0.0
 # Number of dimensions to use for encoding peak intensity
+# Projected up to ``dim_model`` by default and summed with the peak m/z encoding
 dim_intensity:
-# Option to provide a pre-trained spectrum encoder
+# Option to provide a pre-trained spectrum encoder when training
+# Trained from scratch by default
 custom_encoder:
 # Max decoded peptide length
 max_length: 100
@@ -74,7 +78,7 @@ residues:
   "+42.011": 42.010565      # Acetylation
   "+43.006": 43.005814      # Carbamylation
   "-17.027": -17.026549     # NH3 loss
-  "+43.006-17.027": 25.980265
+  "+43.006-17.027": 25.980265      # Carbamylation and NH3 loss
 # Logging frequency in training steps
 n_log: 1
 # Tensorboard object to keep track of training metrics

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,7 +59,7 @@ casanovo --help
 ```
 
 All auxiliary data, model, and training-related parameters can be specified in a user created `.yaml` configuration file.
-See [`casanovo/config.yaml`](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) for the default configuration that was used to obtain the reported results. When running Casanovo in eval and denovo mode, you can change some of the parameters in this file, indicated with "(I)" in the file. You should not change other parameters unless you are training a new Casanovo model.
+See [`casanovo/config.yaml`](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) for the default configuration that was used to obtain the reported results. When running Casanovo in eval or denovo mode, you can change some of the parameters in this file, indicated with "(I)" in the file. You should not change other parameters unless you are training a new Casanovo model.
 
 
 ### Download model weights

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,7 +17,7 @@ Once you have conda installed, you can use this helpful [cheat sheet](https://do
 ### Create a conda environment
 
 Fist, open the terminal (MacOS and Linux) or the Anaconda Prompt (Windows).
-All of the commands that follow should be entered this terminal or Anaconda Prompt window---that is, your *shell*. 
+All of the commands that follow should be entered this terminal or Anaconda Prompt window---that is, your *shell*.
 To create a new conda environment for Casanovo, run the following:
 
 ```sh
@@ -59,7 +59,7 @@ casanovo --help
 ```
 
 All auxiliary data, model, and training-related parameters can be specified in a user created `.yaml` configuration file.
-See [`casanovo/config.yaml`](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) for the default configuration that was used to obtain the reported results. You can change some of the parameters on this file when de novo sequencing as needed (marked as such) and should not change other parameters unless you're training a new Casanovo model.
+See [`casanovo/config.yaml`](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) for the default configuration that was used to obtain the reported results. When running Casanovo in eval and denovo mode, you can change some of the parameters in this file, indicated with "(I)" in the file. You should not change other parameters unless you are training a new Casanovo model.
 
 
 ### Download model weights

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,7 +59,7 @@ casanovo --help
 ```
 
 All auxiliary data, model, and training-related parameters can be specified in a user created `.yaml` configuration file.
-See [`casanovo/config.yaml`](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) for the default configuration that was used to obtain the reported results.
+See [`casanovo/config.yaml`](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) for the default configuration that was used to obtain the reported results. You can change some of the parameters on this file when de novo sequencing as needed (marked as such) and should not change other parameters unless you're training a new Casanovo model.
 
 
 ### Download model weights


### PR DESCRIPTION
Addressing #29 , added comments to `config.yaml` and added a short explanation about the config file to read the docs. Indicated which parameters can be changed when running inference with Casanovo.