### PR TITLE
Switched to Geometric Mean for Peptide Level Scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The `--output` option has been split into two options, `--output_dir` and `--output_root`.
 - The `--validation_peak_path` is now optional when training; if `--validation_peak_path` is not set then the `train_peak_path` will also be used for validation.
 - The `tb_summarywriter` config option is now a boolean config option, and if set to true the TensorBoard summary will be written to a sub-directory of the output directory named `tensorboard`.
+- The Casanovo model peptide level score is now reported as the geometric mean of the raw amino acid scores, rather then the arithmetic mean.
 
 ### Fixed
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -1076,7 +1076,7 @@ def _aa_pep_score(
     peptide_score : float
         The peptide score.
     """
-    peptide_score = np.mean(aa_scores)
+    peptide_score = np.exp(np.mean(np.log(aa_scores)))
     aa_scores = (aa_scores + peptide_score) / 2
     if not fits_precursor_mz:
         peptide_score -= 1

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -439,12 +439,12 @@ def test_aa_pep_score():
     aa_scores_raw = np.asarray([0.0, 0.5, 1.0])
 
     aa_scores, peptide_score = _aa_pep_score(aa_scores_raw, True)
-    np.testing.assert_array_equal(aa_scores, np.asarray([0.25, 0.5, 0.75]))
-    assert peptide_score == pytest.approx(0.5)
+    np.testing.assert_array_equal(aa_scores, np.asarray([0.0, 0.25, 0.5]))
+    assert peptide_score == pytest.approx(0.0)
 
     aa_scores, peptide_score = _aa_pep_score(aa_scores_raw, False)
-    np.testing.assert_array_equal(aa_scores, np.asarray([0.25, 0.5, 0.75]))
-    assert peptide_score == pytest.approx(-0.5)
+    np.testing.assert_array_equal(aa_scores, np.asarray([0.0, 0.25, 0.5]))
+    assert peptide_score == pytest.approx(-1.0)
 
 
 def test_beam_search_decode():

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -446,6 +446,11 @@ def test_aa_pep_score():
     np.testing.assert_array_equal(aa_scores, np.asarray([0.0, 0.25, 0.5]))
     assert peptide_score == pytest.approx(-1.0)
 
+    aa_scores_raw = np.asarray([1.0, 0.25])
+    aa_scores, peptide_score = _aa_pep_score(aa_scores_raw, True)
+    np.testing.assert_array_equal(aa_scores, np.asarray([0.75, 0.375]))
+    assert peptide_score == pytest.approx(0.5)
+
 
 def test_beam_search_decode():
     """


### PR DESCRIPTION
Switched the peptide level score calculation from the arithmetic mean to the geometric mean of amino acid scores.