### PR TITLE
Catch `TypeError` when creating evaluate mode dataloaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Increased minimum Python version from 3.8 to 3.10.
 - DepthCharge is upgraded to the latest version 0.4.9.
+- A more descriptive error message will now be logged for some annotated spectrum file parsing failure cases.
 
 ### Fixed
 

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -294,12 +294,13 @@ class ModelRunner:
 
         try:
             self.loaders.setup(stage="test", annotated=evaluate)
-        except (KeyError, OSError) as e:
+        except (KeyError, OSError, TypeError) as e:
             if evaluate:
                 error_message = (
                     "Error creating annotated spectrum dataloaders. This may "
                     "be the result of having an unannotated peak file present "
-                    "in the validation peak file path list."
+                    "in the validation peak file path list. Check that the "
+                    "spectrum files are annotated correctly."
                 )
 
                 logger.error(error_message)

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -299,7 +299,7 @@ class ModelRunner:
                 error_message = (
                     "Error creating annotated spectrum dataloaders. This may "
                     "be the result of having an unannotated peak file present "
-                    "in the validation peak file path list. Check that the input"
+                    "in the validation peak file path list. Check that the input "
                     "spectrum files are annotated, and if they are that the "
                     "format is correct."
                 )

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -299,8 +299,9 @@ class ModelRunner:
                 error_message = (
                     "Error creating annotated spectrum dataloaders. This may "
                     "be the result of having an unannotated peak file present "
-                    "in the validation peak file path list. Check that the "
-                    "spectrum files are annotated correctly."
+                    "in the validation peak file path list. Check that the input"
+                    "spectrum files are annotated, and if they are that the "
+                    "format is correct."
                 )
 
                 logger.error(error_message)

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -256,92 +256,120 @@ def test_save_final_model(tmp_path, mgf_small, tiny_config):
     assert validation_file.exists()
 
 
-def test_evaluate(
-    tmp_path, mgf_small, mzml_small, mgf_small_unannotated, tiny_config
-):
-    """Test model evaluation during sequencing"""
-    # Train tiny model
+def test_evaluate_success(tmp_path, mgf_small, tiny_config):
+    """Test successful model evaluation with annotated peak files."""
     config = Config(tiny_config)
     config.max_epochs = 1
+
     model_file = tmp_path / "epoch=0-step=1.ckpt"
+    result_file = tmp_path / "result.mztab"
+
     with ModelRunner(config, output_dir=tmp_path) as runner:
         runner.train([mgf_small], [mgf_small])
 
     assert model_file.is_file()
 
-    # Test evaluation with annotated peak file
-    result_file = tmp_path / "result.mztab"
     with ModelRunner(
         config, model_filename=str(model_file), overwrite_ckpt_check=False
     ) as runner:
         runner.predict([mgf_small], result_file, evaluate=True)
 
     assert result_file.is_file()
-    result_file.unlink()
 
+
+@pytest.mark.parametrize(
+    "input_files, expect_match",
+    [
+        pytest.param(
+            ["mzml_small"],
+            False,
+            id="mzml_only",
+        ),
+        pytest.param(
+            ["mgf_small_unannotated"],
+            True,
+            id="unannotated_mgf_only",
+        ),
+        pytest.param(
+            ["mgf_small_unannotated", "mzml_small"],
+            True,
+            id="unannotated_mgf_and_mzml",
+        ),
+        pytest.param(
+            ["mgf_small", "mzml_small"],
+            False,
+            id="annotated_mgf_and_mzml",
+        ),
+        pytest.param(
+            ["mgf_small", "mgf_small_unannotated"],
+            True,
+            id="annotated_and_unannotated_mgf",
+        ),
+        pytest.param(
+            ["mgf_small", "mgf_small_unannotated", "mzml_small"],
+            True,
+            id="annotated_unannotated_and_mzml",
+        ),
+        pytest.param(
+            ["improperly_annotated_file"],
+            True,
+            id="improperly_annotated_mgf_missing_seq",
+        ),
+    ],
+)
+def test_evaluate_failure_cases(
+    tmp_path,
+    mgf_small,
+    mzml_small,
+    mgf_small_unannotated,
+    tiny_config,
+    input_files,
+    expect_match,
+):
+    """Test all evaluation failure modes."""
     exception_string = (
         "Error creating annotated spectrum dataloaders. This may "
         "be the result of having an unannotated peak file present "
         "in the validation peak file path list."
     )
 
-    with pytest.raises(TypeError):
+    config = Config(tiny_config)
+    config.max_epochs = 1
+
+    model_file = tmp_path / "epoch=0-step=1.ckpt"
+    result_file = tmp_path / "result.mztab"
+
+    with ModelRunner(config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+
+    assert model_file.is_file()
+
+    mgf_path = Path(mgf_small)
+    improperly_annotated_file = mgf_path.parent / "improperly_annotated.mgf"
+    improperly_annotated_file.write_text(
+        mgf_path.read_text().replace("SEQ=", "PEPTIDE=")
+    )
+
+    file_map = {
+        "mgf_small": mgf_small,
+        "mzml_small": mzml_small,
+        "mgf_small_unannotated": mgf_small_unannotated,
+        "improperly_annotated_file": improperly_annotated_file,
+    }
+
+    files = [file_map[name] for name in input_files]
+
+    with pytest.raises(
+        TypeError,
+        match=exception_string if expect_match else None,
+    ):
         with ModelRunner(
             config, model_filename=str(model_file), overwrite_ckpt_check=False
         ) as runner:
-            runner.predict([mzml_small], result_file, evaluate=True)
+            runner.predict(files, result_file, evaluate=True)
 
-    with pytest.raises(TypeError, match=exception_string):
-        with ModelRunner(
-            config, model_filename=str(model_file), overwrite_ckpt_check=False
-        ) as runner:
-            runner.predict([mgf_small_unannotated], result_file, evaluate=True)
-
-    with pytest.raises(TypeError, match=exception_string):
-        with ModelRunner(
-            config, model_filename=str(model_file), overwrite_ckpt_check=False
-        ) as runner:
-            runner.predict(
-                [mgf_small_unannotated, mzml_small], result_file, evaluate=True
-            )
-
-    # MzTab with just metadata is written in the case of FileNotFound
-    # or TypeError early exit
+    # Metadata-only MzTab should still be written
     assert result_file.is_file()
-    result_file.unlink()
-
-    # Test mix of annotated an unannotated peak files
-    with pytest.raises(TypeError):
-        with ModelRunner(
-            config, model_filename=str(model_file), overwrite_ckpt_check=False
-        ) as runner:
-            runner.predict([mgf_small, mzml_small], result_file, evaluate=True)
-
-    assert result_file.is_file()
-    result_file.unlink()
-
-    with pytest.raises(TypeError, match=exception_string):
-        with ModelRunner(
-            config, model_filename=str(model_file), overwrite_ckpt_check=False
-        ) as runner:
-            runner.predict(
-                [mgf_small, mgf_small_unannotated], result_file, evaluate=True
-            )
-
-    assert result_file.is_file()
-    result_file.unlink()
-
-    with pytest.raises(TypeError, match=exception_string):
-        with ModelRunner(
-            config, model_filename=str(model_file), overwrite_ckpt_check=False
-        ) as runner:
-            runner.predict(
-                [mgf_small, mgf_small_unannotated, mzml_small],
-                result_file,
-                evaluate=True,
-            )
-
-    result_file.unlink()
 
 
 def test_metrics_logging(tmp_path, mgf_small, tiny_config):


### PR DESCRIPTION
In some cases the module responsible for parsing the peptide sequence will throw a `TypeError` if the peptide sequence annotations are present, but the format is incorrect. In order to simplify troubleshooting I updated the try/catch wrapping the evaluate mode dataloader initialization to add an error message to this effect, while still throwing the original error message for debugging purposes. 