### PR TITLE
Resolve issues causing predictions to disappear

### DIFF
--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -423,7 +423,7 @@ class Spec2Pep(pl.LightningModule):
             is_valid_position[~ends_stop_token, step] = True
 
         is_n_term[is_valid_position] = False
-        discarded_beams |= torch.any(is_n_term)
+        discarded_beams |= torch.any(is_n_term, dim=1)
 
         # Check which beams should be terminated or discarded based on the
         # predicted peptide.

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -1027,7 +1027,7 @@ class Spec2Pep(pl.LightningModule):
                 )
                 next_aa_scores, next_pep_score = _aa_pep_score(
                     next_aa_scores,
-                    abs(calc_mz - precursor_mz) < self.precursor_mass_tol,
+                    True # Don't penalize precursor mass
                 )
                 next_peptide = self.tokenizer.detokenize(
                     next_peptide.unsqueeze(0)

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -347,18 +347,6 @@ class ModelRunner:
             for true_seq, pred_seq, conf in zip(seq_true, seq_pred, pred_conf):
                 writer.writerow([true_seq, pred_seq, conf])
 
-        with open(self.output_dir / "psms.csv", mode="w", newline="") as file:
-            writer = csv.writer(file)
-            writer.writerow(
-                [
-                    "Ground Truth Peptide",
-                    "Predicted Peptide",
-                    "Prediction Confidence",
-                ]
-            )
-            for true_seq, pred_seq, conf in zip(seq_true, seq_pred, pred_conf):
-                writer.writerow([true_seq, pred_seq, conf])
-
     def predict(
         self,
         peak_path: Iterable[str],


### PR DESCRIPTION
- Corrected `torch.any(is_n_term)` to `torch.any(is_n_term, dim=1)` to evaluate each beam individually rather than returning a single value for all beams, which was causing excessive beam discarding.
- Removed the unmatched precursor mass penalty, as chimeric spectra naturally have large precursor mass differences.