### PR TITLE
Add validation frequency option 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Included the `min_peptide_len` parameter in the configuration file to restrict predictions to peptide with a minimum length.
 - Export multiple PSMs per spectrum using the `top_match` parameter in the configuration file.
+- `every_n_train_steps` parameter now controls the frequency of both validation epochs and model checkpointing during training.
 
 ### Changed
 
 - Calculate the amino acid scores as the average of the amino acid scores and the peptide score.
 - Spectra from mzML and mzXML peak files are referred to by their scan numbers in the mzTab output instead of their indexes.
+- We now log steps rather than epochs as units of progress during training.
+- Validation performance metrics are logged (and added to tensorboard) at the validation epoch, and training loss is logged at the end of training epoch, i.e. training and validation metrics are logged asynchronously.
 
 ### Fixed
 

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -51,6 +51,7 @@ class Config:
         dim_intensity=int,
         max_length=int,
         n_log=int,
+        tb_summarywriter=str,
         warmup_iters=int,
         max_iters=int,
         learning_rate=float,

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -81,7 +81,7 @@ residues:
   "+43.006": 43.005814      # Carbamylation
   "-17.027": -17.026549     # NH3 loss
   "+43.006-17.027": 25.980265      # Carbamylation and NH3 loss
-# Logging frequency in training epochs
+# Logging frequency in training steps
 n_log: 1
 # Tensorboard object to keep track of training metrics
 tb_summarywriter:
@@ -117,7 +117,7 @@ save_model: True
 model_save_folder_path: ""
 # Set to "False" to save the PyTorch model instance
 save_weights_only: True
-# Model checkpointing frequency in training steps
+# Model validation and checkpointing frequency in training steps
 every_n_train_steps: 50_000
 # Disable usage of a GPU (including Apple MPS):
 no_gpu: False

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -81,7 +81,7 @@ residues:
   "+43.006": 43.005814      # Carbamylation
   "-17.027": -17.026549     # NH3 loss
   "+43.006-17.027": 25.980265      # Carbamylation and NH3 loss
-# Logging frequency in training steps
+# Logging frequency in training epochs
 n_log: 1
 # Tensorboard object to keep track of training metrics
 tb_summarywriter:

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -890,30 +890,27 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         Write log to console, if requested.
         """
         # Log only if all output for the current epoch is recorded.
-        if len(self._history) > 0 and len(self._history[-1]) == 6:
+        if len(self._history) > 0 and len(self._history[-1]) == 5:
             if len(self._history) == 1:
                 logger.info(
-                    "Epoch\tTrain loss\tValid loss\tAA precision\tAA recall\t"
-                    "Peptide recall"
+                    "Epoch\tTrain loss\tValid loss\tPeptide precision\tAA precision"
                 )
             metrics = self._history[-1]
             if metrics["epoch"] % self.n_log == 0:
                 logger.info(
-                    "%i\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f",
+                    "%i\t%.6f\t%.6f\t%.6f\t%.6f",
                     metrics["epoch"] + 1,
                     metrics.get("train", np.nan),
                     metrics.get("valid", np.nan),
+                    metrics.get("valid_pep_precision", np.nan),
                     metrics.get("valid_aa_precision", np.nan),
-                    metrics.get("valid_aa_recall", np.nan),
-                    metrics.get("valid_pep_recall", np.nan),
                 )
                 if self.tb_summarywriter is not None:
                     for descr, key in [
                         ("loss/train_crossentropy_loss", "train"),
-                        ("loss/dev_crossentropy_loss", "valid"),
-                        ("eval/dev_aa_precision", "valid_aa_precision"),
-                        ("eval/dev_aa_recall", "valid_aa_recall"),
-                        ("eval/dev_pep_recall", "valid_pep_recall"),
+                        ("loss/val_crossentropy_loss", "valid"),
+                        ("eval/val_pep_precision", "valid_pep_precision"),
+                        ("eval/val_aa_precision", "valid_aa_precision"),
                     ]:
                         self.tb_summarywriter.add_scalar(
                             descr,

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -312,6 +312,7 @@ def train(
         max_epochs=config["max_epochs"],
         num_sanity_val_steps=config["num_sanity_val_steps"],
         strategy=_get_strategy(),
+        val_check_interval=config["every_n_train_steps"],
     )
     # Train the model.
     trainer.fit(

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -307,6 +307,7 @@ def train(
         auto_select_gpus=True,
         callbacks=callbacks,
         devices=_get_devices(config["no_gpu"]),
+        enable_checkpointing=config["save_model"],
         logger=config["logger"],
         max_epochs=config["max_epochs"],
         num_sanity_val_steps=config["num_sanity_val_steps"],


### PR DESCRIPTION
I put together this PR after coming to the conclusion that there was no option to run validation before a training epoch ends, which is crucial when training on large datasets like MSKB, but it also includes fixes to issues with logging and checkpointing we introduced earlier (1st commit: e11b80ada0e66f62a64fa880a33bdeb3865d99d1). To list the changes:

- `every_n_train_steps` option now controls both the frequency of validation epochs and model checkpointing. We can decouple the two but kept it as such for simplicity.
-  Validation performance metrics are logged (and added to tensorboard) at the validation epoch, and training loss is logged at the end of training epoch, i.e. training and validation metrics are logged asynchronously.
- We now log `step` rather than `epoch` as the unit of progress.
- Fixed `tb_summarywriter` not being read of the `config.yaml`.
- Fixed metrics being logged, discontinued legacy metric `recall`.
- Fixed `save_model` option, previously didn't have any effect. 

I tested the changes with different settings and things seem to work but our unit tests still don't cover the changed functions.