### PR TITLE
Warning if config file contains an AA that is not in model alphabel

### DIFF
--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -175,6 +175,11 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         )
         self.stop_token = self.decoder._aa2idx["$"]
 
+        # Check if config PTM and AAs are present in model alphabet
+        for aa in config.Config().residues:
+            if aa not in residues:
+                warnings.warn(f"Warning: {aa} is not in model alphabet.")
+
         # Logging.
         self.calculate_precision = calculate_precision
         self.n_log = n_log


### PR DESCRIPTION
I have edited the dev branch with a warning if a PTM or AA is not supported according to the model alphabet. This currently passes all tests on my local instance with pytest. I tested this with sample data and it gives appropriate warnings.

I believe this is mentioned as one of the points in #402.