### PR TITLE
Restart

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -64,6 +64,7 @@ class Config:
         max_epochs=int,
         num_sanity_val_steps=int,
         train_from_scratch=bool,
+        resume_training=bool,
         save_top_k=int,
         model_save_folder_path=str,
         val_check_interval=int,

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -99,6 +99,11 @@ max_epochs: 30
 num_sanity_val_steps: 0
 # Set to "False" to further train a pre-trained Casanovo model
 train_from_scratch: True
+# Restart training from saved checkpoint file
+# restores all optimizer state, lr scheduler, model params
+# CAUTION: Undefined behavior if checkpoint was saved in
+# the middle of an epoch. 
+resume_training: False
 # Calculate peptide and amino acid precision during training. this
 # is expensive, so we recommend against it.
 calculate_precision: False

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -229,6 +229,7 @@ class ModelRunner:
             top_match=self.config.top_match,
             n_log=self.config.n_log,
             tb_summarywriter=self.config.tb_summarywriter,
+            resume_training=self.config.resume_training,
             warmup_iters=self.config.warmup_iters,
             max_iters=self.config.max_iters,
             lr=self.config.learning_rate,

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -103,11 +103,19 @@ class ModelRunner:
         self.initialize_data_module(train_index, valid_index)
         self.loaders.setup()
 
-        self.trainer.fit(
-            self.model,
-            self.loaders.train_dataloader(),
-            self.loaders.val_dataloader(),
-        )
+        if self.config.resume_training:
+            self.trainer.fit(
+                self.model,
+                self.loaders.train_dataloader(),
+                self.loaders.val_dataloader(),
+                ckpt_path=self.model_filename,
+            )
+        else:
+            self.trainer.fit(
+                self.model,
+                self.loaders.train_dataloader(),
+                self.loaders.val_dataloader(),
+            )
 
     def evaluate(self, peak_path: Iterable[str]) -> None:
         """Evaluate peptide sequence preditions from a trained Casanovo model.


### PR DESCRIPTION
Allows user to restart training with fully restored optimizer state, lr scheduler, epoch state, and weights. Distinct from fine-tuning as this will restart at the exact point in training any pause/hardware failure/stall occurred. Removes the need to re-tune the optimizer with warmup stage and removes the need to retrace potentially long training run to reach the point of failure/pause. Users should try to perform validation checks at integer multiples of the number of batches per epoch to avoid potentially seeing batch items multiple times in one epoch (data loader state is not saved).