### PR TITLE
Upgrade to pytorch-lightning 2

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -15,10 +15,8 @@ import appdirs
 import click
 import github
 import requests
-import torch
 import tqdm
-import yaml
-from pytorch_lightning.lite import LightningLite
+from lightning import Fabric
 
 from . import __version__
 from . import utils
@@ -127,7 +125,7 @@ def main(
     # Read parameters from the config file.
     config = Config(config)
 
-    LightningLite.seed_everything(seed=config["random_seed"], workers=True)
+    Fabric.seed_everything(seed=config["random_seed"], workers=True)
 
     # Download model weights if these were not specified (except when training).
     if model is None and mode != "train":

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -50,6 +50,7 @@ class Config:
         dropout=float,
         dim_intensity=int,
         max_length=int,
+        residues=dict,  # note, this key is special-cased and type is ignored
         n_log=int,
         tb_summarywriter=str,
         warmup_iters=int,

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -724,8 +724,8 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         pred = pred[:, :-1, :].reshape(-1, self.decoder.vocab_size + 1)
         loss = self.celoss(pred, truth.flatten())
         self.log(
-            "CELoss",
-            {mode: loss.detach()},
+            f"CELoss/{mode}",
+            loss.detach(),
             on_step=False,
             on_epoch=True,
             sync_dist=True,
@@ -765,13 +765,11 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         )
         log_args = dict(on_step=False, on_epoch=True, sync_dist=True)
         self.log(
-            "Peptide precision at coverage=1",
-            {"valid": pep_precision},
+            "Peptide precision at coverage=1/valid",
+            pep_precision,
             **log_args,
         )
-        self.log(
-            "AA precision at coverage=1", {"valid": aa_precision}, **log_args
-        )
+        self.log("AA precision at coverage=1/valid", aa_precision, **log_args)
 
         return loss
 
@@ -824,7 +822,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         """
         Log the training loss at the end of each epoch.
         """
-        train_loss = self.trainer.callback_metrics["CELoss"]["train"].detach()
+        train_loss = self.trainer.callback_metrics["CELoss/train"].detach()
         metrics = {
             "step": self.trainer.global_step,
             "train": train_loss,
@@ -839,20 +837,18 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         callback_metrics = self.trainer.callback_metrics
         metrics = {
             "step": self.trainer.global_step,
-            "valid": callback_metrics["CELoss"]["valid"].detach(),
+            "valid": callback_metrics["CELoss/valid"].detach(),
             "valid_aa_precision": callback_metrics[
-                "AA precision at coverage=1"
-            ]["valid"].detach(),
+                "AA precision at coverage=1/valid"
+            ].detach(),
             "valid_pep_precision": callback_metrics[
-                "Peptide precision at coverage=1"
-            ]["valid"].detach(),
+                "Peptide precision at coverage=1/valid"
+            ].detach(),
         }
         self._history.append(metrics)
         self._log_history()
 
-    def on_predict_epoch_end(
-        self, results: List[List[Tuple[np.ndarray, List[str], torch.Tensor]]]
-    ) -> None:
+    def on_predict_epoch_end(self) -> None:
         """
         Write the predicted peptide sequences and amino acid scores to the
         output file.
@@ -868,7 +864,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             peptide_score,
             aa_scores,
         ) in itertools.chain.from_iterable(
-            itertools.chain.from_iterable(results)
+            self.trainer.predict_loop.predictions
         ):
             if len(peptide) == 0:
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pandas",
     "psutil",
     "PyGithub",
-    "pytorch-lightning>=1.7,<2.0",
+    "lightning>=2.0.0",
     "PyYAML",
     "requests",
     "scikit-learn",


### PR DESCRIPTION
This migrates the code to the latest major version of pytorch-lightning. I tried to do it with minimal changes to stay true to the original design philosophy of Casanovo. Feedback is much appreciated.

Summary of changes (I followed [this guide](https://lightning.ai/docs/pytorch/latest/upgrade/from_1_9.html) to upgrade):

- LightningLite is deprecated
  - Switch to Fabric
- `auto_select_gpus` parameter for `Trainer` is deprecated
  - Use `find_usable_cuda_devices` in `_get_devices` instead. Also, `devices` can't be 0, so now `_get_devices` falls back to `auto`
- Relying on passed in `outputs` in `on_predict_epoch_end` is deprecated
  - Use `self.trainer.predict_loop.predictions` instead
- Passing a dictionary to `LightingModule.log` is deprecated
  - Log as scalar with the "mode" (e.g. "train" or "valid") embedded in string key to the same effect
- `strategy` parameter for `Trainer` cannot be `None`
  - Return "auto" if no cuda devices