### PR TITLE
Disable multithreading for MPS backend

### DIFF
--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -376,7 +376,7 @@ def _get_devices() -> Union[int, str]:
     """
     if any(
         operator.attrgetter(device + ".is_available")(torch)()
-        for device in ["cuda", "backends.mps"]
+        for device in ("cuda",)
     ):
         return -1
     elif not (n_workers := utils.n_workers()):

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -73,6 +73,15 @@ Not all releases might have a model file included on the [Releases page](https:/
 
 ## Running Casanovo
 
+```{note}
+We recommend a Linux system with a dedicated GPU to achieve optimal runtime performance.
+Notably, Casanovo is restricted to single-threaded execution only on Windows and MacOS.
+```
+
+> **Warning**
+> Casanovo can currently crash if no GPU is available.
+> We are actively trying to fix this known issue.
+
 ### Sequence new mass spectra
 
 To sequence your own mass spectra with Casanovo, use the `denovo` mode:


### PR DESCRIPTION
Only a single worker thread is used for Apple MPS systems.

Fixes #109.