### PR TITLE
Tb fix

### DIFF
--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -914,14 +914,13 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                 ]:
                     metric_value = metrics.get(key, np.nan)
                     if metric_value is not None:
-                        if torch.is_tensor(
-                            metric_value
-                        ):  # Check if metric_value is a torch tensor
+                        # Check if metric_value is a torch tensor
+                        if torch.is_tensor(metric_value):
                             metric_value_np = (
                                 metric_value.clone().cpu().numpy()
-                            )  # tensor losses
+                            )
                         else:
-                            metric_value_np = metric_value  # float pep and aa precision (I think)
+                            metric_value_np = metric_value
                         if not np.isnan(metric_value_np):
                             self.tb_summarywriter.add_scalar(
                                 descr, metric_value_np, metrics["step"]

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -913,10 +913,19 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                     ("eval/val_aa_precision", "valid_aa_precision"),
                 ]:
                     metric_value = metrics.get(key, np.nan)
-                    if not np.isnan(metric_value):
-                        self.tb_summarywriter.add_scalar(
-                            descr, metric_value, metrics["step"]
-                        )
+                    if metric_value is not None:
+                        if torch.is_tensor(
+                            metric_value
+                        ):  # Check if metric_value is a torch tensor
+                            metric_value_np = (
+                                metric_value.clone().cpu().numpy()
+                            )  # tensor losses
+                        else:
+                            metric_value_np = metric_value  # float pep and aa precision (I think)
+                        if not np.isnan(metric_value_np):
+                            self.tb_summarywriter.add_scalar(
+                                descr, metric_value_np, metrics["step"]
+                            )
 
     def configure_optimizers(
         self,


### PR DESCRIPTION
A quick fix to the tb TypeError issue seen [here](https://github.com/Noble-Lab/casanovo/issues/203). It seems like the `if not np.isnan(metric_value)` call in [this line](https://github.com/Noble-Lab/casanovo/blob/26b08cf4ba6f09bd64a2bbddb8c1975788cdbe4e/casanovo/denovo/model.py#L916C3-L916C3) is trying to convert some of the tensor values in metric_value (e.g. the train_loss) to numpy values. From what I can tell some of the values in metrics are floats and some are tensors so I added a short check to see if there are any tensors and if so make a copy of the variable, send to cpu, send to numpy (the last part might be wholly unnecessary). 