### PR TITLE
Add a warning when non-supported PTMs are used.

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -143,6 +143,13 @@ class Config:
         try:
             param_val = self._user_config.get(param, self._params[param])
             if param == "residues":
+                for aa, mass in param_val.items():
+                    aa_str = str(aa)
+                    if len(aa_str) == 1 and aa_str == "C":
+                        warnings.warn("C carbamidomethylation must be a fixed modification.")
+                    elif len(aa_str) > 1 and aa_str[1] == "+":
+                        if aa_str not in ["M+15.995", "N+0.984", "Q+0.984", "C+57.021"]: 
+                            warnings.warn(f'{aa_str} is not a supported PTM.')
                 residues = {
                     str(aa): float(mass) for aa, mass in param_val.items()
                 }

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -143,13 +143,6 @@ class Config:
         try:
             param_val = self._user_config.get(param, self._params[param])
             if param == "residues":
-                for aa, mass in param_val.items():
-                    aa_str = str(aa)
-                    if len(aa_str) == 1 and aa_str == "C":
-                        warnings.warn("C carbamidomethylation must be a fixed modification.")
-                    elif len(aa_str) > 1 and aa_str[1] == "+":
-                        if aa_str not in ["M+15.995", "N+0.984", "Q+0.984", "C+57.021"]: 
-                            warnings.warn(f'{aa_str} is not a supported PTM.')
                 residues = {
                     str(aa): float(mass) for aa, mass in param_val.items()
                 }

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -170,6 +170,11 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         )
         self.stop_token = self.decoder._aa2idx["$"]
 
+        # Check if config PTM and AAs are present in model alphabet
+        for aa in config.Config().residues:
+            if aa not in residues:
+                warnings.warn(f"Warning: {aa} is not in model alphabet.")
+
         # Logging.
         self.calculate_precision = calculate_precision
         self.n_log = n_log


### PR DESCRIPTION
This adds warnings for the user if a PTM is not one of the supported PTMS and is added to the config.yaml file. I believe this is mentioned as one of the points in #402.