### PR TITLE
Only split off known extensions from output filename

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -96,7 +96,8 @@ def main(
             f"casanovo_{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}",
         )
     else:
-        output = os.path.splitext(os.path.abspath(output))[0]
+        basename, ext = os.path.splitext(os.path.abspath(output))
+        output = basename if ext.lower() == ".mztab" else output
 
     # Configure logging.
     logging.captureWarnings(True)

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -67,7 +67,7 @@ logger = logging.getLogger("casanovo")
 @click.option(
     "--output",
     help="The base output file name to store logging (extension: .log) and "
-    "(optionally) prediction results (extension: .csv).",
+    "(optionally) prediction results (extension: .mztab).",
     type=click.Path(dir_okay=False),
 )
 def main(

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -97,7 +97,7 @@ def main(
         )
     else:
         basename, ext = os.path.splitext(os.path.abspath(output))
-        output = basename if ext.lower() == ".mztab" else output
+        output = basename if ext.lower() in (".log", ".mztab") else output
 
     # Configure logging.
     logging.captureWarnings(True)


### PR DESCRIPTION
Old behavior:
- `--output foo.bar` -> `foo.log` and `foo.mztab`
- `--output foo.mztab` -> `foo.log` and `foo.mztab`
- `--output foo.log` -> `foo.log` and `foo.mztab`

New behavior:
- `--output foo.bar` -> `foo.bar.log` and `foo.bar.mztab`
- `--output foo.mztab` -> `foo.log` and `foo.mztab`
- `--output foo.log` -> `foo.log` and `foo.mztab`