### PR TITLE
Fix spectra skipping and add min_n_peaks option

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -34,6 +34,7 @@ class Config:
     _default_config = Path(__file__).parent / "config.yaml"
     _config_types = dict(
         random_seed=int,
+        min_n_peaks=int,
         n_peaks=int,
         min_mz=float,
         max_mz=float,

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -52,6 +52,8 @@ model_save_folder_path: ""
 val_check_interval: 50_000
 
 # SPECTRUM PROCESSING OPTIONS
+# Min number of peaks allowed in a spectrum
+min_n_peaks: 20
 # Number of the most intense peaks to retain, any remaining peaks are discarded
 n_peaks: 150
 # Min peak m/z allowed, peaks with smaller m/z are discarded

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -292,6 +292,7 @@ class ModelRunner:
             train_index=train_index,
             valid_index=valid_index,
             test_index=test_index,
+            min_n_peaks=self.config.min_n_peaks,
             min_mz=self.config.min_mz,
             max_mz=self.config.max_mz,
             min_intensity=self.config.min_intensity,


### PR DESCRIPTION
Skips spectra with fewer than min_n_peaks (min_n_peaks=20 by default) and adds the corresponding config option. Fixes #264 

This solution is a bit hacky and discards spectra at the batching stage but I think the existing functionality for skipping spectra was buggy to begin with: it only replaces the spectra to be skipped with dummy spectra and runs the model on those dummies so that we still get predictions for them. Am I missing something, @bittremieux @wfondrie?


TODOs:
- Find a way to skip spectra before batching, e.g. inside the dataset
- Log how many spectra are skipped
- Unit tests