### PR TITLE
Optimize beam search

### DIFF
--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -387,11 +387,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                 continue
             pred_tokens = tokens[i][: step + 1]
             # Omit stop token.
-            if self.decoder.reverse and pred_tokens[0] == self.stop_token:
-                pred_tokens = pred_tokens[1:]
-            elif (
-                not self.decoder.reverse and pred_tokens[-1] == self.stop_token
-            ):
+            if pred_tokens[-1] == self.stop_token:
                 pred_tokens = pred_tokens[:-1]
             peptide_len = len(pred_tokens)
             # Discard beams that were predicted to end but don't fit the minimum

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -268,6 +268,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         scores = einops.rearrange(scores, "B L V S -> (B S) L V")
 
         # The main decoding loop.
+        self.n_term = self.n_term.to(self.decoder.device)
         for step in range(0, self.max_length):
             # Terminate beams exceeding the precursor m/z tolerance and track
             # all finished beams (either terminated or stop token predicted).


### PR DESCRIPTION
- Move some initialization code for discarding invalid beams (i.e. which tokens are neutral losses or N-terminal residues) to `__init__` to only do it when initializing the model instead of every time a batch of beams is checked for termination.
- Move peptide detokenizing to the point where it's absolutely needed. This is still a slow step (currently done in DepthCharge) that could maybe be skipped by calculating masses from tokens directly? @wfondrie What do you think?
- Only calculate the peptide mass once and then subtract masses of neutral losses instead of adding the neutral losses to the peptide and then calculating the mass of the entire peptide.
- Early stopping when comparing delta masses for different isotopes.
- Numba JIT compilation of mass error calculation. Although this requires moving the precursor m/z and charge tensors to CPU, so I don't know whether it's actually beneficial. Any thoughts @wfondrie @melihyilmaz?