### PR TITLE
Log Average Throughput and Inference Run Time

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -181,7 +181,8 @@ def sequence(
     config, model = setup_model(
         model, config, output_path, output_root_name, False
     )
-    start_time = time.time()
+    start_time = time.perf_counter()
+    utils.log_intro_report(start_time=start_time)
     with ModelRunner(
         config,
         model,
@@ -202,7 +203,10 @@ def sequence(
             evaluate=evaluate,
         )
         utils.log_annotate_report(
-            runner.writer.psms, start_time=start_time, end_time=time.time()
+            runner.writer.psms,
+            start_time=start_time,
+            sequence_start_time=runner.sequence_start_time,
+            end_time=time.perf_counter(),
         )
 
 
@@ -241,7 +245,8 @@ def db_search(
     config, model = setup_model(
         model, config, output_path, output_root_name, False
     )
-    start_time = time.time()
+    start_time = time.perf_counter()
+    utils.log_intro_report(start_time=start_time)
     with ModelRunner(
         config,
         model,
@@ -262,7 +267,9 @@ def db_search(
             str((output_path / output_root_name).with_suffix(".mztab")),
         )
         utils.log_annotate_report(
-            runner.writer.psms, start_time=start_time, end_time=time.time()
+            runner.writer.psms,
+            start_time=start_time,
+            end_time=time.perf_counter(),
         )
 
 
@@ -306,7 +313,8 @@ def train(
     config, model = setup_model(
         model, config, output_path, output_root_name, True
     )
-    start_time = time.time()
+    start_time = time.perf_counter()
+    utils.log_intro_report(start_time=start_time)
     with ModelRunner(
         config,
         model,
@@ -326,7 +334,9 @@ def train(
             logger.info("  %s", peak_file)
 
         runner.train(train_peak_path, validation_peak_path)
-        utils.log_run_report(start_time=start_time, end_time=time.time())
+        utils.log_run_report(
+            start_time=start_time, end_time=time.perf_counter()
+        )
 
 
 @main.command()

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -44,6 +44,7 @@ class MztabWriter:
         ]
         self._run_map = {}
         self.psms: List[PepSpecMatch] = []
+        self.start_time = None
 
     def set_metadata(self, config: Config, **kwargs) -> None:
         """

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -44,7 +44,6 @@ class MztabWriter:
         ]
         self._run_map = {}
         self.psms: List[PepSpecMatch] = []
-        self.start_time = None
 
     def set_metadata(self, config: Config, **kwargs) -> None:
         """

--- a/casanovo/data/psm.py
+++ b/casanovo/data/psm.py
@@ -1,7 +1,7 @@
 """Peptide spectrum match dataclass."""
 
 import dataclasses
-from typing import Tuple, Iterable
+from typing import Optional, Tuple, Iterable
 
 
 @dataclasses.dataclass
@@ -31,6 +31,8 @@ class PepSpecMatch:
     aa_scores : Iterable[float]
         A list of scores for individual amino acids in the peptide
         sequence, where len(aa_scores) == len(sequence).
+    sequence_time : Optional[float], default=None
+        System time in seconds at inference completion
     protein : str
         Protein associated with the peptide sequence (for db mode).
     """
@@ -42,4 +44,5 @@ class PepSpecMatch:
     calc_mz: float
     exp_mz: float
     aa_scores: Iterable[float]
+    sequence_time: Optional[float] = None
     protein: str = "null"

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -844,11 +844,13 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             precursor_mz,
             spectrum_i,
             spectrum_preds,
+            batch_time,
         ) in zip(
             batch[1][:, 1].cpu().detach().numpy(),
             batch[1][:, 2].cpu().detach().numpy(),
             batch[2],
             self.forward(batch[0], batch[1]),
+            itertools.repeat(time.perf_counter()),
         ):
             for peptide_score, aa_scores, peptide in spectrum_preds:
                 predictions.append(
@@ -862,7 +864,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                         ),
                         exp_mz=precursor_mz,
                         aa_scores=aa_scores,
-                        sequence_time=time.perf_counter(),
+                        sequence_time=batch_time,
                     )
                 )
 

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -5,6 +5,7 @@ import glob
 import logging
 import os
 import tempfile
+import time
 import uuid
 import warnings
 from pathlib import Path
@@ -73,6 +74,7 @@ class ModelRunner:
         self.model = None
         self.loaders = None
         self.writer = None
+        self.sequence_start_time = None
 
         if output_dir is None:
             self.callbacks = []
@@ -285,6 +287,7 @@ class ModelRunner:
         self.writer.set_ms_run(test_index.ms_files)
         self.initialize_data_module(test_index=test_index)
         self.loaders.setup(stage="test", annotated=False)
+        self.sequence_start_time = time.perf_counter()
         self.trainer.predict(self.model, self.loaders.test_dataloader())
 
         if evaluate:


### PR DESCRIPTION
Introduced end of run logging functionality for throughput and total inference run time. Similar functionality could be implemented using `lightning.pytorch.callbacks.ThroughputMonitor` for less code complexity, however this would log the throughput to the PyLightning logs (e.g. the tensorboard or CSV logs) and I'm not sure if this would be desirable behavior.