### PR TITLE
Specify Sphinx configuration for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,6 @@ build:
 
 conda:
   environment: docs/environment.yaml
+
+sphinx:
+    configuration: docs/conf.py


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/