### PR TITLE
Correctly report AA precision and recall during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Casanovo runs on CPU and can passes all tests.
 - Enable gradients during prediction and validation to avoid NaNs from occuring as a temporary workaround until a new Pytorch version is available.
 - Upgrade to depthcharge v0.2.3 for `PeptideTransformerDecoder` hotfix.
+- Correctly report amino acid precision and recall during validation.
 
 ### Removed
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -773,8 +773,8 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
 
         aa_precision, _, pep_precision = evaluate.aa_match_metrics(
             *evaluate.aa_match_batch(
-                peptides_pred,
                 peptides_true,
+                peptides_pred,
                 self.decoder._peptide_mass.masses,
             )
         )


### PR DESCRIPTION
Fixes #252.

AA precision and recall were swapped due to swapped input of true and predicted peptides to the evaluation.