### PR TITLE
Update black version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.6.0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 25.9.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+


### PR DESCRIPTION
The pre-commit config currently uses a pretty old version of black, which can lead to the linter in github actions and in the pre-commit hook "disagreeing" on what the right format is. Updating the pre-commit config would (hopefully) resolve this.