### PR TITLE
docs: update downstream tools to include dedicated Limelight section

### DIFF
--- a/docs/downstream_tools.md
+++ b/docs/downstream_tools.md
@@ -6,7 +6,7 @@ Once Casanovo has inferred peptide sequences, several tools are available to ana
 
 [Limelight](https://limelight-ms.org/) is a web application for visualizing and sharing DDA proteomics data and results. It provides tools for viewing the whole data stack, including raw spectra; extracted ion chromatograms (XICs); peptide, protein, and modification views; quality control (QC) views; and more. For more information, see the [Limelight publication in JPR](https://pubmed.ncbi.nlm.nih.gov/40036265/).
 
-To upload results to Limelight, results must be converted to Limelight XML. A converter for generating Limelight XML from Casanovo results is available, see the [converter documentation](https://github.com/yeastrc/limelight-import-casanovo). The Limelight XML may be easily uploaded to Limelight using its web interface, see [the Limelight documentation](https://limelight-ms.readthedocs.io/en/latest/using-limelight/data-upload-guide.html) for more information about uploading data.
+To upload results to Limelight, Casanovo mzTab results files must first be converted to Limelight XML. A converter for generating Limelight XML from Casanovo results is available, see the [converter documentation](https://github.com/yeastrc/limelight-import-casanovo). The Limelight XML may be easily uploaded to Limelight using its web interface. See [the Limelight documentation](https://limelight-ms.readthedocs.io/en/latest/using-limelight/data-upload-guide.html) for more information about uploading data.
 
 ## Nextflow Workflow
 

--- a/docs/downstream_tools.md
+++ b/docs/downstream_tools.md
@@ -4,9 +4,14 @@ Once Casanovo has inferred peptide sequences, several tools are available to ana
 
 ## Limelight Integration
 
-[Limelight](https://limelight-ms.org/) is a web application for visualizing and sharing DDA proteomics data and results. It provides tools for viewing the whole data stack, including raw spectra; extracted ion chromatograms (XICs); peptide, protein, and modification views; quality control (QC) views; and more. For more information, see the [Limelight publication in JPR](https://pubmed.ncbi.nlm.nih.gov/40036265/).
+[Limelight](https://limelight-ms.org/) is a web application for visualizing and sharing DDA proteomics data and results.
+It provides tools for viewing the whole data stack, including raw spectra; extracted ion chromatograms (XICs); peptide, protein, and modification views; quality control (QC) views; and more.
+For more information, see the [Limelight publication in JPR](https://pubmed.ncbi.nlm.nih.gov/40036265/).
 
-To upload results to Limelight, Casanovo mzTab results files must first be converted to Limelight XML. A converter for generating Limelight XML from Casanovo results is available, see the [converter documentation](https://github.com/yeastrc/limelight-import-casanovo). The Limelight XML may be easily uploaded to Limelight using its web interface. See [the Limelight documentation](https://limelight-ms.readthedocs.io/en/latest/using-limelight/data-upload-guide.html) for more information about uploading data.
+To upload results to Limelight, Casanovo mzTab results files must first be converted to Limelight XML.
+A converter for generating Limelight XML from Casanovo results is available, see the [converter documentation](https://github.com/yeastrc/limelight-import-casanovo).
+The Limelight XML may be easily uploaded to Limelight using its web interface.
+See [the Limelight documentation](https://limelight-ms.readthedocs.io/en/latest/using-limelight/data-upload-guide.html) for more information about uploading data.
 
 ## Nextflow Workflow
 

--- a/docs/downstream_tools.md
+++ b/docs/downstream_tools.md
@@ -2,10 +2,17 @@
 
 Once Casanovo has inferred peptide sequences, several tools are available to analyze and visualize the results.
 
-## Nextflow Workflow and Limelight Integration
+## Limelight Integration
+
+[Limelight](https://limelight-ms.org/) is a web application for visualizing and sharing DDA proteomics data and results. It provides tools for viewing the whole data stack, including raw spectra; extracted ion chromatograms (XICs); peptide, protein, and modification views; quality control (QC) views; and more. For more information, see the [Limelight publication in JPR](https://pubmed.ncbi.nlm.nih.gov/40036265/).
+
+To upload results to Limelight, results must be converted to Limelight XML. A converter for generating Limelight XML from Casanovo results is available, see the [converter documentation](https://github.com/yeastrc/limelight-import-casanovo). The Limelight XML may be easily uploaded to Limelight using its web interface, see [the Limelight documentation](https://limelight-ms.readthedocs.io/en/latest/using-limelight/data-upload-guide.html) for more information about uploading data.
+
+## Nextflow Workflow
 
 To simplify the process of setting up and running Casanovo, a dedicated [Nextflow](https://www.nextflow.io/) workflow is available.
-In addition to simplifying the installation of Casanovo and its dependencies, the Casanovo Nextflow workflow provides an automated mass spectrometry data pipeline that converts input data files to a Casanovo-compatible format using [msconvert](https://proteowizard.sourceforge.io/tools/msconvert.html), infers peptide sequences using Casanovo, and (optionally) uploads the results to [Limelight](https://limelight-ms.org/)—a platform for sharing and visualizing proteomics results.
+In addition to simplifying the installation of Casanovo and its dependencies, the Casanovo Nextflow workflow provides an automated mass spectrometry data pipeline that converts input data files to a Casanovo-compatible format using [msconvert](https://proteowizard.sourceforge.io/tools/msconvert.html), infers peptide sequences using Casanovo, and (optionally) uploads the results to [Limelight](https://limelight-ms.org/).
+
 The workflow can be used on POSIX-compatible (UNIX) systems, Windows using WSL, or on a cloud platform such as AWS.
 For more details, refer to the [Casanovo Nextflow Workflow Documentation](https://nf-ms-dda-casanovo.readthedocs.io/).
 


### PR DESCRIPTION
Updated downstream tools to included dedicated Limelight section--removed some text from the Nextflow workflow section that was redundant with this new section.