### PR TITLE
Stabilize torch.topk() behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Instead of having to specify `train_from_scratch` in the config file, training will proceed from an existing model weights file if this is given as an argument to `casanovo train`.
 
+### Fixed
+
+- Fixed beam search decoding error due to non-deterministic selection of beams with equal scores.
+
 ## [4.0.0] - 2023-12-22
 
 ### Added

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -1,4 +1,5 @@
 """The command line entry point for Casanovo."""
+
 import datetime
 import functools
 import logging

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -1,4 +1,5 @@
 """Parse the YAML configuration."""
+
 import logging
 import shutil
 from pathlib import Path

--- a/casanovo/data/datasets.py
+++ b/casanovo/data/datasets.py
@@ -1,4 +1,5 @@
 """A PyTorch Dataset class for annotated spectra."""
+
 from typing import Optional, Tuple
 
 import depthcharge

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -1,4 +1,5 @@
 """Mass spectrometry file type input/output operations."""
+
 import collections
 import csv
 import operator

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -1,4 +1,5 @@
 """Data loaders for the de novo sequencing task."""
+
 import functools
 import os
 from typing import List, Optional, Tuple

--- a/casanovo/denovo/evaluate.py
+++ b/casanovo/denovo/evaluate.py
@@ -1,4 +1,5 @@
 """Methods to evaluate peptide-spectrum predictions."""
+
 import re
 from typing import Dict, Iterable, List, Tuple
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -616,7 +616,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         ).clone()
         # Mask out the index '0', i.e. padding token, by default.
         finished_mask[:, :beam] = True
-        # Reverse the mask zero out finished beams when applied.
+        # Reverse the mask and zero out finished beams when applied.
         finished_mask = (~finished_mask).float()
         # Set non-zero value for index '0' to get only padding after stop token.
         finished_mask[:, :beam] = 1e-8

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -1,4 +1,5 @@
 """A de novo peptide sequencing model."""
+
 import collections
 import heapq
 import logging

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -608,12 +608,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
 
         # Mask out terminated beams. Include precursor m/z tolerance induced
         # termination.
-        # TODO: `clone()` is necessary to get the correct output with n_beams=1.
-        #   An alternative implementation using base PyTorch instead of einops
-        #   might be more efficient.
-        finished_mask = einops.repeat(
-            finished_beams, "(B S) -> B (V S)", S=beam, V=vocab
-        ).clone()
+        finished_mask = finished_beams.reshape(batch, beam).repeat(1, vocab)
         # Mask out the index '0', i.e. padding token, by default.
         finished_mask[:, :beam] = True
         # Reverse the mask and zero out finished beams when applied.

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -612,8 +612,8 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             ~finished_beams.reshape(batch, beam).repeat(1, vocab)
         ).float()
         # Mask out the index '0', i.e. padding token, by default.
-        # Set this to a very small, yet non-zero value, to only get padding
-        # after stop token.
+        # FIXME: Set this to a very small, yet non-zero value, to only
+        # get padding after stop token.
         active_mask[:, :beam] = 1e-8
 
         # Figure out the top K decodings.

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -1,5 +1,6 @@
 """Training and testing functionality for the de novo peptide sequencing
 model."""
+
 import glob
 import logging
 import os
@@ -306,9 +307,9 @@ class ModelRunner:
         self,
         train_index: Optional[AnnotatedSpectrumIndex] = None,
         valid_index: Optional[AnnotatedSpectrumIndex] = None,
-        test_index: (
-            Optional[Union[AnnotatedSpectrumIndex, SpectrumIndex]]
-        ) = None,
+        test_index: Optional[
+            Union[AnnotatedSpectrumIndex, SpectrumIndex]
+        ] = None,
     ) -> None:
         """Initialize the data module
 

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -1,4 +1,5 @@
 """Small utility functions"""
+
 import logging
 import os
 import platform

--- a/casanovo/version.py
+++ b/casanovo/version.py
@@ -1,4 +1,5 @@
 """Package version information."""
+
 from typing import Optional
 
 

--- a/docs/images/help.svg
+++ b/docs/images/help.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 904.0" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 74.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,182 +19,40 @@
         font-weight: 700;
     }
 
-    .terminal-2243088900-matrix {
+    .terminal-577310064-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-2243088900-title {
+    .terminal-577310064-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-2243088900-r1 { fill: #c5c8c6 }
-.terminal-2243088900-r2 { fill: #d0b344 }
-.terminal-2243088900-r3 { fill: #c5c8c6;font-weight: bold }
-.terminal-2243088900-r4 { fill: #68a0b3;font-weight: bold }
-.terminal-2243088900-r5 { fill: #d0b344;font-weight: bold }
-.terminal-2243088900-r6 { fill: #608ab1;text-decoration: underline; }
-.terminal-2243088900-r7 { fill: #868887 }
-.terminal-2243088900-r8 { fill: #98a84b;font-weight: bold }
+    .terminal-577310064-r1 { fill: #c5c8c6 }
     </style>
 
     <defs>
-    <clipPath id="terminal-2243088900-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="853.0" />
+    <clipPath id="terminal-577310064-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="23.4" />
     </clipPath>
-    <clipPath id="terminal-2243088900-line-0">
-    <rect x="0" y="1.5" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-1">
-    <rect x="0" y="25.9" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-2">
-    <rect x="0" y="50.3" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-3">
-    <rect x="0" y="74.7" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-4">
-    <rect x="0" y="99.1" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-5">
-    <rect x="0" y="123.5" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-6">
-    <rect x="0" y="147.9" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-7">
-    <rect x="0" y="172.3" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-8">
-    <rect x="0" y="196.7" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-9">
-    <rect x="0" y="221.1" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-10">
-    <rect x="0" y="245.5" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-11">
-    <rect x="0" y="269.9" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-12">
-    <rect x="0" y="294.3" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-13">
-    <rect x="0" y="318.7" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-14">
-    <rect x="0" y="343.1" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-15">
-    <rect x="0" y="367.5" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-16">
-    <rect x="0" y="391.9" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-17">
-    <rect x="0" y="416.3" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-18">
-    <rect x="0" y="440.7" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-19">
-    <rect x="0" y="465.1" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-20">
-    <rect x="0" y="489.5" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-21">
-    <rect x="0" y="513.9" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-22">
-    <rect x="0" y="538.3" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-23">
-    <rect x="0" y="562.7" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-24">
-    <rect x="0" y="587.1" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-25">
-    <rect x="0" y="611.5" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-26">
-    <rect x="0" y="635.9" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-27">
-    <rect x="0" y="660.3" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-28">
-    <rect x="0" y="684.7" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-29">
-    <rect x="0" y="709.1" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-30">
-    <rect x="0" y="733.5" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-31">
-    <rect x="0" y="757.9" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-32">
-    <rect x="0" y="782.3" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-2243088900-line-33">
-    <rect x="0" y="806.7" width="976" height="24.65"/>
-            </clipPath>
+    
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="902" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="72.4" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-2243088900-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-577310064-clip-terminal)">
     
-    <g class="terminal-2243088900-matrix">
-    <text class="terminal-2243088900-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-2243088900-line-0)">$&#160;casanovo&#160;--help</text><text class="terminal-2243088900-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2243088900-line-0)">
-</text><text class="terminal-2243088900-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-1)">
-</text><text class="terminal-2243088900-r2" x="12.2" y="68.8" textLength="73.2" clip-path="url(#terminal-2243088900-line-2)">Usage:</text><text class="terminal-2243088900-r3" x="97.6" y="68.8" textLength="97.6" clip-path="url(#terminal-2243088900-line-2)">casanovo</text><text class="terminal-2243088900-r1" x="195.2" y="68.8" textLength="24.4" clip-path="url(#terminal-2243088900-line-2)">&#160;[</text><text class="terminal-2243088900-r4" x="219.6" y="68.8" textLength="85.4" clip-path="url(#terminal-2243088900-line-2)">OPTIONS</text><text class="terminal-2243088900-r1" x="305" y="68.8" textLength="24.4" clip-path="url(#terminal-2243088900-line-2)">]&#160;</text><text class="terminal-2243088900-r4" x="329.4" y="68.8" textLength="85.4" clip-path="url(#terminal-2243088900-line-2)">COMMAND</text><text class="terminal-2243088900-r1" x="414.8" y="68.8" textLength="24.4" clip-path="url(#terminal-2243088900-line-2)">&#160;[</text><text class="terminal-2243088900-r4" x="439.2" y="68.8" textLength="48.8" clip-path="url(#terminal-2243088900-line-2)">ARGS</text><text class="terminal-2243088900-r1" x="488" y="68.8" textLength="488" clip-path="url(#terminal-2243088900-line-2)">]...&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-2)">
-</text><text class="terminal-2243088900-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-3)">
-</text><text class="terminal-2243088900-r1" x="0" y="117.6" textLength="976" clip-path="url(#terminal-2243088900-line-4)">&#160;┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓&#160;</text><text class="terminal-2243088900-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-4)">
-</text><text class="terminal-2243088900-r1" x="0" y="142" textLength="439.2" clip-path="url(#terminal-2243088900-line-5)">&#160;┃&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r3" x="439.2" y="142" textLength="97.6" clip-path="url(#terminal-2243088900-line-5)">Casanovo</text><text class="terminal-2243088900-r1" x="536.8" y="142" textLength="439.2" clip-path="url(#terminal-2243088900-line-5)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;┃&#160;</text><text class="terminal-2243088900-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2243088900-line-5)">
-</text><text class="terminal-2243088900-r1" x="0" y="166.4" textLength="976" clip-path="url(#terminal-2243088900-line-6)">&#160;┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛&#160;</text><text class="terminal-2243088900-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-6)">
-</text><text class="terminal-2243088900-r1" x="0" y="190.8" textLength="976" clip-path="url(#terminal-2243088900-line-7)">&#160;Casanovo&#160;de&#160;novo&#160;sequences&#160;peptides&#160;from&#160;tandem&#160;mass&#160;spectra&#160;using&#160;a&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-7)">
-</text><text class="terminal-2243088900-r1" x="0" y="215.2" textLength="976" clip-path="url(#terminal-2243088900-line-8)">&#160;Transformer&#160;model.&#160;Casanovo&#160;currently&#160;supports&#160;mzML,&#160;mzXML,&#160;and&#160;MGF&#160;files&#160;for&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-8)">
-</text><text class="terminal-2243088900-r1" x="0" y="239.6" textLength="976" clip-path="url(#terminal-2243088900-line-9)">&#160;de&#160;novo&#160;sequencing&#160;and&#160;annotated&#160;MGF&#160;files,&#160;such&#160;as&#160;those&#160;from&#160;MassIVE-KB,&#160;for&#160;</text><text class="terminal-2243088900-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-9)">
-</text><text class="terminal-2243088900-r1" x="0" y="264" textLength="976" clip-path="url(#terminal-2243088900-line-10)">&#160;training&#160;new&#160;models.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2243088900-line-10)">
-</text><text class="terminal-2243088900-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-11)">
-</text><text class="terminal-2243088900-r1" x="0" y="312.8" textLength="976" clip-path="url(#terminal-2243088900-line-12)">&#160;Links:&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-12)">
-</text><text class="terminal-2243088900-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-13)">
-</text><text class="terminal-2243088900-r5" x="12.2" y="361.6" textLength="36.6" clip-path="url(#terminal-2243088900-line-14)">&#160;•&#160;</text><text class="terminal-2243088900-r1" x="48.8" y="361.6" textLength="183" clip-path="url(#terminal-2243088900-line-14)">Documentation:&#160;</text><text class="terminal-2243088900-r6" x="231.8" y="361.6" textLength="378.2" clip-path="url(#terminal-2243088900-line-14)">https://casanovo.readthedocs.io</text><text class="terminal-2243088900-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-14)">
-</text><text class="terminal-2243088900-r5" x="12.2" y="386" textLength="36.6" clip-path="url(#terminal-2243088900-line-15)">&#160;•&#160;</text><text class="terminal-2243088900-r1" x="48.8" y="386" textLength="317.2" clip-path="url(#terminal-2243088900-line-15)">Official&#160;code&#160;repository:&#160;</text><text class="terminal-2243088900-r6" x="366" y="386" textLength="451.4" clip-path="url(#terminal-2243088900-line-15)">https://github.com/Noble-Lab/casanovo</text><text class="terminal-2243088900-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2243088900-line-15)">
-</text><text class="terminal-2243088900-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-16)">
-</text><text class="terminal-2243088900-r1" x="0" y="434.8" textLength="976" clip-path="url(#terminal-2243088900-line-17)">&#160;If&#160;you&#160;use&#160;Casanovo&#160;in&#160;your&#160;work,&#160;please&#160;cite:&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-17)">
-</text><text class="terminal-2243088900-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-18)">
-</text><text class="terminal-2243088900-r5" x="12.2" y="483.6" textLength="36.6" clip-path="url(#terminal-2243088900-line-19)">&#160;•&#160;</text><text class="terminal-2243088900-r1" x="48.8" y="483.6" textLength="927.2" clip-path="url(#terminal-2243088900-line-19)">Yilmaz,&#160;M.,&#160;Fondrie,&#160;W.&#160;E.,&#160;Bittremieux,&#160;W.,&#160;Oh,&#160;S.&#160;&amp;&#160;Noble,&#160;W.&#160;S.&#160;De&#160;novo&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-19)">
-</text><text class="terminal-2243088900-r1" x="48.8" y="508" textLength="927.2" clip-path="url(#terminal-2243088900-line-20)">mass&#160;spectrometry&#160;peptide&#160;sequencing&#160;with&#160;a&#160;transformer&#160;model.&#160;Proceedings&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2243088900-line-20)">
-</text><text class="terminal-2243088900-r1" x="48.8" y="532.4" textLength="927.2" clip-path="url(#terminal-2243088900-line-21)">of&#160;the&#160;39th&#160;International&#160;Conference&#160;on&#160;Machine&#160;Learning&#160;-&#160;ICML&#160;&#x27;22&#160;(2022)&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-21)">
-</text><text class="terminal-2243088900-r1" x="48.8" y="556.8" textLength="927.2" clip-path="url(#terminal-2243088900-line-22)">doi:10.1101/2022.02.07.479481.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-22)">
-</text><text class="terminal-2243088900-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-23)">
-</text><text class="terminal-2243088900-r7" x="0" y="605.6" textLength="24.4" clip-path="url(#terminal-2243088900-line-24)">╭─</text><text class="terminal-2243088900-r7" x="24.4" y="605.6" textLength="109.8" clip-path="url(#terminal-2243088900-line-24)">&#160;Options&#160;</text><text class="terminal-2243088900-r7" x="134.2" y="605.6" textLength="817.4" clip-path="url(#terminal-2243088900-line-24)">───────────────────────────────────────────────────────────────────</text><text class="terminal-2243088900-r7" x="951.6" y="605.6" textLength="24.4" clip-path="url(#terminal-2243088900-line-24)">─╮</text><text class="terminal-2243088900-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-24)">
-</text><text class="terminal-2243088900-r7" x="0" y="630" textLength="12.2" clip-path="url(#terminal-2243088900-line-25)">│</text><text class="terminal-2243088900-r4" x="24.4" y="630" textLength="12.2" clip-path="url(#terminal-2243088900-line-25)">-</text><text class="terminal-2243088900-r4" x="36.6" y="630" textLength="61" clip-path="url(#terminal-2243088900-line-25)">-help</text><text class="terminal-2243088900-r8" x="122" y="630" textLength="24.4" clip-path="url(#terminal-2243088900-line-25)">-h</text><text class="terminal-2243088900-r1" x="146.4" y="630" textLength="817.4" clip-path="url(#terminal-2243088900-line-25)">&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r7" x="963.8" y="630" textLength="12.2" clip-path="url(#terminal-2243088900-line-25)">│</text><text class="terminal-2243088900-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-2243088900-line-25)">
-</text><text class="terminal-2243088900-r7" x="0" y="654.4" textLength="976" clip-path="url(#terminal-2243088900-line-26)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-2243088900-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-26)">
-</text><text class="terminal-2243088900-r7" x="0" y="678.8" textLength="24.4" clip-path="url(#terminal-2243088900-line-27)">╭─</text><text class="terminal-2243088900-r7" x="24.4" y="678.8" textLength="122" clip-path="url(#terminal-2243088900-line-27)">&#160;Commands&#160;</text><text class="terminal-2243088900-r7" x="146.4" y="678.8" textLength="805.2" clip-path="url(#terminal-2243088900-line-27)">──────────────────────────────────────────────────────────────────</text><text class="terminal-2243088900-r7" x="951.6" y="678.8" textLength="24.4" clip-path="url(#terminal-2243088900-line-27)">─╮</text><text class="terminal-2243088900-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-27)">
-</text><text class="terminal-2243088900-r7" x="0" y="703.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-28)">│</text><text class="terminal-2243088900-r4" x="24.4" y="703.2" textLength="109.8" clip-path="url(#terminal-2243088900-line-28)">configure</text><text class="terminal-2243088900-r1" x="146.4" y="703.2" textLength="817.4" clip-path="url(#terminal-2243088900-line-28)">&#160;Generate&#160;a&#160;Casanovo&#160;configuration&#160;file&#160;to&#160;customize.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r7" x="963.8" y="703.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-28)">│</text><text class="terminal-2243088900-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-28)">
-</text><text class="terminal-2243088900-r7" x="0" y="727.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-29)">│</text><text class="terminal-2243088900-r4" x="24.4" y="727.6" textLength="109.8" clip-path="url(#terminal-2243088900-line-29)">evaluate&#160;</text><text class="terminal-2243088900-r1" x="146.4" y="727.6" textLength="817.4" clip-path="url(#terminal-2243088900-line-29)">&#160;Evaluate&#160;de&#160;novo&#160;peptide&#160;sequencing&#160;performance.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r7" x="963.8" y="727.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-29)">│</text><text class="terminal-2243088900-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-29)">
-</text><text class="terminal-2243088900-r7" x="0" y="752" textLength="12.2" clip-path="url(#terminal-2243088900-line-30)">│</text><text class="terminal-2243088900-r4" x="24.4" y="752" textLength="109.8" clip-path="url(#terminal-2243088900-line-30)">sequence&#160;</text><text class="terminal-2243088900-r1" x="146.4" y="752" textLength="817.4" clip-path="url(#terminal-2243088900-line-30)">&#160;De&#160;novo&#160;sequence&#160;peptides&#160;from&#160;tandem&#160;mass&#160;spectra.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r7" x="963.8" y="752" textLength="12.2" clip-path="url(#terminal-2243088900-line-30)">│</text><text class="terminal-2243088900-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-2243088900-line-30)">
-</text><text class="terminal-2243088900-r7" x="0" y="776.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-31)">│</text><text class="terminal-2243088900-r4" x="24.4" y="776.4" textLength="109.8" clip-path="url(#terminal-2243088900-line-31)">train&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r1" x="146.4" y="776.4" textLength="817.4" clip-path="url(#terminal-2243088900-line-31)">&#160;Train&#160;a&#160;Casanovo&#160;model&#160;on&#160;your&#160;own&#160;data.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r7" x="963.8" y="776.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-31)">│</text><text class="terminal-2243088900-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-2243088900-line-31)">
-</text><text class="terminal-2243088900-r7" x="0" y="800.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-32)">│</text><text class="terminal-2243088900-r4" x="24.4" y="800.8" textLength="109.8" clip-path="url(#terminal-2243088900-line-32)">version&#160;&#160;</text><text class="terminal-2243088900-r1" x="146.4" y="800.8" textLength="817.4" clip-path="url(#terminal-2243088900-line-32)">&#160;Get&#160;the&#160;Casanovo&#160;version&#160;information&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2243088900-r7" x="963.8" y="800.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-32)">│</text><text class="terminal-2243088900-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-2243088900-line-32)">
-</text><text class="terminal-2243088900-r7" x="0" y="825.2" textLength="976" clip-path="url(#terminal-2243088900-line-33)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-2243088900-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-2243088900-line-33)">
-</text><text class="terminal-2243088900-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-2243088900-line-34)">
+    <g class="terminal-577310064-matrix">
+    <text class="terminal-577310064-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-577310064-line-0)">$&#160;casanovo&#160;--help</text><text class="terminal-577310064-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-577310064-line-0)">
 </text>
     </g>
     </g>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures used for testing."""
+
 import numpy as np
 import psims
 import pytest

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,4 +1,5 @@
 """Test configuration loading"""
+
 import pytest
 import yaml
 

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -1,4 +1,5 @@
 """Unit tests specifically for the model_runner module."""
+
 import pytest
 import torch
 

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -426,7 +426,7 @@ def test_beam_search_decode():
 
     # Test _get_topk_beams() with finished beams in the batch.
     model = Spec2Pep(n_beams=1, residues="massivekb", min_peptide_len=3)
-    
+
     # Sizes and other variables.
     batch = 2  # B
     beam = model.n_beams  # S
@@ -440,33 +440,33 @@ def test_beam_search_decode():
         size=(batch, length, vocab, beam), fill_value=torch.nan
     )
     scores = einops.rearrange(scores, "B L V S -> (B S) L V")
-    tokens = torch.zeros(batch * beam, length, dtype=torch.int64)    
-    
+    tokens = torch.zeros(batch * beam, length, dtype=torch.int64)
+
     # Simulate non-zero amino acid-level probability scores.
-    scores[:, :step+1, :] = torch.rand(batch, step+1, vocab)
+    scores[:, : step + 1, :] = torch.rand(batch, step + 1, vocab)
     scores[:, step, range(1, 4)] = torch.tensor([1.0, 2.0, 3.0])
-    
-    # Simulate one finished and one unfinished beam in the same batch
-    tokens[0,:step] = torch.tensor([4, 14, 4, 28])
-    tokens[1,:step] = torch.tensor([4, 14, 4, 1])
-    
-    # Set finished beams array to allow decoding from only one beam
+
+    # Simulate one finished and one unfinished beam in the same batch.
+    tokens[0, :step] = torch.tensor([4, 14, 4, 28])
+    tokens[1, :step] = torch.tensor([4, 14, 4, 1])
+
+    # Set finished beams array to allow decoding from only one beam.
     test_finished_beams = torch.tensor([True, False])
 
     new_tokens, new_scores = model._get_topk_beams(
         tokens, scores, test_finished_beams, batch, step
     )
-    
-    # Only the second peptide should have a new token predicted
+
+    # Only the second peptide should have a new token predicted.
     expected_tokens = torch.tensor(
         [
             [4, 14, 4, 28, 0],
             [4, 14, 4, 1, 3],
-
         ]
     )
-  
-    assert torch.equal(new_tokens[:, : step + 1], expected_tokens)    
+
+    assert torch.equal(new_tokens[:, : step + 1], expected_tokens)
+
 
 def test_eval_metrics():
     """

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -424,6 +424,49 @@ def test_beam_search_decode():
     )
     assert torch.equal(discarded_beams, torch.tensor([False, True, True]))
 
+    # Test _get_topk_beams() with finished beams in the batch.
+    model = Spec2Pep(n_beams=1, residues="massivekb", min_peptide_len=3)
+    
+    # Sizes and other variables.
+    batch = 2  # B
+    beam = model.n_beams  # S
+    model.decoder.reverse = True
+    length = model.max_length + 1  # L
+    vocab = model.decoder.vocab_size + 1  # V
+    step = 4
+
+    # Initialize dummyy scores and tokens.
+    scores = torch.full(
+        size=(batch, length, vocab, beam), fill_value=torch.nan
+    )
+    scores = einops.rearrange(scores, "B L V S -> (B S) L V")
+    tokens = torch.zeros(batch * beam, length, dtype=torch.int64)    
+    
+    # Simulate non-zero amino acid-level probability scores.
+    scores[:, :step+1, :] = torch.rand(batch, step+1, vocab)
+    scores[:, step, range(1, 4)] = torch.tensor([1.0, 2.0, 3.0])
+    
+    # Simulate one finished and one unfinished beam in the same batch
+    tokens[0,:step] = torch.tensor([4, 14, 4, 28])
+    tokens[1,:step] = torch.tensor([4, 14, 4, 1])
+    
+    # Set finished beams array to allow decoding from only one beam
+    test_finished_beams = torch.tensor([True, False])
+
+    new_tokens, new_scores = model._get_topk_beams(
+        tokens, scores, test_finished_beams, batch, step
+    )
+    
+    # Only the second peptide should have a new token predicted
+    expected_tokens = torch.tensor(
+        [
+            [4, 14, 4, 28, 0],
+            [4, 14, 4, 1, 3],
+
+        ]
+    )
+  
+    assert torch.equal(new_tokens[:, : step + 1], expected_tokens)    
 
 def test_eval_metrics():
     """


### PR DESCRIPTION
Addresses #284 

To make sure we get the padding token at index  '0'  as the top scoring token for finished beams at each decoding step, I added a small epsilon of `1e-8` to index '0' in `finished_mask` so that it's not zeroed out like the rest of values on the same row. Again, these zero rows correspond to finished beams and we use masking to avoid extending them with new AA tokens.

This seems to resolve the error with minimal/no overhead (I get the same output on both CPU and GPU for the problematic mgf files mentioned in the issue) but unit tests still need to be added (@bittremieux feel free if you get a chance) and I'm open to moving away from `torch.topk()` if there are suggestions for a more robust or elegant solution.