### PR TITLE
Experimental vs Calculated MZ Bug Fix

### DIFF
--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -919,8 +919,8 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                     spectrum_id=tuple(spectrum_i),
                     peptide_score=peptide_score,
                     charge=int(charge),
-                    calc_mz=precursor_mz,
-                    exp_mz=self.peptide_mass_calculator.mass(peptide, charge),
+                    calc_mz=self.peptide_mass_calculator.mass(peptide, charge),
+                    exp_mz=precursor_mz,
                     aa_scores=aa_scores,
                 )
             )


### PR DESCRIPTION
As pointed out by Isha, the `calc_mz` and `precursor_mz` values are currently erroneously swapped when passing PSMs to the output writer.