### PR TITLE
Fix validation and checkpointing interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The CLI has been overhauled to use subcommands.
 - Upgraded to Lightning >=2.0
 - Checkpointing is now configured to save the top-k models instead of all.
+- `every_n_train_steps` has been renamed to `val_check_interval` in accordance to the corresponding Pytorch Lightning parameter.
 
 ### Fixed
 
@@ -21,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -  Checkpoints now include model parameters, allowing for mismatches with the provided configuration file.
 - `accelerator` parameter now controls the accelerator (CPU, GPU, etc) that is used.
 - `devices` parameter controls the number of accelerators used.
-- `every_n_train_steps` parameter now controls the frequency of both validation epochs and model checkpointing during training.
+- `val_check_interval` parameter now controls the frequency of both validation epochs and model checkpointing during training.
 
 ### Changed
 

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -65,7 +65,7 @@ class Config:
         train_from_scratch=bool,
         save_top_k=int,
         model_save_folder_path=str,
-        every_n_train_steps=int,
+        val_check_interval=int,
         accelerator=str,
         devices=int,
         calculate_precision=bool,

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -117,7 +117,7 @@ save_top_k: 5
 # Path to saved checkpoints
 model_save_folder_path: ""
 # Model validation and checkpointing frequency in training steps
-every_n_train_steps: 50_000
+val_check_interval: 50_000
 # Calculate peptide and amino acid precision during training. this
 # is expensive, so we recommend against it.
 calculate_precision: False

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -193,7 +193,7 @@ class ModelRunner:
                 max_epochs=self.config.max_epochs,
                 num_sanity_val_steps=self.config.num_sanity_val_steps,
                 strategy=self._get_strategy(),
-                val_check_interval=self.config.every_n_train_steps,
+                val_check_interval=self.config.val_check_interval,
             )
             trainer_cfg.update(additional_cfg)
 

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -194,6 +194,7 @@ class ModelRunner:
                 num_sanity_val_steps=self.config.num_sanity_val_steps,
                 strategy=self._get_strategy(),
                 val_check_interval=self.config.val_check_interval,
+                check_val_every_n_epoch=None,
             )
             trainer_cfg.update(additional_cfg)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -60,8 +60,8 @@ Using the filename (column "filename") you can then retrieve the corresponding p
 
 By default, Casanovo saves a snapshot of the model weights after every 50,000 training steps.
 Note that the number of samples that are processed during a single training step depends on the batch size.
-Therefore, when using the default training batch size of 32, this correspond to saving a model snapshot after every 1.6 million training samples.
-You can optionally modify the snapshot frequency in the [config file](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) (parameter `every_n_train_steps`), depending on your dataset size.
+Therefore, when using the default training batch size of 32, this corresponds to saving a model snapshot after every 1.6 million training samples.
+You can optionally modify the snapshot (and validation) frequency in the [config file](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) (parameter `val_check_interval`), depending on your dataset size.
 Note that taking very frequent model snapshots will result in somewhat slower training time because Casanovo will evaluate its performance on the validation data for every snapshot.
 
 When saving a model snapshot, Casanovo will use the validation data to compute performance measures (training loss, validation loss, amino acid precision, and peptide precision) and print this information to the console and log file.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,7 +193,7 @@ def tiny_config(tmp_path):
         "warmup_iters": 1,
         "max_iters": 1,
         "max_epochs": 20,
-        "every_n_train_steps": 1,
+        "val_check_interval": 1,
         "model_save_folder_path": str(tmp_path),
         "accelerator": "cpu",
     }


### PR DESCRIPTION
The option to configure the interval for validation and checkpointing has been changed:
- Config option `every_n_train_steps` has been renamed to `val_check_interval` in accordance to the corresponding Pytorch Lightning parameter.
- This now determines the number of training steps _across_ epochs instead of _within_ a single epoch. I.e. previously if there were 75,000 batches in the training data, validation would run at epoch=0,steps=50k; epoch=1,steps=50k; epoch=2,steps=50k; ...; whereas now it will run at epoch=0,steps=50k; epoch=1,steps=25k; epoch=1,steps=75k; ...

Fixes #211.