### PR TITLE
Minor error correction in the installation of black and pre-commit us…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ up the pre-commit hook:
 pip install black pre-commit
 
 # Using conda
-conda -c conda-forge black pre-commit
+conda install -c conda-forge black pre-commit
 ```
 
 2. Navigate to your local copy of the Casanovo repository and activate the hook:


### PR DESCRIPTION
…ing conda, added the 'install' command to it. 

The commands to install black and pre-commit are incorrect and have a missing install section. This is just a minor correction in the documentation. ~Can't participate in GSOC as I don't have local GPU, but I have a small contribution from my end. Did not mean to annoy you with README changes~