### PR TITLE
Specify weights only keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [5.1.2] - 2025-12-11
+
+### Changed
+
+- Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files.
+
 ## [5.1.1] - 2025-11-27
 
 ### Changed
@@ -317,7 +323,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial Casanovo version.
 
-[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...HEAD
+[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.1.2...HEAD
+[5.1.1]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...v5.1.2
 [5.1.1]: https://github.com/Noble-Lab/casanovo/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/Noble-Lab/casanovo/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/Noble-Lab/casanovo/compare/v4.3.0...v5.0.0

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -538,6 +538,7 @@ class ModelRunner:
                 self.model = model_clss.load_from_checkpoint(
                     self.model_filename,
                     map_location=device,
+                    weights_only=False,
                     **model_params,
                 )
                 self.model.tokenizer = tokenizer

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -512,7 +512,10 @@ class ModelRunner:
         model_clss = DbSpec2Pep if db_search else Spec2Pep
         try:
             self.model = model_clss.load_from_checkpoint(
-                self.model_filename, map_location=device, **loaded_model_params
+                self.model_filename,
+                map_location=device,
+                weights_only=False,
+                **loaded_model_params,
             )
             # Use tokenizer initialized from config file instead of loaded
             # from checkpoint file.


### PR DESCRIPTION
In Pytorch 2.6 they changed the default value of the `weights_only` for `Torch.load` from `False` to `True`, which breaks our model loading implementation. I'm basing this against `main` from now under the assumption that this will be a hotfix, but I can rebase it to `dev` if we want to push this to a later release.