### PR TITLE
Restrict NumPy to pre-2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.2.1] - 2024-06-25
+
+### Fixed
+
+- Pin NumPy version to below v2.0 to ensure compatibility with current DepthCharge version.
+
 ## [4.2.0] - 2024-05-14
 
 ### Added
@@ -248,7 +254,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial Casanovo version.
 
-[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v4.2.0...HEAD
+[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v4.2.1...HEAD
+[4.2.1]: https://github.com/Noble-Lab/casanovo/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/Noble-Lab/casanovo/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/Noble-Lab/casanovo/compare/v4.0.1...v4.1.0
 [4.0.1]: https://github.com/Noble-Lab/casanovo/compare/v4.0.0...v4.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "click",
     "depthcharge-ms>=0.2.3,<0.3.0",
     "natsort",
-    "numpy",
+    "numpy<2.0",
     "pandas",
     "psutil",
     "PyGithub",


### PR DESCRIPTION
Fixes #339.

Hotfix until NumPy v2.0 will be supported after the DepthCharge upgrade.