### PR TITLE
1st version of beam_search_optimization

### DIFF
--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -5,6 +5,8 @@ import heapq
 import logging
 import warnings
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 import depthcharge.masses
 import einops
@@ -14,9 +16,10 @@ import lightning.pytorch as pl
 from torch.utils.tensorboard import SummaryWriter
 from depthcharge.components import ModelMixin, PeptideDecoder, SpectrumEncoder
 
-from . import evaluate
-from .. import config
-from ..data import ms_io
+from casanovo.denovo import evaluate
+
+from casanovo import config
+from casanovo.data import ms_io
 
 logger = logging.getLogger("casanovo")
 
@@ -92,31 +95,32 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
     """
 
     def __init__(
-        self,
-        dim_model: int = 512,
-        n_head: int = 8,
-        dim_feedforward: int = 1024,
-        n_layers: int = 9,
-        dropout: float = 0.0,
-        dim_intensity: Optional[int] = None,
-        max_length: int = 100,
-        residues: Union[Dict[str, float], str] = "canonical",
-        max_charge: int = 5,
-        precursor_mass_tol: float = 50,
-        isotope_error_range: Tuple[int, int] = (0, 1),
-        min_peptide_len: int = 6,
-        n_beams: int = 1,
-        top_match: int = 1,
-        n_log: int = 10,
-        tb_summarywriter: Optional[
-            torch.utils.tensorboard.SummaryWriter
-        ] = None,
-        train_label_smoothing: float = 0.01,
-        warmup_iters: int = 100_000,
-        cosine_schedule_period_iters: int = 600_000,
-        out_writer: Optional[ms_io.MztabWriter] = None,
-        calculate_precision: bool = False,
-        **kwargs: Dict,
+            self,
+            dim_model: int = 512,
+            n_head: int = 8,
+            dim_feedforward: int = 1024,
+            n_layers: int = 9,
+            dropout: float = 0.0,
+            dim_intensity: Optional[int] = None,
+            max_length: int = 100,
+            residues: Union[Dict[str, float], str] = "canonical",
+            max_charge: int = 5,
+            precursor_mass_tol: float = 50,
+            isotope_error_range: Tuple[int, int] = (0, 1),
+            min_peptide_len: int = 6,
+            n_beams: int = 1,
+            top_match: int = 1,
+            n_log: int = 10,
+            tb_summarywriter: Optional[
+                torch.utils.tensorboard.SummaryWriter
+            ] = None,
+            train_label_smoothing: float = 0.01,
+            warmup_iters: int = 100_000,
+            cosine_schedule_period_iters: int = 600_000,
+            out_writer: Optional[ms_io.MztabWriter] = None,
+            calculate_precision: bool = False,
+            random_seed: int = 42,
+            **kwargs: Dict,
     ):
         super().__init__()
         self.save_hyperparameters()
@@ -144,6 +148,16 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             ignore_index=0, label_smoothing=train_label_smoothing
         )
         self.val_celoss = torch.nn.CrossEntropyLoss(ignore_index=0)
+
+        self.rng = np.random.RandomState(random_seed)
+
+
+        np.random.seed(random_seed)
+        torch.manual_seed(random_seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed(random_seed)
+            torch.cuda.manual_seed_all(random_seed)
+
         # Optimizer settings.
         self.warmup_iters = warmup_iters
         self.cosine_schedule_period_iters = cosine_schedule_period_iters
@@ -170,6 +184,32 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         )
         self.stop_token = self.decoder._aa2idx["$"]
 
+        # Optimization 1: Precompute token masses - don't specify device yet
+        self.token_masses = torch.zeros(self.decoder.vocab_size + 1)
+        for aa, mass in self.peptide_mass_calculator.masses.items():
+            if aa in self.decoder._aa2idx:
+                idx = self.decoder._aa2idx[aa]
+                self.token_masses[idx] = mass
+
+        # Precompute negative mass tokens and N-terminal residue tokens - store as lists
+        self.neg_mass_tokens_list = []
+        for aa, mass in self.peptide_mass_calculator.masses.items():
+            if mass < 0 and aa in self.decoder._aa2idx:
+                self.neg_mass_tokens_list.append(self.decoder._aa2idx[aa])
+
+        self.n_term_tokens_list = []
+        for aa in self.peptide_mass_calculator.masses:
+            if aa.startswith(("+", "-")) and aa in self.decoder._aa2idx:
+                self.n_term_tokens_list.append(self.decoder._aa2idx[aa])
+
+        # Isotope mass shift precomputation - don't specify device yet
+        self.isotope_mass_shifts = torch.tensor(
+            [1.00335 / charge for charge in range(1, max_charge + 1)]
+        )
+
+        # Optimization 4: Mass calculation cache
+        self._peptide_mass_cache = {}
+
         # Logging.
         self.calculate_precision = calculate_precision
         self.n_log = n_log
@@ -183,7 +223,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         self.out_writer = out_writer
 
     def forward(
-        self, spectra: torch.Tensor, precursors: torch.Tensor
+            self, spectra: torch.Tensor, precursors: torch.Tensor
     ) -> List[List[Tuple[float, np.ndarray, str]]]:
         """
         Predict peptide sequences for a batch of MS/MS spectra.
@@ -213,10 +253,10 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         )
 
     def beam_search_decode(
-        self, spectra: torch.Tensor, precursors: torch.Tensor
+            self, spectra: torch.Tensor, precursors: torch.Tensor
     ) -> List[List[Tuple[float, np.ndarray, str]]]:
         """
-        Beam search decoding of the spectrum predictions.
+        Beam search decoding of the spectrum predictions. Optimized version.
 
         Parameters
         ----------
@@ -237,6 +277,18 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             peptide predictions consists of a tuple with the peptide score,
             the amino acid scores, and the predicted peptide sequence.
         """
+        # Ensure all tensors are on the correct device
+        device = spectra.device
+
+        # First time called, convert lists to tensors and move to correct device
+        if not hasattr(self, 'neg_mass_tokens'):
+            self.neg_mass_tokens = torch.tensor(self.neg_mass_tokens_list, device=device)
+            self.n_term_tokens = torch.tensor(self.n_term_tokens_list, device=device)
+
+        # Move all precomputed tensors to the correct device
+        self.token_masses = self.token_masses.to(device)
+        self.isotope_mass_shifts = self.isotope_mass_shifts.to(device)
+
         memories, mem_masks = self.encoder(spectra)
 
         # Sizes.
@@ -250,8 +302,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             size=(batch, length, vocab, beam), fill_value=torch.nan
         )
         scores = scores.type_as(spectra)
-        tokens = torch.zeros(batch, length, beam, dtype=torch.int64)
-        tokens = tokens.to(self.encoder.device)
+        tokens = torch.zeros(batch, length, beam, dtype=torch.int64, device=device)
 
         # Create cache for decoded beams.
         pred_cache = collections.OrderedDict((i, []) for i in range(batch))
@@ -260,6 +311,12 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         pred, _ = self.decoder(None, precursors, memories, mem_masks)
         tokens[:, 0, :] = torch.topk(pred[:, 0, :], beam, dim=1)[1]
         scores[:, :1, :, :] = einops.repeat(pred, "B L V -> B L V S", S=beam)
+
+        # Optimization 5: Initialize beam mass accumulation tensor
+        beam_masses = torch.zeros(batch * beam, device=device)
+        # Update masses for first tokens
+        first_tokens = einops.rearrange(tokens[:, 0, :], "B S -> (B S)")
+        beam_masses += self.token_masses[first_tokens]
 
         # Make all tensors the right shape for decoding.
         precursors = einops.repeat(precursors, "B L -> (B S) L", S=beam)
@@ -272,11 +329,9 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         for step in range(0, self.max_length):
             # Terminate beams exceeding the precursor m/z tolerance and track
             # all finished beams (either terminated or stop token predicted).
-            (
-                finished_beams,
-                beam_fits_precursor,
-                discarded_beams,
-            ) = self._finish_beams(tokens, precursors, step)
+            finished_beams, beam_fits_precursor, discarded_beams = self._finish_beams(
+                tokens, precursors, step, beam_masses
+            )
             # Cache peptide predictions from the finished beams (but not the
             # discarded beams).
             self._cache_finished_beams(
@@ -302,8 +357,8 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             )
             # Find the top-k beams with the highest scores and continue decoding
             # those.
-            tokens, scores = self._get_topk_beams(
-                tokens, scores, finished_beams, batch, step + 1
+            tokens, scores, beam_masses = self._get_topk_beams(
+                tokens, scores, finished_beams, batch, step + 1, beam_masses
             )
 
         # Return the peptide with the highest confidence score, within the
@@ -311,26 +366,28 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         return list(self._get_top_peptide(pred_cache))
 
     def _finish_beams(
-        self,
-        tokens: torch.Tensor,
-        precursors: torch.Tensor,
-        step: int,
+            self,
+            tokens: torch.Tensor,
+            precursors: torch.Tensor,
+            step: int,
+            beam_masses: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Track all beams that have been finished, either by predicting the stop
         token or because they were terminated due to exceeding the precursor
-        m/z tolerance.
+        m/z tolerance. Optimized version uses vectorized operations and reduces
+        detokenize operations.
 
         Parameters
         ----------
         tokens : torch.Tensor of shape (n_spectra * n_beams, max_length)
             Predicted amino acid tokens for all beams and all spectra.
-         scores : torch.Tensor of shape
-         (n_spectra *  n_beams, max_length, n_amino_acids)
-            Scores for the predicted amino acid tokens for all beams and all
-            spectra.
+        precursors : torch.Tensor of size (n_spectra * n_beams, 3)
+            The measured precursor mass, charge, and m/z for each beam.
         step : int
             Index of the current decoding step.
+        beam_masses : torch.Tensor
+            Current accumulated masses for each beam.
 
         Returns
         -------
@@ -345,266 +402,254 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             discarded (e.g. because they were predicted to end but violate the
             minimum peptide length).
         """
-        # Check for tokens with a negative mass (i.e. neutral loss).
-        aa_neg_mass = [None]
-        for aa, mass in self.peptide_mass_calculator.masses.items():
-            if mass < 0:
-                aa_neg_mass.append(aa)
-        # Find N-terminal residues.
-        n_term = torch.Tensor(
-            [
-                self.decoder._aa2idx[aa]
-                for aa in self.peptide_mass_calculator.masses
-                if aa.startswith(("+", "-"))
-            ]
-        ).to(self.decoder.device)
+        device = tokens.device
 
-        beam_fits_precursor = torch.zeros(
-            tokens.shape[0], dtype=torch.bool
-        ).to(self.encoder.device)
-        # Beams with a stop token predicted in the current step can be finished.
-        finished_beams = torch.zeros(tokens.shape[0], dtype=torch.bool).to(
-            self.encoder.device
-        )
+        # Initialize result tensors
+        batch_size = tokens.shape[0]
+        finished_beams = torch.zeros(batch_size, dtype=torch.bool, device=device)
+        beam_fits_precursor = torch.zeros(batch_size, dtype=torch.bool, device=device)
+        discarded_beams = torch.zeros(batch_size, dtype=torch.bool, device=device)
+
+        # Vectorized operations: find beams with stop tokens
         ends_stop_token = tokens[:, step] == self.stop_token
         finished_beams[ends_stop_token] = True
-        # Beams with a dummy token predicted in the current step can be
-        # discarded.
-        discarded_beams = torch.zeros(tokens.shape[0], dtype=torch.bool).to(
-            self.encoder.device
-        )
+
+        # Vectorized operations: find beams with padding tokens
         discarded_beams[tokens[:, step] == 0] = True
-        # Discard beams with invalid modification combinations (i.e. N-terminal
-        # modifications occur multiple times or in internal positions).
-        if step > 1:  # Only relevant for longer predictions.
-            dim0 = torch.arange(tokens.shape[0])
-            final_pos = torch.full((ends_stop_token.shape[0],), step)
+
+        # Handle N-terminal modifications special case (vectorized)
+        if step > 1:  # Only relevant for longer predictions
+            dim0 = torch.arange(tokens.shape[0], device=device)
+            final_pos = torch.full((ends_stop_token.shape[0],), step, device=device)
             final_pos[ends_stop_token] = step - 1
-            # Multiple N-terminal modifications.
+
+            # Multiple N-terminal modifications
             multiple_mods = torch.isin(
-                tokens[dim0, final_pos], n_term
-            ) & torch.isin(tokens[dim0, final_pos - 1], n_term)
-            # N-terminal modifications occur at an internal position.
-            # Broadcasting trick to create a two-dimensional mask.
-            mask = (final_pos - 1)[:, None] >= torch.arange(tokens.shape[1])
-            internal_mods = torch.isin(
-                torch.where(mask.to(self.encoder.device), tokens, 0), n_term
-            ).any(dim=1)
+                tokens[dim0, final_pos], self.n_term_tokens
+            ) & torch.isin(tokens[dim0, final_pos - 1], self.n_term_tokens)
+
+            # N-terminal modifications occur at an internal position
+            position_range = torch.arange(tokens.shape[1], device=device)
+            mask = (final_pos - 1).unsqueeze(1) >= position_range
+            masked_tokens = torch.where(mask, tokens, torch.zeros_like(tokens))
+            internal_mods = torch.any(
+                torch.isin(masked_tokens, self.n_term_tokens), dim=1
+            )
+
             discarded_beams[multiple_mods | internal_mods] = True
 
-        # Check which beams should be terminated or discarded based on the
-        # predicted peptide.
-        for i in range(len(finished_beams)):
-            # Skip already discarded beams.
+        # Check sequence length (vectorized)
+        pred_lengths = torch.zeros(batch_size, dtype=torch.int64, device=device)
+        for i in range(batch_size):
             if discarded_beams[i]:
                 continue
-            pred_tokens = tokens[i][: step + 1]
-            peptide_len = len(pred_tokens)
-            peptide = self.decoder.detokenize(pred_tokens)
-            # Omit stop token.
-            if self.decoder.reverse and peptide[0] == "$":
-                peptide = peptide[1:]
-                peptide_len -= 1
-            elif not self.decoder.reverse and peptide[-1] == "$":
-                peptide = peptide[:-1]
-                peptide_len -= 1
-            # Discard beams that were predicted to end but don't fit the minimum
-            # peptide length.
-            if finished_beams[i] and peptide_len < self.min_peptide_len:
-                discarded_beams[i] = True
+
+            sequence_length = step + 1
+            # Calculate length not including stop token
+            if ends_stop_token[i]:
+                sequence_length -= 1
+            pred_lengths[i] = sequence_length
+
+        # Discard beams that are too short (vectorized)
+        too_short = (finished_beams & (pred_lengths < self.min_peptide_len))
+        discarded_beams[too_short] = True
+
+        # Handle mass checks
+        # Get relevant information for each beam
+        precursor_charges = precursors[:, 1]
+        precursor_mzs = precursors[:, 2]
+
+        # Check mass for each beam (try to vectorize where possible)
+        for i in range(batch_size):
+            if discarded_beams[i]:
                 continue
-            # Terminate the beam if it has not been finished by the model but
-            # the peptide mass exceeds the precursor m/z to an extent that it
-            # cannot be corrected anymore by a subsequently predicted AA with
-            # negative mass.
-            precursor_charge = precursors[i, 1]
-            precursor_mz = precursors[i, 2]
-            matches_precursor_mz = exceeds_precursor_mz = False
-            for aa in [None] if finished_beams[i] else aa_neg_mass:
-                if aa is None:
-                    calc_peptide = peptide
-                else:
-                    calc_peptide = peptide.copy()
-                    calc_peptide.append(aa)
-                try:
-                    calc_mz = self.peptide_mass_calculator.mass(
-                        seq=calc_peptide, charge=precursor_charge
-                    )
-                    delta_mass_ppm = [
-                        _calc_mass_error(
-                            calc_mz,
-                            precursor_mz,
-                            precursor_charge,
-                            isotope,
-                        )
-                        for isotope in range(
-                            self.isotope_error_range[0],
-                            self.isotope_error_range[1] + 1,
-                        )
-                    ]
-                    # Terminate the beam if the calculated m/z for the predicted
-                    # peptide (without potential additional AAs with negative
-                    # mass) is within the precursor m/z tolerance.
-                    matches_precursor_mz = aa is None and any(
-                        abs(d) < self.precursor_mass_tol
-                        for d in delta_mass_ppm
-                    )
-                    # Terminate the beam if the calculated m/z exceeds the
-                    # precursor m/z + tolerance and hasn't been corrected by a
-                    # subsequently predicted AA with negative mass.
-                    if matches_precursor_mz:
-                        exceeds_precursor_mz = False
-                    else:
-                        exceeds_precursor_mz = all(
-                            d > self.precursor_mass_tol for d in delta_mass_ppm
-                        )
-                        exceeds_precursor_mz = (
-                            finished_beams[i] or aa is not None
-                        ) and exceeds_precursor_mz
-                    if matches_precursor_mz or exceeds_precursor_mz:
+
+            # Get current beam mass and precursor info
+            curr_mass = beam_masses[i]
+            charge = precursor_charges[i].item()  # Must use item() here
+            obs_mz = precursor_mzs[i].item()  # Must use item() here
+
+            # Check if current mass is within tolerance
+            calc_mz = curr_mass / charge + 1.007276  # Proton mass
+            matches_precursor = False
+            exceeds_precursor = False
+
+            # Early termination check: check isotope error range
+            for isotope in range(self.isotope_error_range[0], self.isotope_error_range[1] + 1):
+                delta_mass_ppm = self._calc_mass_error_tensor(calc_mz, obs_mz, charge, isotope)
+
+                if abs(delta_mass_ppm.item()) < self.precursor_mass_tol:
+                    matches_precursor = True
+                    break
+
+            # If current doesn't match but not finished, try adding negative mass AA to see if could match
+            if not matches_precursor and not finished_beams[i]:
+                for neg_token in self.neg_mass_tokens:
+                    neg_mass = self.token_masses[neg_token]
+                    adjusted_mz = (curr_mass + neg_mass) / charge + 1.007276
+
+                    # Check if adding negative mass AA would match
+                    for isotope in range(self.isotope_error_range[0], self.isotope_error_range[1] + 1):
+                        delta_ppm = self._calc_mass_error_tensor(adjusted_mz, obs_mz, charge, isotope)
+
+                        if abs(delta_ppm.item()) < self.precursor_mass_tol:
+                            # Can match, but don't terminate now
+                            matches_precursor = False
+                            exceeds_precursor = False
+                            break
+
+                    if matches_precursor or not exceeds_precursor:
                         break
-                except KeyError:
-                    matches_precursor_mz = exceeds_precursor_mz = False
-            # Finish beams that fit or exceed the precursor m/z.
-            # Don't finish beams that don't include a stop token if they don't
-            # exceed the precursor m/z tolerance yet.
-            if finished_beams[i]:
-                beam_fits_precursor[i] = matches_precursor_mz
-            elif exceeds_precursor_mz:
+
+                # If all negative mass AA can't bring mass back to tolerance range
+                if not matches_precursor:
+                    exceeds_precursor = True
+            else:
+                # Finished beam, check if exceeds tolerance
+                exceeds_precursor = not matches_precursor
+
+            # Update result tensors
+            beam_fits_precursor[i] = matches_precursor
+            if exceeds_precursor:
                 finished_beams[i] = True
-                beam_fits_precursor[i] = matches_precursor_mz
+
         return finished_beams, beam_fits_precursor, discarded_beams
 
     def _cache_finished_beams(
-        self,
-        tokens: torch.Tensor,
-        scores: torch.Tensor,
-        step: int,
-        beams_to_cache: torch.Tensor,
-        beam_fits_precursor: torch.Tensor,
-        pred_cache: Dict[
-            int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
-        ],
+            self,
+            tokens: torch.Tensor,
+            scores: torch.Tensor,
+            step: int,
+            beams_to_cache: torch.Tensor,
+            beam_fits_precursor: torch.Tensor,
+            pred_cache: Dict[int, List[Tuple[float, float, np.ndarray, torch.Tensor]]],
     ):
         """
-        Cache terminated beams.
+        Cache terminated beams. Optimized version reduces detokenize operations.
 
         Parameters
         ----------
         tokens : torch.Tensor of shape (n_spectra * n_beams, max_length)
             Predicted amino acid tokens for all beams and all spectra.
-         scores : torch.Tensor of shape
-         (n_spectra *  n_beams, max_length, n_amino_acids)
-            Scores for the predicted amino acid tokens for all beams and all
-            spectra.
+        scores : torch.Tensor of shape (n_spectra * n_beams, max_length, n_amino_acids)
+            Scores for the predicted amino acid tokens for all beams and all spectra.
         step : int
             Index of the current decoding step.
         beams_to_cache : torch.Tensor of shape (n_spectra * n_beams)
-            Boolean tensor indicating whether the current beams are ready for
-            caching.
+            Boolean tensor indicating whether the current beams are ready for caching.
         beam_fits_precursor: torch.Tensor of shape (n_spectra * n_beams)
             Boolean tensor indicating whether the beams are within the
             precursor m/z tolerance.
-        pred_cache : Dict[
-                int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
-        ]
+        pred_cache : Dict[int, List[Tuple[float, float, np.ndarray, torch.Tensor]]]
             Priority queue with finished beams for each spectrum, ordered by
             peptide score. For each finished beam, a tuple with the (negated)
             peptide score, a random tie-breaking float, the amino acid-level
             scores, and the predicted tokens is stored.
         """
-        for i in range(len(beams_to_cache)):
-            if not beams_to_cache[i]:
-                continue
-            # Find the starting index of the spectrum.
-            spec_idx = i // self.n_beams
-            # FIXME: The next 3 lines are very similar as what's done in
-            #  _finish_beams. Avoid code duplication?
-            pred_tokens = tokens[i][: step + 1]
-            # Omit the stop token from the peptide sequence (if predicted).
+        # Only process if there are beams to cache
+        if not torch.any(beams_to_cache):
+            return
+
+        # Extract indices of beams to cache
+        cache_indices = torch.nonzero(beams_to_cache).squeeze(-1)
+
+        for idx in cache_indices:
+            # Find spectrum starting index
+            spec_idx = idx.item() // self.n_beams
+
+            # Extract predicted tokens
+            pred_tokens = tokens[idx][: step + 1]
+            # Check for stop token
             has_stop_token = pred_tokens[-1] == self.stop_token
             pred_peptide = pred_tokens[:-1] if has_stop_token else pred_tokens
-            # Don't cache this peptide if it was already predicted previously.
-            if any(
-                torch.equal(pred_cached[-1], pred_peptide)
-                for pred_cached in pred_cache[spec_idx]
-            ):
-                # TODO: Add duplicate predictions with their highest score.
+
+            # Check if already predicted the same peptide
+            duplicate = False
+            for pred_cached in pred_cache[spec_idx]:
+                if torch.equal(pred_cached[-1], pred_peptide):
+                    duplicate = True
+                    break
+
+            if duplicate:
                 continue
-            smx = self.softmax(scores[i : i + 1, : step + 1, :])
-            aa_scores = smx[0, range(len(pred_tokens)), pred_tokens].tolist()
-            # Add an explicit score 0 for the missing stop token in case this
-            # was not predicted (i.e. early stopping).
+
+            # Get amino acid level scores
+            smx = self.softmax(scores[idx: idx + 1, : step + 1, :])
+            aa_scores = smx[0, range(len(pred_tokens)), pred_tokens].cpu().detach().numpy()
+
+            # Add missing stop token explicit 0 score
             if not has_stop_token:
-                aa_scores.append(0)
-            aa_scores = np.asarray(aa_scores)
-            # Calculate the updated amino acid-level and the peptide scores.
-            aa_scores, peptide_score = _aa_pep_score(
-                aa_scores, beam_fits_precursor[i]
+                aa_scores = np.append(aa_scores, 0)
+
+            # Calculate updated amino acid level and peptide scores
+            aa_scores, peptide_score = self._aa_pep_score(
+                aa_scores, beam_fits_precursor[idx].item()
             )
-            # Omit the stop token from the amino acid-level scores.
+
+            # Omit stop token from amino acid level scores
             aa_scores = aa_scores[:-1]
-            # Add the prediction to the cache (minimum priority queue, maximum
-            # the number of beams elements).
+
+            # Add prediction to cache (minimum priority queue, max beams elements)
             if len(pred_cache[spec_idx]) < self.n_beams:
                 heapadd = heapq.heappush
             else:
                 heapadd = heapq.heappushpop
+
             heapadd(
                 pred_cache[spec_idx],
                 (
                     peptide_score,
-                    np.random.random_sample(),
+                    self.rng.random_sample(),
                     aa_scores,
                     torch.clone(pred_peptide),
                 ),
             )
 
     def _get_topk_beams(
-        self,
-        tokens: torch.tensor,
-        scores: torch.tensor,
-        finished_beams: torch.tensor,
-        batch: int,
-        step: int,
-    ) -> Tuple[torch.tensor, torch.tensor]:
+            self,
+            tokens: torch.tensor,
+            scores: torch.tensor,
+            finished_beams: torch.tensor,
+            batch: int,
+            step: int,
+            beam_masses: torch.tensor,
+    ) -> Tuple[torch.tensor, torch.tensor, torch.tensor]:
         """
         Find the top-k beams with the highest scores and continue decoding
-        those.
-
-        Stop decoding for beams that have been finished.
+        those. Optimized version uses vectorized operations and updates beam_masses.
 
         Parameters
         ----------
         tokens : torch.Tensor of shape (n_spectra * n_beams, max_length)
             Predicted amino acid tokens for all beams and all spectra.
-         scores : torch.Tensor of shape
-         (n_spectra *  n_beams, max_length, n_amino_acids)
-            Scores for the predicted amino acid tokens for all beams and all
-            spectra.
+        scores : torch.Tensor of shape (n_spectra * n_beams, max_length, n_amino_acids)
+            Scores for the predicted amino acid tokens for all beams and all spectra.
         finished_beams : torch.Tensor of shape (n_spectra * n_beams)
-            Boolean tensor indicating whether the current beams are ready for
-            caching.
+            Boolean tensor indicating whether the current beams are ready for caching.
         batch: int
             Number of spectra in the batch.
         step : int
             Index of the next decoding step.
+        beam_masses : torch.Tensor of shape (n_spectra * n_beams)
+            Current accumulated masses for each beam.
 
         Returns
         -------
         tokens : torch.Tensor of shape (n_spectra * n_beams, max_length)
-            Predicted amino acid tokens for all beams and all spectra.
-         scores : torch.Tensor of shape
-         (n_spectra *  n_beams, max_length, n_amino_acids)
-            Scores for the predicted amino acid tokens for all beams and all
-            spectra.
+            Updated predicted amino acid tokens for all beams and all spectra.
+        scores : torch.Tensor of shape (n_spectra * n_beams, max_length, n_amino_acids)
+            Updated scores for the predicted amino acid tokens for all beams and all spectra.
+        beam_masses : torch.Tensor of shape (n_spectra * n_beams)
+            Updated accumulated masses for each beam.
         """
+        device = tokens.device
         beam = self.n_beams  # S
         vocab = self.decoder.vocab_size + 1  # V
 
         # Reshape to group by spectrum (B for "batch").
         tokens = einops.rearrange(tokens, "(B S) L -> B L S", S=beam)
         scores = einops.rearrange(scores, "(B S) L V -> B L V S", S=beam)
+        beam_masses = einops.rearrange(beam_masses, "(B S) -> B S", S=beam)
 
         # Get the previous tokens and scores.
         prev_tokens = einops.repeat(
@@ -618,7 +663,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         )
 
         # Get the scores for all possible beams at this step.
-        step_scores = torch.zeros(batch, step + 1, beam * vocab).type_as(
+        step_scores = torch.zeros(batch, step + 1, beam * vocab, device=device).type_as(
             scores
         )
         step_scores[:, :step, :] = prev_scores
@@ -631,42 +676,56 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
             ~finished_beams.reshape(batch, beam).repeat(1, vocab)
         ).float()
         # Mask out the index '0', i.e. padding token, by default.
-        # FIXME: Set this to a very small, yet non-zero value, to only
-        # get padding after stop token.
         active_mask[:, :beam] = 1e-8
 
         # Figure out the top K decodings.
         _, top_idx = torch.topk(step_scores.nanmean(dim=1) * active_mask, beam)
-        v_idx, s_idx = np.unravel_index(top_idx.cpu(), (vocab, beam))
-        s_idx = einops.rearrange(s_idx, "B S -> (B S)")
-        b_idx = einops.repeat(torch.arange(batch), "B -> (B S)", S=beam)
 
-        # Record the top K decodings.
-        tokens[:, :step, :] = einops.rearrange(
-            prev_tokens[b_idx, :, 0, s_idx], "(B S) L -> B L S", S=beam
-        )
-        tokens[:, step, :] = torch.tensor(v_idx)
-        scores[:, : step + 1, :, :] = einops.rearrange(
-            scores[b_idx, : step + 1, :, s_idx], "(B S) L V -> B L V S", S=beam
-        )
-        scores = einops.rearrange(scores, "B L V S -> (B S) L V")
-        tokens = einops.rearrange(tokens, "B L S -> (B S) L")
-        return tokens, scores
+        # Extract top K decoding indices
+        top_idx_cpu = top_idx.cpu().numpy()
+        v_idx = top_idx_cpu // beam
+        s_idx = top_idx_cpu % beam
+
+        # Create new tokens and scores
+        tokens_new = torch.zeros_like(tokens)
+        scores_new = torch.zeros_like(scores)
+        beam_masses_new = torch.zeros_like(beam_masses)
+
+        for b in range(batch):
+            for s in range(beam):
+                old_s = s_idx[b, s]
+                new_token = torch.tensor(v_idx[b, s], device=device)
+
+                # Copy previous step tokens
+                tokens_new[b, :step, s] = tokens[b, :step, old_s]
+                # Add new token
+                tokens_new[b, step, s] = new_token
+
+                # Copy scores
+                for l in range(step + 1):
+                    scores_new[b, l, :, s] = scores[b, l, :, old_s]
+
+                # Update masses
+                beam_masses_new[b, s] = beam_masses[b, old_s] + self.token_masses[new_token]
+
+        # Reshape back to flattened shape
+        tokens = einops.rearrange(tokens_new, "B L S -> (B S) L")
+        scores = einops.rearrange(scores_new, "B L V S -> (B S) L V")
+        beam_masses = einops.rearrange(beam_masses_new, "B S -> (B S)")
+
+        return tokens, scores, beam_masses
 
     def _get_top_peptide(
-        self,
-        pred_cache: Dict[
-            int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
-        ],
+            self,
+            pred_cache: Dict[int, List[Tuple[float, float, np.ndarray, torch.Tensor]]],
     ) -> Iterable[List[Tuple[float, np.ndarray, str]]]:
         """
         Return the peptide with the highest confidence score for each spectrum.
+        Optimized version only performs detokenize in the final output.
 
         Parameters
         ----------
-        pred_cache : Dict[
-                int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
-        ]
+        pred_cache : Dict[int, List[Tuple[float, float, np.ndarray, torch.Tensor]]]
             Priority queue with finished beams for each spectrum, ordered by
             peptide score. For each finished beam, a tuple with the peptide
             score, a random tie-breaking float, the amino acid-level scores,
@@ -685,7 +744,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                     (
                         pep_score,
                         aa_scores[::-1] if self.decoder.reverse else aa_scores,
-                        "".join(self.decoder.detokenize(pred_tokens)),
+                        "".join(self.decoder.detokenize(pred_tokens)),  # Only detokenize here
                     )
                     for pep_score, _, aa_scores, pred_tokens in heapq.nlargest(
                         self.top_match, peptides
@@ -693,6 +752,61 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                 ]
             else:
                 yield []
+
+    def _aa_pep_score(
+            self,
+            aa_scores: np.ndarray,
+            fits_precursor_mz: bool
+    ) -> Tuple[np.ndarray, float]:
+        """
+        Calculate amino acid and peptide-level confidence score from the raw amino
+        acid scores.
+
+        The peptide score is the mean of the raw amino acid scores. The amino acid
+        scores are the mean of the raw amino acid scores and the peptide score.
+
+        Parameters
+        ----------
+        aa_scores : np.ndarray
+            Amino acid level confidence scores.
+        fits_precursor_mz : bool
+            Flag indicating whether the prediction fits the precursor m/z filter.
+
+        Returns
+        -------
+        aa_scores : np.ndarray
+            The amino acid scores.
+        peptide_score : float
+            The peptide score.
+        """
+        peptide_score = np.mean(aa_scores)
+        aa_scores = (aa_scores + peptide_score) / 2
+        if not fits_precursor_mz:
+            peptide_score -= 1
+        return aa_scores, peptide_score
+
+    def _calc_mass_error_tensor(self, calc_mz, obs_mz, charge, isotope=0):
+        """
+        GPU tensor version of mass error calculation.
+
+        Parameters
+        ----------
+        calc_mz : float or tensor
+            The theoretical m/z.
+        obs_mz : float or tensor
+            The observed m/z.
+        charge : int
+            The charge.
+        isotope : int
+            Correct for the given number of C13 isotopes (default: 0).
+
+        Returns
+        -------
+        float or tensor
+            The mass error in ppm.
+        """
+        isotope_shift = isotope * 1.00335 / charge
+        return (calc_mz - (obs_mz - isotope_shift)) / obs_mz * 10 ** 6
 
     def _forward_step(
         self,
@@ -968,6 +1082,32 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                             descr, metric_value, metrics["step"]
                         )
 
+    def _calculate_peptide_mass(self, tokens, charge):
+        """
+        Cached method for calculating peptide mass.
+
+        Parameters
+        ----------
+        tokens : torch.Tensor
+            Tensor of peptide token indices.
+        charge : int
+            The charge of the peptide.
+
+        Returns
+        -------
+        float
+            The calculated peptide mass.
+        """
+        cache_key = tuple(tokens.cpu().numpy().tolist()) + (charge,)
+        if cache_key not in self._peptide_mass_cache:
+            # Calculate mass directly from tokens
+            mass = 0.0
+            for token in tokens:
+                mass += self.token_masses[token].item()
+            self._peptide_mass_cache[cache_key] = mass
+
+        return self._peptide_mass_cache[cache_key]
+
     def configure_optimizers(
         self,
     ) -> Tuple[torch.optim.Optimizer, Dict[str, Any]]:
@@ -1026,6 +1166,34 @@ class CosineWarmupScheduler(torch.optim.lr_scheduler._LRScheduler):
         return lr_factor
 
 
+import numba
+
+
+@numba.jit(nopython=True)
+def _calc_mass_error_numba(calc_mz, obs_mz, charge, isotope=0):
+    """
+    Calculate the mass error in ppm between the theoretical m/z and the observed
+    m/z, optionally accounting for an isotopologue mismatch. Numba JIT compiled version.
+
+    Parameters
+    ----------
+    calc_mz : float
+        The theoretical m/z.
+    obs_mz : float
+        The observed m/z.
+    charge : int
+        The charge.
+    isotope : int
+        Correct for the given number of C13 isotopes (default: 0).
+
+    Returns
+    -------
+    float
+        The mass error in ppm.
+    """
+    return (calc_mz - (obs_mz - isotope * 1.00335 / charge)) / obs_mz * 10 ** 6
+
+
 def _calc_mass_error(
     calc_mz: float, obs_mz: float, charge: int, isotope: int = 0
 ) -> float:
@@ -1052,32 +1220,49 @@ def _calc_mass_error(
     return (calc_mz - (obs_mz - isotope * 1.00335 / charge)) / obs_mz * 10**6
 
 
-def _aa_pep_score(
-    aa_scores: np.ndarray, fits_precursor_mz: bool
-) -> Tuple[np.ndarray, float]:
-    """
-    Calculate amino acid and peptide-level confidence score from the raw amino
-    acid scores.
+if __name__ == "__main__":
+    import time
+    import torch
 
-    The peptide score is the mean of the raw amino acid scores. The amino acid
-    scores are the mean of the raw amino acid scores and the peptide score.
+    # Prefer GPU if available
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print("Using device:", device)
 
-    Parameters
-    ----------
-    aa_scores : np.ndarray
-        Amino acid level confidence scores.
-    fits_precursor_mz : bool
-        Flag indicating whether the prediction fits the precursor m/z filter.
+    # Initialize model with beam size of 1
+    model = Spec2Pep(n_beams=1)
+    model.to(device)
 
-    Returns
-    -------
-    aa_scores : np.ndarray
-        The amino acid scores.
-    peptide_score : float
-        The peptide score.
-    """
-    peptide_score = np.mean(aa_scores)
-    aa_scores = (aa_scores + peptide_score) / 2
-    if not fits_precursor_mz:
-        peptide_score -= 1
-    return aa_scores, peptide_score
+    # Create random input data:
+    # 10 spectra, each with 100 peaks containing [m/z, intensity]
+    n_spectra = 10
+    n_peaks = 100
+    spectra = torch.rand(n_spectra, n_peaks, 2, device=device)
+
+    # Create precursor data: [precursor_mass, precursor_charge, precursor_mz]
+    precursors = torch.zeros(n_spectra, 3, device=device)
+    precursors[:, 0] = torch.rand(n_spectra, device=device) * 1000  # precursor mass
+    precursors[:, 1] = torch.randint(1, model.hparams.max_charge + 1, (n_spectra,), device=device)  # charge
+    precursors[:, 2] = torch.rand(n_spectra, device=device) * 1000  # precursor m/z
+
+    # Warm-up run to avoid initialization overhead in timing
+    with torch.no_grad():
+        _ = model.forward(spectra, precursors)
+
+    # Perform multiple runs for stable timing results
+    n_runs = 10
+    times = []
+    with torch.no_grad():
+        for _ in range(n_runs):
+            if device.type == "cuda":
+                torch.cuda.synchronize()  # Ensure GPU operations are complete
+            start = time.perf_counter()
+            _ = model.forward(spectra, precursors)
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            end = time.perf_counter()
+            times.append(end - start)
+
+    # Calculate average processing time in milliseconds per spectrum
+    avg_time = sum(times) / n_runs
+    avg_time_per_spectrum = avg_time / n_spectra
+    print(f"Average processing time per spectrum: {avg_time_per_spectrum * 1000:.2f} ms")


### PR DESCRIPTION
Reduce the calls to .item() to avoid excessive synchronization between the GPU and CPU. Instead of calling .item() in loops, process tensors in batches. For boolean checks, these should be checked directly on the GPU; if that is not possible, transfer an entire batch to the CPU once with .cpu() and then iterate over it.

Initialize necessary data structures for invalid beam checks in __init__ to prevent redundant setup during runtime.

Optimize detokenization by deferring it until final output in _finish_beams or _cache_finished_beams. Reduce redundant mass calculations by maintaining a beam_masses tensor, updating it incrementally with each token selection rather than recomputing the full sequence mass each time. Perform precursor mass checks using vectorized GPU operations instead of Python loops.

Speed up mass error calculations by leveraging Numba JIT on the CPU if data is already on the CPU. If feasible, implement the logic directly on the GPU or process data in batches on the CPU to minimize GPU-CPU synchronization overhead.