### PR TITLE
Output root suffix fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Removed the `evaluate` sub-command, and all model evaluation functionality has been moved to the `sequence` command using the new `--evaluate` flag.
 - The `--output` option has been split into two options, `--output_dir` and `--output_root`.
-- The path suffix (extension) of `--output_root` will no longer be removed as in the old `--output` option.
+- The path suffix (extension) of `--output_root` will no longer be removed as it was with the old `--output` option.
 - The `--validation_peak_path` is now optional when training; if `--validation_peak_path` is not set then the `train_peak_path` will also be used for validation.
 - The `tb_summarywriter` config option is now a boolean config option, and if set to true the TensorBoard summary will be written to a sub-directory of the output directory named `tensorboard`.
 - The Casanovo model peptide level score is now reported as the geometric mean of the raw amino acid scores, rather then the arithmetic mean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Removed the `evaluate` sub-command, and all model evaluation functionality has been moved to the `sequence` command using the new `--evaluate` flag.
 - The `--output` option has been split into two options, `--output_dir` and `--output_root`.
+- The path suffix (extension) of `--output_root` will no longer be removed as in the old `--output` option.
 - The `--validation_peak_path` is now optional when training; if `--validation_peak_path` is not set then the `train_peak_path` will also be used for validation.
 - The `tb_summarywriter` config option is now a boolean config option, and if set to true the TensorBoard summary will be written to a sub-directory of the output directory named `tensorboard`.
 - The Casanovo model peptide level score is now reported as the geometric mean of the raw amino acid scores, rather then the arithmetic mean.

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -196,8 +196,7 @@ def sequence(
         for peak_file in peak_path:
             logger.info("  %s", peak_file)
 
-        results_path = output_path / output_root_name
-        results_path = results_path.with_name(results_path.name + ".mztab")
+        results_path = output_path / f"{output_root_name}.mztab"
         runner.predict(
             peak_path,
             str(results_path),
@@ -258,8 +257,7 @@ def db_search(
         logger.info("Using the following FASTA file:")
         logger.info("  %s", fasta_path)
 
-        results_path = output_path / output_root_name
-        results_path = results_path.with_name(results_path.name + ".mztab")
+        results_path = output_path / f"{output_root_name}.mztab"
         runner.db_search(
             peak_path,
             fasta_path,

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -196,9 +196,11 @@ def sequence(
         for peak_file in peak_path:
             logger.info("  %s", peak_file)
 
+        results_path = output_path / output_root_name
+        results_path = results_path.with_name(results_path.name + ".mztab")
         runner.predict(
             peak_path,
-            str((output_path / output_root_name).with_suffix(".mztab")),
+            str(results_path),
             evaluate=evaluate,
         )
         utils.log_annotate_report(
@@ -256,10 +258,12 @@ def db_search(
         logger.info("Using the following FASTA file:")
         logger.info("  %s", fasta_path)
 
+        results_path = output_path / output_root_name
+        results_path = results_path.with_name(results_path.name + ".mztab")
         runner.db_search(
             peak_path,
             fasta_path,
-            str((output_path / output_root_name).with_suffix(".mztab")),
+            str(results_path),
         )
         utils.log_annotate_report(
             runner.writer.psms, start_time=start_time, end_time=time.time()
@@ -648,7 +652,9 @@ def _setup_output(
     if not overwrite:
         utils.check_dir_file_exists(output_path, f"{output_root}.log")
 
-    setup_logging((output_path / output_root).with_suffix(".log"), verbosity)
+    log_file_path = output_path / output_root
+    log_file_path = log_file_path.with_name(log_file_path.name + ".log")
+    setup_logging(log_file_path, verbosity)
     return output_path, output_root
 
 

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -650,8 +650,7 @@ def _setup_output(
     if not overwrite:
         utils.check_dir_file_exists(output_path, f"{output_root}.log")
 
-    log_file_path = output_path / output_root
-    log_file_path = log_file_path.with_name(log_file_path.name + ".log")
+    log_file_path = output_path / f"{output_root}.log"
     setup_logging(log_file_path, verbosity)
     return output_path, output_root
 

--- a/docs/images/help.svg
+++ b/docs/images/help.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 74.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 904.0" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,40 +19,181 @@
         font-weight: 700;
     }
 
-    .terminal-577310064-matrix {
+    .terminal-1140158551-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-577310064-title {
+    .terminal-1140158551-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-577310064-r1 { fill: #c5c8c6 }
+    .terminal-1140158551-r1 { fill: #c5c8c6 }
+.terminal-1140158551-r2 { fill: #d0b344 }
+.terminal-1140158551-r3 { fill: #c5c8c6;font-weight: bold }
+.terminal-1140158551-r4 { fill: #68a0b3;font-weight: bold }
+.terminal-1140158551-r5 { fill: #d0b344;font-weight: bold }
+.terminal-1140158551-r6 { fill: #868887 }
+.terminal-1140158551-r7 { fill: #98a84b;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-577310064-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="23.4" />
+    <clipPath id="terminal-1140158551-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="853.0" />
     </clipPath>
-    
+    <clipPath id="terminal-1140158551-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-23">
+    <rect x="0" y="562.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-24">
+    <rect x="0" y="587.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-25">
+    <rect x="0" y="611.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-26">
+    <rect x="0" y="635.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-27">
+    <rect x="0" y="660.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-28">
+    <rect x="0" y="684.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-29">
+    <rect x="0" y="709.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-30">
+    <rect x="0" y="733.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-31">
+    <rect x="0" y="757.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-32">
+    <rect x="0" y="782.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1140158551-line-33">
+    <rect x="0" y="806.7" width="976" height="24.65"/>
+            </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="72.4" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="902" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-577310064-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1140158551-clip-terminal)">
     
-    <g class="terminal-577310064-matrix">
-    <text class="terminal-577310064-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-577310064-line-0)">$&#160;casanovo&#160;--help</text><text class="terminal-577310064-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-577310064-line-0)">
+    <g class="terminal-1140158551-matrix">
+    <text class="terminal-1140158551-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-1140158551-line-0)">$&#160;casanovo&#160;--help</text><text class="terminal-1140158551-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1140158551-line-0)">
+</text><text class="terminal-1140158551-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-1)">
+</text><text class="terminal-1140158551-r2" x="12.2" y="68.8" textLength="73.2" clip-path="url(#terminal-1140158551-line-2)">Usage:</text><text class="terminal-1140158551-r3" x="97.6" y="68.8" textLength="97.6" clip-path="url(#terminal-1140158551-line-2)">casanovo</text><text class="terminal-1140158551-r1" x="195.2" y="68.8" textLength="24.4" clip-path="url(#terminal-1140158551-line-2)">&#160;[</text><text class="terminal-1140158551-r4" x="219.6" y="68.8" textLength="85.4" clip-path="url(#terminal-1140158551-line-2)">OPTIONS</text><text class="terminal-1140158551-r1" x="305" y="68.8" textLength="24.4" clip-path="url(#terminal-1140158551-line-2)">]&#160;</text><text class="terminal-1140158551-r4" x="329.4" y="68.8" textLength="85.4" clip-path="url(#terminal-1140158551-line-2)">COMMAND</text><text class="terminal-1140158551-r1" x="414.8" y="68.8" textLength="24.4" clip-path="url(#terminal-1140158551-line-2)">&#160;[</text><text class="terminal-1140158551-r4" x="439.2" y="68.8" textLength="48.8" clip-path="url(#terminal-1140158551-line-2)">ARGS</text><text class="terminal-1140158551-r1" x="488" y="68.8" textLength="488" clip-path="url(#terminal-1140158551-line-2)">]...&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-2)">
+</text><text class="terminal-1140158551-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-3)">
+</text><text class="terminal-1140158551-r1" x="0" y="117.6" textLength="976" clip-path="url(#terminal-1140158551-line-4)">&#160;┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓&#160;</text><text class="terminal-1140158551-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-4)">
+</text><text class="terminal-1140158551-r1" x="0" y="142" textLength="439.2" clip-path="url(#terminal-1140158551-line-5)">&#160;┃&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r3" x="439.2" y="142" textLength="97.6" clip-path="url(#terminal-1140158551-line-5)">Casanovo</text><text class="terminal-1140158551-r1" x="536.8" y="142" textLength="439.2" clip-path="url(#terminal-1140158551-line-5)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;┃&#160;</text><text class="terminal-1140158551-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1140158551-line-5)">
+</text><text class="terminal-1140158551-r1" x="0" y="166.4" textLength="976" clip-path="url(#terminal-1140158551-line-6)">&#160;┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛&#160;</text><text class="terminal-1140158551-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-6)">
+</text><text class="terminal-1140158551-r1" x="0" y="190.8" textLength="976" clip-path="url(#terminal-1140158551-line-7)">&#160;Casanovo&#160;de&#160;novo&#160;sequences&#160;peptides&#160;from&#160;tandem&#160;mass&#160;spectra&#160;using&#160;a&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-7)">
+</text><text class="terminal-1140158551-r1" x="0" y="215.2" textLength="976" clip-path="url(#terminal-1140158551-line-8)">&#160;Transformer&#160;model.&#160;Casanovo&#160;currently&#160;supports&#160;mzML,&#160;mzXML,&#160;and&#160;MGF&#160;files&#160;for&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-8)">
+</text><text class="terminal-1140158551-r1" x="0" y="239.6" textLength="976" clip-path="url(#terminal-1140158551-line-9)">&#160;de&#160;novo&#160;sequencing&#160;and&#160;annotated&#160;MGF&#160;files,&#160;such&#160;as&#160;those&#160;from&#160;MassIVE-KB,&#160;for&#160;</text><text class="terminal-1140158551-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-9)">
+</text><text class="terminal-1140158551-r1" x="0" y="264" textLength="976" clip-path="url(#terminal-1140158551-line-10)">&#160;training&#160;new&#160;models.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1140158551-line-10)">
+</text><text class="terminal-1140158551-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-11)">
+</text><text class="terminal-1140158551-r1" x="0" y="312.8" textLength="976" clip-path="url(#terminal-1140158551-line-12)">&#160;Links:&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-12)">
+</text><text class="terminal-1140158551-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-13)">
+</text><text class="terminal-1140158551-r5" x="12.2" y="361.6" textLength="36.6" clip-path="url(#terminal-1140158551-line-14)">&#160;•&#160;</text><text class="terminal-1140158551-r1" x="48.8" y="361.6" textLength="927.2" clip-path="url(#terminal-1140158551-line-14)">Documentation:&#160;https://casanovo.readthedocs.io&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-14)">
+</text><text class="terminal-1140158551-r5" x="12.2" y="386" textLength="36.6" clip-path="url(#terminal-1140158551-line-15)">&#160;•&#160;</text><text class="terminal-1140158551-r1" x="48.8" y="386" textLength="927.2" clip-path="url(#terminal-1140158551-line-15)">Official&#160;code&#160;repository:&#160;https://github.com/Noble-Lab/casanovo&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1140158551-line-15)">
+</text><text class="terminal-1140158551-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-16)">
+</text><text class="terminal-1140158551-r1" x="0" y="434.8" textLength="976" clip-path="url(#terminal-1140158551-line-17)">&#160;If&#160;you&#160;use&#160;Casanovo&#160;in&#160;your&#160;work,&#160;please&#160;cite:&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-17)">
+</text><text class="terminal-1140158551-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-18)">
+</text><text class="terminal-1140158551-r5" x="12.2" y="483.6" textLength="36.6" clip-path="url(#terminal-1140158551-line-19)">&#160;•&#160;</text><text class="terminal-1140158551-r1" x="48.8" y="483.6" textLength="927.2" clip-path="url(#terminal-1140158551-line-19)">Yilmaz,&#160;M.,&#160;Fondrie,&#160;W.&#160;E.,&#160;Bittremieux,&#160;W.,&#160;Oh,&#160;S.&#160;&amp;&#160;Noble,&#160;W.&#160;S.&#160;De&#160;novo&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-19)">
+</text><text class="terminal-1140158551-r1" x="48.8" y="508" textLength="927.2" clip-path="url(#terminal-1140158551-line-20)">mass&#160;spectrometry&#160;peptide&#160;sequencing&#160;with&#160;a&#160;transformer&#160;model.&#160;Proceedings&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1140158551-line-20)">
+</text><text class="terminal-1140158551-r1" x="48.8" y="532.4" textLength="927.2" clip-path="url(#terminal-1140158551-line-21)">of&#160;the&#160;39th&#160;International&#160;Conference&#160;on&#160;Machine&#160;Learning&#160;-&#160;ICML&#160;&#x27;22&#160;(2022)&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-21)">
+</text><text class="terminal-1140158551-r1" x="48.8" y="556.8" textLength="927.2" clip-path="url(#terminal-1140158551-line-22)">doi:10.1101/2022.02.07.479481.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-22)">
+</text><text class="terminal-1140158551-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-23)">
+</text><text class="terminal-1140158551-r6" x="0" y="605.6" textLength="24.4" clip-path="url(#terminal-1140158551-line-24)">╭─</text><text class="terminal-1140158551-r6" x="24.4" y="605.6" textLength="109.8" clip-path="url(#terminal-1140158551-line-24)">&#160;Options&#160;</text><text class="terminal-1140158551-r6" x="134.2" y="605.6" textLength="817.4" clip-path="url(#terminal-1140158551-line-24)">───────────────────────────────────────────────────────────────────</text><text class="terminal-1140158551-r6" x="951.6" y="605.6" textLength="24.4" clip-path="url(#terminal-1140158551-line-24)">─╮</text><text class="terminal-1140158551-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-24)">
+</text><text class="terminal-1140158551-r6" x="0" y="630" textLength="12.2" clip-path="url(#terminal-1140158551-line-25)">│</text><text class="terminal-1140158551-r4" x="24.4" y="630" textLength="73.2" clip-path="url(#terminal-1140158551-line-25)">--help</text><text class="terminal-1140158551-r7" x="122" y="630" textLength="24.4" clip-path="url(#terminal-1140158551-line-25)">-h</text><text class="terminal-1140158551-r1" x="146.4" y="630" textLength="817.4" clip-path="url(#terminal-1140158551-line-25)">&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r6" x="963.8" y="630" textLength="12.2" clip-path="url(#terminal-1140158551-line-25)">│</text><text class="terminal-1140158551-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-1140158551-line-25)">
+</text><text class="terminal-1140158551-r6" x="0" y="654.4" textLength="976" clip-path="url(#terminal-1140158551-line-26)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1140158551-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-26)">
+</text><text class="terminal-1140158551-r6" x="0" y="678.8" textLength="24.4" clip-path="url(#terminal-1140158551-line-27)">╭─</text><text class="terminal-1140158551-r6" x="24.4" y="678.8" textLength="122" clip-path="url(#terminal-1140158551-line-27)">&#160;Commands&#160;</text><text class="terminal-1140158551-r6" x="146.4" y="678.8" textLength="805.2" clip-path="url(#terminal-1140158551-line-27)">──────────────────────────────────────────────────────────────────</text><text class="terminal-1140158551-r6" x="951.6" y="678.8" textLength="24.4" clip-path="url(#terminal-1140158551-line-27)">─╮</text><text class="terminal-1140158551-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-27)">
+</text><text class="terminal-1140158551-r6" x="0" y="703.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-28)">│</text><text class="terminal-1140158551-r4" x="24.4" y="703.2" textLength="109.8" clip-path="url(#terminal-1140158551-line-28)">configure</text><text class="terminal-1140158551-r1" x="146.4" y="703.2" textLength="817.4" clip-path="url(#terminal-1140158551-line-28)">&#160;Generate&#160;a&#160;Casanovo&#160;configuration&#160;file&#160;to&#160;customize.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r6" x="963.8" y="703.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-28)">│</text><text class="terminal-1140158551-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-28)">
+</text><text class="terminal-1140158551-r6" x="0" y="727.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-29)">│</text><text class="terminal-1140158551-r4" x="24.4" y="727.6" textLength="109.8" clip-path="url(#terminal-1140158551-line-29)">db-search</text><text class="terminal-1140158551-r1" x="146.4" y="727.6" textLength="817.4" clip-path="url(#terminal-1140158551-line-29)">&#160;Perform&#160;a&#160;database&#160;search&#160;on&#160;MS/MS&#160;data&#160;using&#160;Casanovo-DB.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r6" x="963.8" y="727.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-29)">│</text><text class="terminal-1140158551-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-29)">
+</text><text class="terminal-1140158551-r6" x="0" y="752" textLength="12.2" clip-path="url(#terminal-1140158551-line-30)">│</text><text class="terminal-1140158551-r4" x="24.4" y="752" textLength="109.8" clip-path="url(#terminal-1140158551-line-30)">sequence&#160;</text><text class="terminal-1140158551-r1" x="146.4" y="752" textLength="817.4" clip-path="url(#terminal-1140158551-line-30)">&#160;De&#160;novo&#160;sequence&#160;peptides&#160;from&#160;tandem&#160;mass&#160;spectra.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r6" x="963.8" y="752" textLength="12.2" clip-path="url(#terminal-1140158551-line-30)">│</text><text class="terminal-1140158551-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-1140158551-line-30)">
+</text><text class="terminal-1140158551-r6" x="0" y="776.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-31)">│</text><text class="terminal-1140158551-r4" x="24.4" y="776.4" textLength="109.8" clip-path="url(#terminal-1140158551-line-31)">train&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r1" x="146.4" y="776.4" textLength="817.4" clip-path="url(#terminal-1140158551-line-31)">&#160;Train&#160;a&#160;Casanovo&#160;model&#160;on&#160;your&#160;own&#160;data.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r6" x="963.8" y="776.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-31)">│</text><text class="terminal-1140158551-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-1140158551-line-31)">
+</text><text class="terminal-1140158551-r6" x="0" y="800.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-32)">│</text><text class="terminal-1140158551-r4" x="24.4" y="800.8" textLength="109.8" clip-path="url(#terminal-1140158551-line-32)">version&#160;&#160;</text><text class="terminal-1140158551-r1" x="146.4" y="800.8" textLength="817.4" clip-path="url(#terminal-1140158551-line-32)">&#160;Get&#160;the&#160;Casanovo&#160;version&#160;information.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1140158551-r6" x="963.8" y="800.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-32)">│</text><text class="terminal-1140158551-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-1140158551-line-32)">
+</text><text class="terminal-1140158551-r6" x="0" y="825.2" textLength="976" clip-path="url(#terminal-1140158551-line-33)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1140158551-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-1140158551-line-33)">
+</text><text class="terminal-1140158551-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-1140158551-line-34)">
 </text>
     </g>
     </g>


### PR DESCRIPTION
Fixed issue where the suffix of the output root argument would get overridden, e.g. if output root is set to foo.bar the output files would become `foo.log` and `foo.mztab` rather than the expected `foo.bar.log` and `foo.bar.mztab`. 