### PR TITLE
Only create log directory when checkpointing is enabled

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Optional, Dict, Callable, Tuple, Union
 
 import yaml
-import torch
 
 from . import utils
 

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -171,10 +171,12 @@ class ModelRunner:
             Determines whether to set the trainer up for model training
             or evaluation / inference.
         """
+        logger = self.config.logger if self.config.logger is not None else False
         trainer_cfg = dict(
             accelerator=self.config.accelerator,
             devices=1,
-            logger=self.config.logger,
+            enable_checkpointing=False,
+            logger=logger,
         )
 
         if train:


### PR DESCRIPTION
Checkpointing during training can be enabled using the `logger` config option. If this is not specified, or during inference, don't create the `lightning_logs/` directory.

Fixes #187.