### PR TITLE
Replace list comprehension with slicing

### DIFF
--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -520,8 +520,13 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             if is_peptide_cached:
                 continue
             smx = self.softmax(scores)
-            aa_scores = np.asarray(
-                [smx[i, j, k].item() for j, k in enumerate(pred_seq)]
+
+            aa_scores = (
+                smx[i, np.arange(len(pred_seq)), pred_seq]
+                .to("cpu")
+                .detach()
+                .numpy()
+                .astype(np.float64)
             )
             pep_score = _aa_pep_score(aa_scores)[1]
             # Cache peptides with fitting (idx=0) or non-fitting (idx=1)


### PR DESCRIPTION
Thanks for the great work on Casanovo!

I was doing some profiling and noticed that this list comprehension was taking quite a bit of time, at least for my workloads. Replacing it with slicing offers a pretty significant speed up. I'm not totally sure if the dtype needs to be `float64` - I just made the type match the implementation of the v3.2.0 release.

I'm happy to make any changes.