### PR TITLE
Clarify dependencies

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -39,10 +39,11 @@ If this is the case, then you have set up conda and the environment correctly.
 Be sure to retype in the activation command into your terminal when you reopen anaconda and want to use Casanovo.
 ```
 
-### *Optional:* Install PyTorch
+### *Optional:* Install PyTorch manually
 
-If you have a graphics processing unit (GPU) that you want Casanovo to use, we recommend installing PyTorch manually.
-This will ensure that the version of PyTorch used by Casanovo will be compatible with your CPU.
+Casanovo employs the PyTorch machine learning framework, which by default will be installed automatically along with the other dependencies.
+However, if you have a graphics processing unit (GPU) that you want Casanovo to use, we recommend installing PyTorch manually.
+This will ensure that the version of PyTorch used by Casanovo will be compatible with your GPU.
 For installation instructions, see the [PyTorch documentation](https://pytorch.org/get-started/locally/#start-locally)
 
 ### Install Casanovo

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pandas
     psutil
     PyGithub
-    pytorch-lightning>=1.7
+    pytorch-lightning>=1.7,<2.0
     PyYAML
     requests
     scikit-learn


### PR DESCRIPTION
- In the _Getting Started_, clarify that optional PyTorch refers to automatic vs manual installation.
- Pin PyTorch Lightning to pre 2.0 to avoid installation conflicts.

Fixes #147.