### PR TITLE
Don't predict short peptides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Included the `min_peptide_len` parameter in the configuration file to restrict predictions to peptide with a minimum length.
+
 ### Changed
 
 - Calculate the amino acid scores as the average of the amino acid scores and the peptide score.
@@ -13,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Verify that the final predicted amino acid is the stop token.
+- The score of the stop token is taken into account when calculating the predicted peptide score.
 
 ## [3.2.0] - 2022-11-18
 

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -142,6 +142,7 @@ def main(
         max_charge=int,
         precursor_mass_tol=float,
         isotope_error_range=lambda min_max: (int(min_max[0]), int(min_max[1])),
+        min_peptide_len=int,
         dim_model=int,
         n_head=int,
         dim_feedforward=int,

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -28,6 +28,8 @@ max_charge: 10
 precursor_mass_tol: 50  # ppm
 # Isotopes to consider when comparing predicted and observed precursor m/z's (I)
 isotope_error_range: [0, 1]
+# The minimum length of predicted peptides.
+min_peptide_len: 7
 
 # Model architecture options.
 # Dimensionality of latent representations, i.e. peak embeddings

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -28,8 +28,8 @@ max_charge: 10
 precursor_mass_tol: 50  # ppm
 # Isotopes to consider when comparing predicted and observed precursor m/z's (I)
 isotope_error_range: [0, 1]
-# The minimum length of predicted peptides.
-min_peptide_len: 7
+# The minimum length of predicted peptides (I).
+min_peptide_len: 6
 
 # Model architecture options.
 # Dimensionality of latent representations, i.e. peak embeddings

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -265,15 +265,14 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             )
 
             # Stop decoding when all current beams have been finished.
-            decoded = finished_beams
-            if decoded.all():
+            if finished_beams.all():
                 break
             # Update the scores.
-            scores[~decoded, : step + 2, :], _ = self.decoder(
-                tokens[~decoded, : step + 1],
-                precursors[~decoded, :],
-                memories[~decoded, :, :],
-                mem_masks[~decoded, :],
+            scores[~finished_beams, : step + 2, :], _ = self.decoder(
+                tokens[~finished_beams, : step + 1],
+                precursors[~finished_beams, :],
+                memories[~finished_beams, :, :],
+                mem_masks[~finished_beams, :],
             )
             # Find the top-k beams with the highest scores and continue decoding
             # those.
@@ -347,7 +346,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                     calc_peptide = peptide
                 else:
                     calc_peptide = peptide.copy()
-                    peptide.append(aa)
+                    calc_peptide.append(aa)
                 try:
                     calc_mz = self.peptide_mass_calculator.mass(
                         seq=calc_peptide, charge=precursor_charge

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -514,7 +514,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         Find the top-k beams with the highest scores and continue decoding
         those.
 
-        Stop decoding for beams where the stop token was predicted.
+        Stop decoding for beams that have been finished.
 
         Parameters
         ----------

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -438,9 +438,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             ):
                 continue
             smx = self.softmax(scores[i : i + 1, : step + 1, :])
-            aa_scores = [
-                smx[0, j, k].item() for j, k in enumerate(pred_tokens)
-            ]
+            aa_scores = smx[0, range(len(pred_tokens)), pred_tokens].tolist()
             # Add an explicit score 0 for the missing stop token in case this
             # was not predicted (i.e. early stopping).
             if not has_stop_token:

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -98,7 +98,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         max_charge: int = 5,
         precursor_mass_tol: float = 50,
         isotope_error_range: Tuple[int, int] = (0, 1),
-        min_peptide_len: int = 8,
+        min_peptide_len: int = 6,
         n_beams: int = 5,
         n_log: int = 10,
         tb_summarywriter: Optional[

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -519,9 +519,9 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             # Don't cache this peptide if it was already predicted previously.
             if is_peptide_cached:
                 continue
-            smx = self.softmax(scores)
+            smx = self.softmax(scores[i:i+1, :len(pred_seq), :])
             aa_scores = np.asarray(
-                [smx[i, j, k].item() for j, k in enumerate(pred_seq)]
+                [smx[0, j, k].item() for j, k in enumerate(pred_seq)]
             )
             pep_score = _aa_pep_score(aa_scores)[1]
             # Cache peptides with fitting (idx=0) or non-fitting (idx=1)

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -110,6 +110,7 @@ def _execute_existing(
         max_charge=config["max_charge"],
         precursor_mass_tol=config["precursor_mass_tol"],
         isotope_error_range=config["isotope_error_range"],
+        min_peptide_len=config["min_peptide_len"],
         n_beams=config["n_beams"],
         n_log=config["n_log"],
         out_writer=out_writer,

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -39,10 +39,11 @@ If this is the case, then you have set up conda and the environment correctly.
 Be sure to retype in the activation command into your terminal when you reopen anaconda and want to use Casanovo.
 ```
 
-### *Optional:* Install PyTorch
+### *Optional:* Install PyTorch manually
 
-If you have a graphics processing unit (GPU) that you want Casanovo to use, we recommend installing PyTorch manually.
-This will ensure that the version of PyTorch used by Casanovo will be compatible with your CPU.
+Casanovo employs the PyTorch machine learning framework, which by default will be installed automatically along with the other dependencies.
+However, if you have a graphics processing unit (GPU) that you want Casanovo to use, we recommend installing PyTorch manually.
+This will ensure that the version of PyTorch used by Casanovo will be compatible with your GPU.
 For installation instructions, see the [PyTorch documentation](https://pytorch.org/get-started/locally/#start-locally)
 
 ### Install Casanovo

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pandas
     psutil
     PyGithub
-    pytorch-lightning>=1.7
+    pytorch-lightning>=1.7,<2.0
     PyYAML
     requests
     scikit-learn

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -119,10 +119,15 @@ def test_aa_pep_score():
     Test the calculation of amino acid and peptide scores from the raw amino
     acid scores.
     """
-    aa_scores_orig = np.asarray([0.0, 0.5, 1.0])
-    aa_scores, peptide_score = _aa_pep_score(aa_scores_orig)
+    aa_scores_raw = np.asarray([0.0, 0.5, 1.0])
+
+    aa_scores, peptide_score = _aa_pep_score(aa_scores_raw, True)
     np.testing.assert_array_equal(aa_scores, np.asarray([0.25, 0.5, 0.75]))
     assert peptide_score == pytest.approx(0.5)
+
+    aa_scores, peptide_score = _aa_pep_score(aa_scores_raw, False)
+    np.testing.assert_array_equal(aa_scores, np.asarray([0.25, 0.5, 0.75]))
+    assert peptide_score == pytest.approx(-0.5)
 
 
 def test_beam_search_decode():


### PR DESCRIPTION
Rather than simply modifying the peptide score to account for low-scoring stop tokens after very confident prefixes in low-ranking beams, I ended up refactoring the beam search and peptide caching functionality quite a bit.

- The score of the stop token is now included when calculating the peptide score. If no stop token is predicted, an additional "amino acid" with score `0` is added for the purpose of calculating the peptide score. (The score of the stop token is not reported in the mzTab output.)
- Rather than calculating the peptide score when evaluating the beam and when collecting the output, I removed this functionality duplication and compute the peptide score only once when evaluating the beam and then store it.
- This also moves the precursor m/z filter directly in the beam evaluation. Consequently, peptide caching could be simplified significantly. There's now only a single cache for each beam (as opposed to precursor fitting vs not-precursor fitting), because predictions that don't fit the precursor m/z immediately get penalized, and the predicted peptides are directly returned from `beam_search_decode` rather than the raw tokens.
- I added a parameter that controls the minimum length of the predicted peptides (default: 7). If beams include the stop token before this minimum peptide length is reached, they get discarded.

The upshot is that very short peptides are no longer predicted and predictions that don't include a stop token (i.e. because they exceed the precursor m/z before the stop token occurs) are penalized.

@melihyilmaz:
- I would appreciate a thorough review of the code changes.
- The unit tests currently don't fail, but some of them are commented out or don't test anything useful. Can you have a look and updated the commented-out tests and add relevant new tests to verify that the new functionality works as expected?
- Identification performance should be better. First of all, because the short peptides bug is now fixed. But from some spot checks it seems that some PSMs also get better predictions due to the way the beams are handled. I haven't systematically verified this, so running on (part of) the 9-species benchmark to quantify the performance would be useful.

Fixes #107. Fixes #115. Supersedes #134.