### PR TITLE
Add lines to force gradient calculation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Casanovo now runs on CPU and can passes all tests.
+- Enable gradients during prediction and validation to avoid NaNs from occuring as a temporary workaround until a new Pytorch version is available.
 
 ### Added
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -758,6 +758,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             The loss of the validation step.
         """
         # Record the loss.
+        # FIXME: Temporary workaround to avoid the NaN bug.
         with torch.set_grad_enabled(True):
             loss = self.training_step(batch, mode="valid")
         if not self.calculate_precision:
@@ -810,6 +811,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             and amino acid-level confidence scores.
         """
         predictions = []
+        # FIXME: Temporary workaround to avoid the NaN bug.
         with torch.set_grad_enabled(True):
             for (
                 precursor_charge,

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -758,7 +758,8 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             The loss of the validation step.
         """
         # Record the loss.
-        loss = self.training_step(batch, mode="valid")
+        with torch.set_grad_enabled(True):
+            loss = self.training_step(batch, mode="valid")
         if not self.calculate_precision:
             return loss
 
@@ -809,28 +810,29 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             and amino acid-level confidence scores.
         """
         predictions = []
-        for (
-            precursor_charge,
-            precursor_mz,
-            spectrum_i,
-            spectrum_preds,
-        ) in zip(
-            batch[1][:, 1].cpu().detach().numpy(),
-            batch[1][:, 2].cpu().detach().numpy(),
-            batch[2],
-            self.forward(batch[0], batch[1]),
-        ):
-            for peptide_score, aa_scores, peptide in spectrum_preds:
-                predictions.append(
-                    (
-                        spectrum_i,
-                        precursor_charge,
-                        precursor_mz,
-                        peptide,
-                        peptide_score,
-                        aa_scores,
+        with torch.set_grad_enabled(True):
+            for (
+                precursor_charge,
+                precursor_mz,
+                spectrum_i,
+                spectrum_preds,
+            ) in zip(
+                batch[1][:, 1].cpu().detach().numpy(),
+                batch[1][:, 2].cpu().detach().numpy(),
+                batch[2],
+                self.forward(batch[0], batch[1]),
+            ):
+                for peptide_score, aa_scores, peptide in spectrum_preds:
+                    predictions.append(
+                        (
+                            spectrum_i,
+                            precursor_charge,
+                            precursor_mz,
+                            peptide,
+                            peptide_score,
+                            aa_scores,
+                        )
                     )
-                )
 
         return predictions
 


### PR DESCRIPTION
Forces gradient calculation during inference in order to prevent NaNs from being produced.

The line used: `with torch.set_grad_enabled(True):`