### PR TITLE
Ensure --model has to be set when not training from scratch

### DIFF
--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -100,7 +100,7 @@ max_epochs: 30
 # Number of validation steps to run before training begins
 num_sanity_val_steps: 0
 # Set to "False" to further train a pre-trained Casanovo model
-train_from_scratch: True
+train_from_scratch: False
 # Calculate peptide and amino acid precision during training. this
 # is expensive, so we recommend against it.
 calculate_precision: False

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -100,7 +100,7 @@ max_epochs: 30
 # Number of validation steps to run before training begins
 num_sanity_val_steps: 0
 # Set to "False" to further train a pre-trained Casanovo model
-train_from_scratch: False
+train_from_scratch: True
 # Calculate peptide and amino acid precision during training. this
 # is expensive, so we recommend against it.
 calculate_precision: False

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -257,10 +257,18 @@ class ModelRunner:
             self.model_filename is None,
         )
 
-        if train and (not self.config.train_from_scratch) and (self.model_filename is None):
-            logger.error("Training with `train_from_scratch: False` requires an input `--model`.")
-            raise ValueError("Training with `train_from_scratch: False` requires an input `--model`.")
-        
+        if (
+            train
+            and (not self.config.train_from_scratch)
+            and (self.model_filename is None)
+        ):
+            logger.error(
+                "Training with `train_from_scratch: False` requires an input `--model`."
+            )
+            raise ValueError(
+                "Training with `train_from_scratch: False` requires an input `--model`."
+            )
+
         if train and any(from_scratch):
             self.model = Spec2Pep(**model_params)
             return

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -256,6 +256,11 @@ class ModelRunner:
             self.config.train_from_scratch,
             self.model_filename is None,
         )
+
+        if train and (not self.config.train_from_scratch) and (self.model_filename is None):
+            logger.error("Training with `train_from_scratch: False` requires an input `--model`.")
+            raise ValueError("Training with `train_from_scratch: False` requires an input `--model`.")
+        
         if train and any(from_scratch):
             self.model = Spec2Pep(**model_params)
             return


### PR DESCRIPTION
I'm adding this pull request directly to the main branch as it does not add extra features.
This PR adds an extra compatibility check between two casanovo options.

Currently, `casanovo train` with a `config.yaml` specifying `train_from_scratch: False`, can still be run without setting the `--model` parameter. (It then still trains from scratch). I've added a `raise ValueError` that makes setting `--model` required when not training from scratch.