### PR TITLE
Use a single beam by default

### DIFF
--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -100,7 +100,7 @@ train_batch_size: 32
 # Number of spectra in one inference batch (I)
 predict_batch_size: 1024
 # Number of beams used in beam search (I)
-n_beams: 5
+n_beams: 1
 # Number of PSMs for each spectrum (I)
 top_match: 1
 # Object for logging training progress

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -101,7 +101,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         precursor_mass_tol: float = 50,
         isotope_error_range: Tuple[int, int] = (0, 1),
         min_peptide_len: int = 6,
-        n_beams: int = 5,
+        n_beams: int = 1,
         top_match: int = 1,
         n_log: int = 10,
         tb_summarywriter: Optional[

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -1,7 +1,6 @@
 """A de novo peptide sequencing model."""
 import collections
 import heapq
-import itertools
 import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -605,9 +604,12 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
 
         # Mask out terminated beams. Include precursor m/z tolerance induced
         # termination.
+        # TODO: `clone()` is necessary to get the correct output with n_beams=1.
+        #   An alternative implementation using base PyTorch instead of einops
+        #   might be more efficient.
         finished_mask = einops.repeat(
             finished_beams, "(B S) -> B (V S)", S=beam, V=vocab
-        )
+        ).clone()
         # Mask out the index '0', i.e. padding token, by default.
         finished_mask[:, :beam] = True
 

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -341,7 +341,36 @@ def test_beam_search_decode():
     )
 
     assert torch.equal(pred_cache[0][0][-1], torch.tensor([4, 14, 4, 13]))
-
+    
+    # Test _get_topk_beams().
+    step=1
+    scores = torch.full(
+        size=(batch, length, vocab, beam), fill_value=torch.nan
+    )    
+    scores = einops.rearrange(scores, "B L V S -> (B S) L V")
+    tokens = torch.zeros(batch * beam, length, dtype=torch.int64)
+    tokens[0,0] = 4
+    scores[0, step, :] = 0
+    scores[0, step, 14] = torch.tensor([1]) 
+    test_finished_beams = torch.tensor([False])
+    
+    new_tokens, new_scores = model._get_topk_beams(
+        tokens, scores, test_finished_beams, batch, step
+    )
+    
+    expected_tokens = torch.tensor(
+        [
+            [4, 14],
+        ]
+    )   
+    
+    expected_scores = torch.zeros(beam, vocab)
+    expected_scores[:, 14] = torch.tensor([1])   
+    
+    assert torch.equal(new_scores[:, step, :], expected_scores) 
+    assert torch.equal(new_tokens[:, : step + 1], expected_tokens)
+    
+    
     # Test _finish_beams() for tokens with a negative mass.
     model = Spec2Pep(n_beams=2, residues="massivekb")
     beam = model.n_beams  # S


### PR DESCRIPTION
And ensure that there are correct results when using only a single beam.

@melihyilmaz: Please include your unit tests for only a single beam on this branch.