### PR TITLE
mzTab validation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Precursor charges are now exported as integers instead of floats in the mzTab output file, in compliance with the mzTab specification.
+
 ## [4.2.0] - 2024-05-14
 
 ### Added

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -198,7 +198,7 @@ class MztabWriter:
                         # FIXME: Can we get the retention time from the data
                         #  loader?
                         "null",  # retention_time
-                        psm[3],  # charge
+                        int(psm[3]),  # charge
                         psm[4],  # exp_mass_to_charge
                         psm[5],  # calc_mass_to_charge
                         f"ms_run[{self._run_map[filename]}]:{idx}",


### PR DESCRIPTION
Changed the charge value that's written to the results mzTab file to an integer value in order to comply with the mzTab standard.