### PR TITLE
Remove `train_from_scratch` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Instead of having to specify `train_from_scratch` in the config file, training will proceed from an existing model weights file if this is given as an argument to `casanovo train`.
+
 ## [4.0.0] - 2023-12-22
 
 ### Added

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -64,7 +64,6 @@ class Config:
         top_match=int,
         max_epochs=int,
         num_sanity_val_steps=int,
-        train_from_scratch=bool,
         save_top_k=int,
         model_save_folder_path=str,
         val_check_interval=int,

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -99,8 +99,6 @@ train_batch_size: 32
 max_epochs: 30
 # Number of validation steps to run before training begins
 num_sanity_val_steps: 0
-# Set to "False" to further train a pre-trained Casanovo model
-train_from_scratch: True
 # Calculate peptide and amino acid precision during training. this
 # is expensive, so we recommend against it.
 calculate_precision: False

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -251,16 +251,16 @@ class ModelRunner:
             calculate_precision=self.config.calculate_precision,
         )
 
-        from_scratch = (
-            self.config.train_from_scratch,
-            self.model_filename is None,
-        )
-        if train and any(from_scratch):
-            self.model = Spec2Pep(**model_params)
-            return
-        elif self.model_filename is None:
-            logger.error("A model file must be provided")
-            raise ValueError("A model file must be provided")
+        if self.model_filename is None:
+            # Train a model from scratch if no model file is provided.
+            if train:
+                self.model = Spec2Pep(**model_params)
+                return
+            # Else we're not training, so a model file must be provided.
+            else:
+                logger.error("A model file must be provided")
+                raise ValueError("A model file must be provided")
+        # Else a model file is provided (to continue training or for inference).
 
         if not Path(self.model_filename).exists():
             logger.error(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,7 +222,6 @@ def tiny_config(tmp_path):
         "weight_decay": 1e-5,
         "train_batch_size": 32,
         "num_sanity_val_steps": 0,
-        "train_from_scratch": True,
         "calculate_precision": False,
         "residues": {
             "G": 57.021464,


### PR DESCRIPTION
Instead of having to specify `train_from_scratch` in the config file, training will proceed from an existing model weights file if this is given as an argument to `casanovo train`.

Fixes #263.