### PR TITLE
Add Option to Disable Precursor Check

### DIFF
--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -14,6 +14,7 @@
 # peptide score.
 # database search: Select candidate peptides within the specified precursor m/z
 # tolerance.
+# Set to "inf" (with quotation marks) to disable the filter entirely.
 precursor_mass_tol: 50  # ppm
 # Isotopes to consider when comparing predicted and observed precursor m/z's.
 isotope_error_range: [0, 1]


### PR DESCRIPTION
Marking as draft since Github tests are failing pending #480.