### PR TITLE
Run unit tests on macOS with M1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,9 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run unit and system tests
-      run: |
-        pytest --cov=casanovo tests/
+      run: pytest --cov=casanovo tests/
+      env:
+        PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.0
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "scikit-learn",
     "spectrum_utils",
     "tensorboard",
-    "torch>=2.1",
+    "torch>=2.3",
     "tqdm",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
See [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) for the available (free) runners for GitHub Actions.