### PR TITLE
Remove precursor mass check from *de novo* mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.9.0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 26.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increased minimum Python version from 3.8 to 3.10.
 - DepthCharge is upgraded to the latest version 0.4.9.
 - A more descriptive error message will now be logged for some annotated spectrum file parsing failure cases.
-- The precursor mass filter will no longer be applied in *de novo* mode, so the config options `precursor_mass_tol` and `isotope_error_range` will now only apply to database search mode, and peptide-level scores will no longer be adjusted.
+- The precursor mass filter will no longer be applied in *de novo* mode, so the config options `precursor_mass_tol` and `isotope_error_range` will now only apply to database search mode, and peptide-level scores will no longer be adjusted based on the precursor mass.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increased minimum Python version from 3.8 to 3.10.
 - DepthCharge is upgraded to the latest version 0.4.9.
 - A more descriptive error message will now be logged for some annotated spectrum file parsing failure cases.
-- The precursor mass filter will no longer be applied in *de novo* mode, so the config option `precursor_mass_tol` will now only apply to database search mode.
+- The precursor mass filter will no longer be applied in *de novo* mode, so the config options `precursor_mass_tol` and `isotope_error_range` will now only apply to database search mode.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increased minimum Python version from 3.8 to 3.10.
 - DepthCharge is upgraded to the latest version 0.4.9.
 - A more descriptive error message will now be logged for some annotated spectrum file parsing failure cases.
-- The precursor mass filter will no longer be applied in *de novo* mode, so the config options `precursor_mass_tol` and `isotope_error_range` will now only apply to database search mode.
+- The precursor mass filter will no longer be applied in *de novo* mode, so the config options `precursor_mass_tol` and `isotope_error_range` will now only apply to database search mode, and peptide level scores will no longer be adjusted.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increased minimum Python version from 3.8 to 3.10.
 - DepthCharge is upgraded to the latest version 0.4.9.
 - A more descriptive error message will now be logged for some annotated spectrum file parsing failure cases.
+- The precursor mass filter will no longer be applied in *de novo* mode, so the config option `precursor_mass_tol` will now only apply to database search mode.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Increased minimum Python version from 3.8 to 3.10.
 - DepthCharge is upgraded to the latest version 0.4.9.
-- A more descriptive error message will now be logged for some annotated spectrum file parsing failure cases.
-- The precursor mass filter will no longer be applied in *de novo* mode, so the config options `precursor_mass_tol` and `isotope_error_range` will now only apply to database search mode, and peptide-level scores will no longer be adjusted based on the precursor mass.
+- A more descriptive error message is logged for some annotated spectrum file parsing failure cases.
+- The precursor mass filter is no longer applied in *de novo* mode, and correspondingly peptide-level scores are no longer penalized based on the precursor mass. The config options `precursor_mass_tol` and `isotope_error_range` now only apply to database search mode.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increased minimum Python version from 3.8 to 3.10.
 - DepthCharge is upgraded to the latest version 0.4.9.
 - A more descriptive error message will now be logged for some annotated spectrum file parsing failure cases.
-- The precursor mass filter will no longer be applied in *de novo* mode, so the config options `precursor_mass_tol` and `isotope_error_range` will now only apply to database search mode, and peptide level scores will no longer be adjusted.
+- The precursor mass filter will no longer be applied in *de novo* mode, so the config options `precursor_mass_tol` and `isotope_error_range` will now only apply to database search mode, and peptide-level scores will no longer be adjusted.
 
 ### Fixed
 

--- a/casanovo/__init__.py
+++ b/casanovo/__init__.py
@@ -1,4 +1,3 @@
 from .version import _get_version
 
-
 __version__ = _get_version()

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -10,7 +10,6 @@ import yaml
 
 from . import utils
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -9,8 +9,6 @@
 # parameters when running Casanovo in database search mode.
 ###
 
-# Isotopes to consider when comparing predicted and observed precursor m/z's.
-isotope_error_range: [0, 1]
 # The minimum length of considered peptides.
 min_peptide_len: 6
 # The maximum length of considered peptides.
@@ -42,7 +40,10 @@ n_beams: 1
 
 # Max absolute difference allowed with respect to observed precursor m/z.
 # Only peptides within the specified precursor m/z tolerance are considered.
-precursor_mass_tol: 50  # ppm
+precursor_mass_tol: 50  # 
+
+# Isotopes to consider when comparing predicted and observed precursor m/z's.
+isotope_error_range: [0, 1]
 
 # Enzyme for in silico digestion, used to generate candidate peptides.
 # See pyteomics.parser.expasy_rules for valid enzymes.

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -40,7 +40,7 @@ n_beams: 1
 
 # Max absolute difference allowed with respect to observed precursor m/z.
 # Only peptides within the specified precursor m/z tolerance are considered.
-precursor_mass_tol: 50  # 
+precursor_mass_tol: 50 
 
 # Isotopes to consider when comparing predicted and observed precursor m/z's.
 isotope_error_range: [0, 1]

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -9,13 +9,6 @@
 # parameters when running Casanovo in database search mode.
 ###
 
-# Max absolute difference allowed with respect to observed precursor m/z.
-# de novo: Predictions outside the tolerance range are assigned a negative
-# peptide score.
-# database search: Select candidate peptides within the specified precursor m/z
-# tolerance.
-# Set to "inf" (with quotation marks) to disable the filter entirely.
-precursor_mass_tol: 50  # ppm
 # Isotopes to consider when comparing predicted and observed precursor m/z's.
 isotope_error_range: [0, 1]
 # The minimum length of considered peptides.
@@ -46,6 +39,10 @@ n_beams: 1
 ###
 # The following parameters are unique to Casanovo's database search mode.
 ###
+
+# Max absolute difference allowed with respect to observed precursor m/z.
+# Only peptides within the specified precursor m/z tolerance are considered.
+precursor_mass_tol: 50  # ppm
 
 # Enzyme for in silico digestion, used to generate candidate peptides.
 # See pyteomics.parser.expasy_rules for valid enzymes.

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -21,7 +21,6 @@ from depthcharge.tokenizers import PeptideTokenizer
 from torch.utils.data import DataLoader
 from torch.utils.data.datapipes.iter.combinatorics import ShufflerIterDataPipe
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -18,7 +18,6 @@ from ..data import ms_io, psm
 from ..denovo.transformers import PeptideDecoder, SpectrumEncoder
 from . import evaluate
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -443,32 +443,30 @@ class Spec2Pep(pl.LightningModule):
 
         # Discard beams with invalid modification combinations
         if step > 1:
-            dim0 = torch.arange(batch_size, device=device)
             final_pos = torch.full((batch_size,), step, device=device)
             final_pos[ends_stop_token] = step - 1
 
             # Vectorized check for multiple N-terminal modifications
-            num_modifications = torch.isin(tokens, nterm_idx).sum(dim=1)
+            token_is_nterm = torch.isin(tokens, nterm_idx)
+            num_modifications = token_is_nterm.sum(dim=1)
             has_n_term = num_modifications > 0
 
             # We only need to this check if there are any n-term mods
             if torch.any(has_n_term).item():
                 # Catch multiple modifications, pretty straightforward
-                multiple_mods = num_modifications > 1
+                multiple_mods = num_modifications[has_n_term] > 1
 
                 # Vectorized check for internal N-terminal modifications.
                 # This will fail to catch internal modifications in some cases
                 # where there are multiple mods, but these are already discarded
                 # by the previous check.
-                n_terminal_pos = 0 if self.tokenizer.reverse else final_pos
-                nterm_token_is_mod = torch.isin(
-                    tokens[dim0, n_terminal_pos], nterm_idx
+                n_terminal_pos = (
+                    0 if self.tokenizer.reverse else final_pos[has_n_term]
                 )
-                internal_mods = has_n_term & ~nterm_token_is_mod
+                internal_mods = ~token_is_nterm[has_n_term, n_terminal_pos]
 
-                discarded_beams = (
-                    discarded_beams | multiple_mods | internal_mods
-                )
+                # Only discard beams we have actually checked
+                discarded_beams[has_n_term] |= multiple_mods | internal_mods
 
         # Calculate peptide lengths
         peptide_lens = torch.full((batch_size,), step + 1, device=device)

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -450,20 +450,18 @@ class Spec2Pep(pl.LightningModule):
             final_pos[ends_stop_token] = step - 1
 
             # Vectorized check for multiple N-terminal modifications
-            last_token_is_nterm = torch.isin(
-                tokens[dim0, final_pos], nterm_idx
-            )
-            prev_token_is_nterm = torch.isin(
-                tokens[dim0, final_pos - 1], nterm_idx
-            )
-            multiple_mods = last_token_is_nterm & prev_token_is_nterm
+            num_modifications = torch.isin(tokens, nterm_idx).sum(dim=1)
+            has_n_term = num_modifications > 0
+            multiple_mods = num_modifications > 1
 
             # Vectorized check for internal N-terminal modifications
-            has_n_term = torch.any(torch.isin(tokens, nterm_idx), dim=1)
             if self.tokenizer.reverse:
                 first_token_is_nterm = torch.isin(tokens[dim0, 0], nterm_idx)
                 internal_mods = has_n_term & ~first_token_is_nterm
             else:
+                last_token_is_nterm = torch.isin(
+                    tokens[dim0, final_pos], nterm_idx
+                )
                 internal_mods = has_n_term & ~last_token_is_nterm
 
             discarded_beams = discarded_beams | multiple_mods | internal_mods

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -451,18 +451,23 @@ class Spec2Pep(pl.LightningModule):
 
             # Vectorized check for multiple N-terminal modifications
             num_modifications = torch.isin(tokens, nterm_idx).sum(dim=1)
-            has_n_term = num_modifications > 0
             multiple_mods = num_modifications > 1
 
-            # Vectorized check for internal N-terminal modifications
+            # Vectorized check for internal N-terminal modifications.
+            # This will fail to catch internal modifications in some cases
+            # where there are multiple mods, but these are already discarded
+            # by the previous check.
+            has_n_term = num_modifications > 0
             if self.tokenizer.reverse:
-                first_token_is_nterm = torch.isin(tokens[dim0, 0], nterm_idx)
-                internal_mods = has_n_term & ~first_token_is_nterm
+                first_token_is_nterm_mod = torch.isin(
+                    tokens[dim0, 0], nterm_idx
+                )
+                internal_mods = has_n_term & ~first_token_is_nterm_mod
             else:
-                last_token_is_nterm = torch.isin(
+                last_token_is_nterm_mod = torch.isin(
                     tokens[dim0, final_pos], nterm_idx
                 )
-                internal_mods = has_n_term & ~last_token_is_nterm
+                internal_mods = has_n_term & ~last_token_is_nterm_mod
 
             discarded_beams = discarded_beams | multiple_mods | internal_mods
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -449,25 +449,26 @@ class Spec2Pep(pl.LightningModule):
 
             # Vectorized check for multiple N-terminal modifications
             num_modifications = torch.isin(tokens, nterm_idx).sum(dim=1)
-            multiple_mods = num_modifications > 1
-
-            # Vectorized check for internal N-terminal modifications.
-            # This will fail to catch internal modifications in some cases
-            # where there are multiple mods, but these are already discarded
-            # by the previous check.
             has_n_term = num_modifications > 0
-            if self.tokenizer.reverse:
-                first_token_is_nterm_mod = torch.isin(
-                    tokens[dim0, 0], nterm_idx
-                )
-                internal_mods = has_n_term & ~first_token_is_nterm_mod
-            else:
-                last_token_is_nterm_mod = torch.isin(
-                    tokens[dim0, final_pos], nterm_idx
-                )
-                internal_mods = has_n_term & ~last_token_is_nterm_mod
 
-            discarded_beams = discarded_beams | multiple_mods | internal_mods
+            # We only need to this check if there are any n-term mods
+            if torch.any(has_n_term).item():
+                # Catch multiple modifications, pretty straightforward
+                multiple_mods = num_modifications > 1
+
+                # Vectorized check for internal N-terminal modifications.
+                # This will fail to catch internal modifications in some cases
+                # where there are multiple mods, but these are already discarded
+                # by the previous check.
+                n_terminal_pos = 0 if self.tokenizer.reverse else final_pos
+                nterm_token_is_mod = torch.isin(
+                    tokens[dim0, n_terminal_pos], nterm_idx
+                )
+                internal_mods = has_n_term & ~nterm_token_is_mod
+
+                discarded_beams = (
+                    discarded_beams | multiple_mods | internal_mods
+                )
 
         # Calculate peptide lengths
         peptide_lens = torch.full((batch_size,), step + 1, device=device)

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -61,12 +61,6 @@ class Spec2Pep(pl.LightningModule):
     precursor_mass_tol : float
         The maximum allowable precursor mass tolerance (in ppm) for
         correct predictions.
-    isotope_error_range : Tuple[int, int]
-        Take into account the error introduced by choosing a
-        non-monoisotopic peak for fragmentation by not penalizing
-        predicted precursor m/z's that fit the specified isotope error:
-        `abs(calc_mz - (precursor_mz - isotope * 1.00335 / precursor_charge))
-        < precursor_mass_tol`
     min_peptide_len : int
         The minimum length of predicted peptides.
     n_beams : int
@@ -105,7 +99,6 @@ class Spec2Pep(pl.LightningModule):
         residues: str | Dict[str, float] = "canonical",
         max_charge: int = 5,
         precursor_mass_tol: float = 50,
-        isotope_error_range: Tuple[int, int] = (0, 1),
         min_peptide_len: int = 6,
         n_beams: int = 1,
         top_match: int = 1,
@@ -164,7 +157,6 @@ class Spec2Pep(pl.LightningModule):
         self.max_peptide_len = max_peptide_len
         self.residues = residues
         self.precursor_mass_tol = precursor_mass_tol
-        self.isotope_error_range = isotope_error_range
         self.min_peptide_len = min_peptide_len
         self.n_beams = n_beams
         self.top_match = top_match

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -58,9 +58,6 @@ class Spec2Pep(pl.LightningModule):
         collection of amino acids and masses.
     max_charge : int
         The maximum precursor charge to consider.
-    precursor_mass_tol : float
-        The maximum allowable precursor mass tolerance (in ppm) for
-        correct predictions.
     min_peptide_len : int
         The minimum length of predicted peptides.
     n_beams : int

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -209,18 +209,6 @@ class Spec2Pep(pl.LightningModule):
             persistent=False,
         )
 
-        # Register tensor buffer for amino acid token masses
-        self.register_buffer(
-            "token_masses",
-            torch.zeros(self.vocab_size, dtype=torch.float64),
-            persistent=False,
-        )
-        # Populate token masses from tokenizer residues
-        for aa, mass in self.tokenizer.residues.items():
-            idx = self.tokenizer.index.get(aa)
-            if idx is not None:
-                self.token_masses[idx] = mass
-
     @property
     def device(self) -> torch.device:
         """
@@ -331,39 +319,25 @@ class Spec2Pep(pl.LightningModule):
         tokens[:, 0, :] = top_indices
         scores[:, :1, :, :] = einops.repeat(pred, "B L V -> B L V S", S=beam)
 
-        # Initialize cumulative masses to track peptide masses
-        token_masses = self.token_masses.to(device)
-        cumulative_masses = torch.zeros(batch, beam, device=device)
-        for b in range(batch):
-            for s in range(beam):
-                token_idx = tokens[b, 0, s].item()
-                if token_idx < len(token_masses):  # ensure index is valid
-                    cumulative_masses[b, s] = token_masses[token_idx]
-
         # Make all tensors the right shape for decoding.
         precursors = einops.repeat(precursors, "B L -> (B S) L", S=beam)
         mem_masks = einops.repeat(mem_masks, "B L -> (B S) L", S=beam)
         memories = einops.repeat(memories, "B L V -> (B S) L V", S=beam)
         tokens = einops.rearrange(tokens, "B L S -> (B S) L")
         scores = einops.rearrange(scores, "B L V S -> (B S) L V")
-        cumulative_masses = einops.rearrange(cumulative_masses, "B S -> (B S)")
 
         # Store temporary attributes for use by other methods
-        self._cumulative_masses = cumulative_masses
         self._batch_size = batch
         self._beam_size = beam
 
         try:
             # The main decoding loop.
             for step in range(0, self.max_peptide_len):
-                # Terminate beams exceeding the precursor m/z tolerance and
-                # track all finished beams (either terminated or stop token
+                # Track all finished beams (either terminated or stop token
                 # predicted).
-                (
-                    finished_beams,
-                    beam_fits_precursor,
-                    discarded_beams,
-                ) = self._finish_beams(tokens, precursors, step)
+                finished_beams, discarded_beams = self._finish_beams(
+                    tokens, step
+                )
 
                 # Cache peptide predictions from the finished beams (but not
                 # the discarded beams).
@@ -374,7 +348,6 @@ class Spec2Pep(pl.LightningModule):
                         scores,
                         step,
                         beams_to_cache,
-                        beam_fits_precursor,
                         pred_cache,
                     )
 
@@ -409,7 +382,7 @@ class Spec2Pep(pl.LightningModule):
                 )
         finally:
             # Ensure temporary attributes are cleaned up in all cases to prevent memory leaks
-            temp_attrs = ["_cumulative_masses", "_batch_size", "_beam_size"]
+            temp_attrs = ["_batch_size", "_beam_size"]
             for attr in temp_attrs:
                 if hasattr(self, attr):
                     delattr(self, attr)
@@ -421,9 +394,8 @@ class Spec2Pep(pl.LightningModule):
     def _finish_beams(
         self,
         tokens: torch.Tensor,
-        precursors: torch.Tensor,
         step: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Track all beams that have been finished.
 
@@ -445,9 +417,6 @@ class Spec2Pep(pl.LightningModule):
         finished_beams : torch.Tensor of shape (n_spectra * n_beams)
             Boolean tensor indicating whether the current beams have
             been finished.
-        beam_fits_precursor: torch.Tensor of shape (n_spectra * n_beams)
-            Boolean tensor indicating if the current beams are within
-            the precursor m/z tolerance.
         discarded_beams : torch.Tensor of shape (n_spectra * n_beams)
             Boolean tensor indicating whether the current beams should
             be discarded (e.g. because they were predicted to end but
@@ -459,16 +428,11 @@ class Spec2Pep(pl.LightningModule):
 
         # Use precomputed indices and ensure they're on the correct device
         nterm_idx = self.nterm_idx
-        neg_mass_idx = self.neg_mass_idx
-        token_masses = self.token_masses
 
         # Check the tokens at the current step
         current_tokens = tokens[:, step]
 
         # Initialize return tensors
-        beam_fits_precursor = torch.zeros(
-            batch_size, dtype=torch.bool, device=device
-        )
         finished_beams = torch.zeros(
             batch_size, dtype=torch.bool, device=device
         )
@@ -496,16 +460,14 @@ class Spec2Pep(pl.LightningModule):
             multiple_mods = last_token_is_nterm & prev_token_is_nterm
 
             # Vectorized check for internal N-terminal modifications
-            positions = torch.arange(tokens.shape[1], device=device)
-            mask = (final_pos - 1).unsqueeze(1) >= positions
-            token_mask = torch.where(mask, tokens, torch.zeros_like(tokens))
-            internal_mods = torch.any(torch.isin(token_mask, nterm_idx), dim=1)
+            has_n_term = torch.any(torch.isin(tokens, nterm_idx), dim=1)
+            if self.tokenizer.reverse:
+                first_token_is_nterm = torch.isin(tokens[dim0, 0], nterm_idx)
+                internal_mods = has_n_term & ~first_token_is_nterm
+            else:
+                internal_mods = has_n_term & ~last_token_is_nterm
 
             discarded_beams = discarded_beams | multiple_mods | internal_mods
-
-        # Get precursor information
-        precursor_charges = precursors[:, 1]
-        precursor_mzs = precursors[:, 2]
 
         # Calculate peptide lengths
         peptide_lens = torch.full((batch_size,), step + 1, device=device)
@@ -521,169 +483,7 @@ class Spec2Pep(pl.LightningModule):
         too_short = peptide_lens < self.min_peptide_len
         discarded_beams[too_short & finished_beams] = True
 
-        # Mask for beams we need to check mass tolerance
-        beams_to_check = ~discarded_beams
-
-        if torch.any(beams_to_check):
-            # For all beams that need checking, perform a batch-wise, high-precision
-            # recalculation of their mass and check against the precursor m/z tolerance.
-            idx = torch.nonzero(beams_to_check).squeeze(-1)
-
-            # Get the effective token sequences for the current step (without stop tokens).
-            sequences_to_check = []
-            charges_to_check = precursor_charges[idx]
-
-            for i, beam_idx in enumerate(idx):
-                seq = tokens[beam_idx, : step + 1]
-                # If the last token is a stop token, remove it.
-                if seq[-1] == self.stop_token:
-                    seq = seq[:-1]
-                sequences_to_check.append(seq)
-
-            # Find the maximum sequence length for padding.
-            if sequences_to_check:
-                max_len = max(len(seq) for seq in sequences_to_check)
-                if max_len > 0:
-                    # Create a padded tensor.
-                    padded_sequences = torch.zeros(
-                        len(sequences_to_check),
-                        max_len,
-                        dtype=torch.int64,
-                        device=device,
-                    )
-                    for i, seq in enumerate(sequences_to_check):
-                        if len(seq) > 0:
-                            padded_sequences[i, : len(seq)] = seq
-
-                    # Batch calculate precursor ions.
-                    # The tokenizer requires input on the CPU.
-                    recalc_mzs = self.tokenizer.calculate_precursor_ions(
-                        padded_sequences.cpu(), charges_to_check.cpu()
-                    ).to(device, dtype=torch.float64)
-
-                    # Convert to neutral mass.
-                    recalc_neutral_masses = (
-                        recalc_mzs - 1.007276
-                    ) * charges_to_check.double()
-
-                    # Update cumulative mass with the high-precision value.
-                    self._cumulative_masses[idx] = recalc_neutral_masses.to(
-                        self._cumulative_masses.dtype
-                    )
-
-                    # This is the recalculated theoretical m/z.
-                    current_mzs = recalc_mzs
-                else:
-                    # If all sequences are empty, set m/z to 0.
-                    current_mzs = torch.zeros(
-                        len(idx), dtype=torch.float64, device=device
-                    )
-            else:
-                current_mzs = torch.zeros(
-                    len(idx), dtype=torch.float64, device=device
-                )
-
-            precursor_mzs_obs = precursor_mzs[idx].double()
-
-            # Create a tensor for the isotope error range (e.g., [0, 1]).
-            isotope_range = torch.arange(
-                self.isotope_error_range[0],
-                self.isotope_error_range[1] + 1,
-                device=device,
-                dtype=torch.float64,
-            )
-
-            # Calculate the m/z correction for each isotope based on charge.
-            isotope_corr = (
-                isotope_range.unsqueeze(0)
-                * 1.00335
-                / charges_to_check.double().unsqueeze(1)
-            )
-
-            # Calculate the PPM difference between the current m/z and the observed m/z for all isotope corrections.
-            delta_ppms = (
-                (
-                    current_mzs.unsqueeze(1)
-                    - (precursor_mzs_obs.unsqueeze(1) - isotope_corr)
-                )
-                / precursor_mzs_obs.unsqueeze(1)
-                * 1e6
-            )
-
-            # For each beam, check if any isotope correction brings the PPM error within tolerance.
-            matches_any = (
-                torch.abs(delta_ppms) < self.precursor_mass_tol
-            ).any(dim=1)
-
-            # Store which beams match the precursor tolerance
-            temp_matches = torch.zeros_like(beam_fits_precursor)
-            temp_matches[idx] = matches_any
-
-            # Decide whether to force terminate only for beams that have not naturally ended AND are not within the tolerance.
-            still_alive = ~finished_beams[idx]
-            to_terminate = still_alive & ~matches_any
-
-            # Handle cases where a negative mass AA could potentially correct the mass.
-            if torch.any(to_terminate) and self.neg_mass_idx.numel() > 0:
-                exceeding_indices = torch.where(to_terminate)[0]
-                neg_masses = self.token_masses[self.neg_mass_idx]
-
-                exceeding_masses = recalc_neutral_masses[exceeding_indices]
-                exceeding_charges = charges_to_check[
-                    exceeding_indices
-                ].double()
-                exceeding_precursor_mzs = precursor_mzs_obs[exceeding_indices]
-
-                # Calculate potential m/z with each negative mass AA
-                potential_masses = exceeding_masses.unsqueeze(
-                    1
-                ) + neg_masses.double().unsqueeze(0)
-                potential_mzs = (
-                    potential_masses.unsqueeze(2)
-                    / exceeding_charges.unsqueeze(1).unsqueeze(2)
-                    + 1.007276
-                )
-
-                isotope_corr_expanded = (
-                    isotope_range.unsqueeze(0).unsqueeze(0)
-                    * 1.00335
-                    / exceeding_charges.unsqueeze(1).unsqueeze(2)
-                )
-                observed_mzs_expanded = (
-                    exceeding_precursor_mzs.unsqueeze(1).unsqueeze(2)
-                    - isotope_corr_expanded
-                )
-                delta_ppms_neg = (
-                    (potential_mzs - observed_mzs_expanded)
-                    / exceeding_precursor_mzs.unsqueeze(1).unsqueeze(2)
-                    * 1e6
-                )
-
-                any_neg_aa_works = torch.any(
-                    torch.abs(delta_ppms_neg) < self.precursor_mass_tol,
-                    dim=(1, 2),
-                )
-                any_not_strictly_exceeding = torch.any(
-                    delta_ppms_neg <= self.precursor_mass_tol, dim=(1, 2)
-                )
-
-                # Update the matches flag for beams that can be 'saved' by a negative mass AA.
-                can_be_saved = any_neg_aa_works | any_not_strictly_exceeding
-                temp_matches[idx[exceeding_indices]] |= can_be_saved
-                to_terminate[exceeding_indices] = ~can_be_saved
-
-            # Terminate beams that are confirmed to exceed the tolerance.
-            to_terminate = idx[to_terminate]
-            finished_beams[to_terminate] = True
-
-            # Discard any beams which exceed the precursor filter but are less
-            # than the minimum peptide length
-            discarded_beams[to_terminate] = too_short[to_terminate]
-
-            # update beam_fits_precursor for finished beams
-            beam_fits_precursor |= temp_matches & finished_beams
-
-        return finished_beams, beam_fits_precursor, discarded_beams
+        return finished_beams, discarded_beams
 
     def _cache_finished_beams(
         self,
@@ -691,7 +491,6 @@ class Spec2Pep(pl.LightningModule):
         scores: torch.Tensor,
         step: int,
         beams_to_cache: torch.Tensor,
-        beam_fits_precursor: torch.Tensor,
         pred_cache: Dict[
             int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
         ],
@@ -712,9 +511,6 @@ class Spec2Pep(pl.LightningModule):
         beams_to_cache : torch.Tensor of shape (n_spectra * n_beams)
             Boolean tensor indicating whether the current beams are
             ready for caching.
-        beam_fits_precursor: torch.Tensor of shape (n_spectra * n_beams)
-            Boolean tensor indicating whether the beams are within the
-            precursor m/z tolerance.
         pred_cache : Dict[
             int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
         ]
@@ -767,9 +563,7 @@ class Spec2Pep(pl.LightningModule):
                 aa_scores = np.append(aa_scores, 0)
 
             # Calculate the peptide score using the appropriate scoring function
-            peptide_score = _peptide_score(
-                aa_scores, beam_fits_precursor[i].item()
-            )
+            peptide_score = _peptide_score(aa_scores)
 
             # Omit the stop token from the amino acid-level scores.
             aa_scores = aa_scores[:-1]
@@ -835,14 +629,9 @@ class Spec2Pep(pl.LightningModule):
         vocab = self.vocab_size  # V
         device = self.device  # Get device from input tensor
 
-        token_masses = self.token_masses
-
         # Reshape to group by spectrum (B for "batch").
         tokens = einops.rearrange(tokens, "(B S) L -> B L S", S=beam)
         scores = einops.rearrange(scores, "(B S) L V -> B L V S", S=beam)
-        cumulative_masses = einops.rearrange(
-            self._cumulative_masses, "(B S) -> B S", S=beam
-        )
 
         # Get the previous tokens and scores.
         prev_tokens = einops.repeat(
@@ -900,19 +689,6 @@ class Spec2Pep(pl.LightningModule):
             scores[b_idx, : step + 1, :, s_idx_flat],
             "(B S) L V -> B L V S",
             S=beam,
-        )
-
-        # Vectorized cumulative mass update
-        # Gather parent beam masses
-        parent_masses = torch.gather(cumulative_masses, dim=1, index=s_idx)
-
-        # Get new token masses and update
-        new_token_masses = token_masses[v_idx]
-        cumulative_masses_new = parent_masses + new_token_masses
-
-        # Update class attribute with new cumulative masses
-        self._cumulative_masses = einops.rearrange(
-            cumulative_masses_new, "B S -> (B S)"
         )
 
         # Reshape for return
@@ -1682,35 +1458,8 @@ class CosineWarmupScheduler(torch.optim.lr_scheduler._LRScheduler):
         return lr_factor
 
 
-def _calc_mass_error(
-    calc_mz: float, obs_mz: float, charge: int, isotope: int = 0
-) -> float:
-    """
-    Calculate the mass error in ppm between the theoretical m/z and the
-    observed m/z, optionally accounting for an isotopologue mismatch.
-
-    Parameters
-    ----------
-    calc_mz : float
-        The theoretical m/z.
-    obs_mz : float
-        The observed m/z.
-    charge : int
-        The charge.
-    isotope : int
-        Correct for the given number of C13 isotopes (default: 0).
-
-    Returns
-    -------
-    float
-        The mass error in ppm.
-    """
-    return (calc_mz - (obs_mz - isotope * 1.00335 / charge)) / obs_mz * 10**6
-
-
 def _peptide_score(
     aa_scores: np.ndarray,
-    fits_precursor_mz: Union[bool, np.ndarray] = True,
     lengths: Optional[np.ndarray] = None,
 ) -> Union[float, np.ndarray]:
     """
@@ -1726,9 +1475,6 @@ def _peptide_score(
     aa_scores : np.ndarray
         A 1D array of amino acid scores for a single peptide, or a 2D
         padded array for a batch of peptides.
-    fits_precursor_mz : bool or np.ndarray
-        Flag or array of flags indicating whether predictions fit the
-        precursor m/z filter.
     lengths : Optional[np.ndarray]
         An array of peptide lengths, required when `aa_scores` is a 2D
         (batched) array.
@@ -1746,8 +1492,6 @@ def _peptide_score(
         peptide_log_score = np.sum(log_scores)
         peptide_score = np.exp(peptide_log_score)
 
-        if not fits_precursor_mz:
-            peptide_score -= 1
         return peptide_score
 
     # BATCH PATH: database search
@@ -1761,11 +1505,5 @@ def _peptide_score(
         idx = np.arange(batch_size)
         peptide_log_scores = cumsum[idx, np.maximum(lengths - 1, 0)]
         peptide_scores = np.exp(peptide_log_scores)
-
-        if isinstance(fits_precursor_mz, (bool, np.bool_)):
-            if not fits_precursor_mz:
-                peptide_scores -= 1
-        else:
-            peptide_scores[~fits_precursor_mz] -= 1
 
         return peptide_scores

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -98,7 +98,6 @@ class Spec2Pep(pl.LightningModule):
         max_peptide_len: int = 100,
         residues: str | Dict[str, float] = "canonical",
         max_charge: int = 5,
-        precursor_mass_tol: float = 50,
         min_peptide_len: int = 6,
         n_beams: int = 1,
         top_match: int = 1,
@@ -156,7 +155,6 @@ class Spec2Pep(pl.LightningModule):
         # Data properties.
         self.max_peptide_len = max_peptide_len
         self.residues = residues
-        self.precursor_mass_tol = precursor_mass_tol
         self.min_peptide_len = min_peptide_len
         self.n_beams = n_beams
         self.top_match = top_match

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -399,15 +399,13 @@ class Spec2Pep(pl.LightningModule):
         Track all beams that have been finished.
 
         Beams are finished by predicting the stop token or because they
-        were terminated due to exceeding the precursor m/z tolerance.
+        were terminated due to violating minimum peptide length or
+        invalid N-terminal modification placement.
 
         Parameters
         ----------
         tokens : torch.Tensor of shape (n_spectra * n_beams, max_length)
             Predicted amino acid tokens for all beams and all spectra.
-        precursors : torch.Tensor of shape (n_spectra * n_beams, 3)
-            The measured precursor mass (axis 0), precursor charge
-            (axis 1), and precursor m/z (axis 2) of each MS/MS spectrum.
         step : int
             Index of the current decoding step.
 

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -480,14 +480,6 @@ class ModelRunner:
             out_writer=self.writer,
         )
 
-        if db_search:
-            db_only_params = dict(
-                isotope_error_range=self.config.isotope_error_range,
-                precursor_mass_tol=self.config.precursor_mass_tol,
-            )
-            model_params.update(db_only_params)
-            loaded_model_params.update(db_only_params)
-
         if self.model_filename is None:
             if db_search:
                 logger.error("A model file must be provided for DB search")

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -25,7 +25,6 @@ from ..denovo.dataloaders import DeNovoDataModule
 from ..denovo.evaluate import aa_match_batch, aa_match_metrics
 from ..denovo.model import DbSpec2Pep, Spec2Pep
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -443,8 +443,6 @@ class ModelRunner:
             )
 
         model_params = dict(
-            precursor_mass_tol=self.config.precursor_mass_tol,
-            isotope_error_range=self.config.isotope_error_range,
             min_peptide_len=self.config.min_peptide_len,
             top_match=self.config.top_match,
             n_beams=self.config.n_beams,
@@ -468,8 +466,6 @@ class ModelRunner:
         # Reconfigurable non-architecture related parameters for a
         # loaded model.
         loaded_model_params = dict(
-            precursor_mass_tol=self.config.precursor_mass_tol,
-            isotope_error_range=self.config.isotope_error_range,
             min_peptide_len=self.config.min_peptide_len,
             max_peptide_len=self.config.max_peptide_len,
             top_match=self.config.top_match,
@@ -483,6 +479,14 @@ class ModelRunner:
             calculate_precision=self.config.calculate_precision,
             out_writer=self.writer,
         )
+
+        if db_search:
+            db_only_params = dict(
+                isotope_error_range=self.config.isotope_error_range,
+                precursor_mass_tol=self.config.precursor_mass_tol,
+            )
+            model_params.update(db_only_params)
+            loaded_model_params.update(db_only_params)
 
         if self.model_filename is None:
             if db_search:

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2208,7 +2208,6 @@ def test_get_top_peptide_ranking(tiny_config):
 
 @pytest.mark.parametrize("topk", [1, 2, 3])
 def test_get_top_peptide_multiple(topk, tiny_config):
-    # foo
     config = Config(tiny_config)
     model = Spec2Pep(
         top_match=topk,

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -649,6 +649,53 @@ def test_is_valid_url():
     assert not casanovo._is_valid_url("foobar")
 
 
+@pytest.mark.parametrize(
+    "aa_scores_raw, expected",
+    [
+        (np.asarray([0.0, 0.5, 1.0]), 0.0),
+        (np.asarray([1.0, 0.25]), 0.25),
+    ],
+)
+def test_peptide_score_scalar(aa_scores_raw, expected):
+    peptide_score = _peptide_score(aa_scores_raw)
+    assert peptide_score == pytest.approx(expected)
+
+
+def test_peptide_score_batch():
+    aa_scores_batch = np.array(
+        [
+            [0.5, 0.8, 0.0],
+            [0.9, 0.7, 0.6],
+        ]
+    )
+    lengths_batch = np.array([2, 3])
+
+    expected_scores = np.array(
+        [
+            0.5 * 0.8,
+            0.9 * 0.7 * 0.6,
+        ]
+    )
+
+    peptide_scores = _peptide_score(aa_scores_batch, lengths_batch)
+    assert np.allclose(peptide_scores, expected_scores)
+
+
+def test_peptide_score_batch_requires_lengths():
+    aa_scores_batch = np.array(
+        [
+            [0.5, 0.8, 0.0],
+            [0.9, 0.7, 0.6],
+        ]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="`lengths` must be provided for batched input.",
+    ):
+        _peptide_score(aa_scores_batch, None)
+
+
 def test_peptide_score():
     """
     Test the calculation of amino acid and peptide scores from the raw amino
@@ -2102,7 +2149,6 @@ def test_finish_beams(tiny_config):
 
     model._batch_size = batch
     model._beam_size = beam
-    model._cumulative_masses = torch.zeros(batch * beam, device=device)
 
     vocab = len(model.tokenizer) + 1
     scores = torch.full((batch, length, vocab, beam), torch.nan, device=device)
@@ -2111,9 +2157,6 @@ def test_finish_beams(tiny_config):
     tokens = torch.zeros(
         batch * beam, length, dtype=torch.int64, device=device
     )
-    precursors = torch.tensor(
-        [469.25364, 2.0, 235.63410], device=device
-    ).repeat(beam, 1)
 
     peptides = [
         ("PEPK", False),
@@ -2128,54 +2171,15 @@ def test_finish_beams(tiny_config):
         for j in range(step + 1):
             scores[i, j, toks[j]] = 1
 
-    # update masses
-    for i in range(batch * beam):
-        mass = sum(
-            model.token_masses[tokens[i, j].item()]
-            for j in range(step + 1)
-            if 0 < tokens[i, j].item() < len(model.token_masses)
-        )
-        model._cumulative_masses[i] = mass
+    finished, discarded = model._finish_beams(tokens, step)
 
-    finished, fits, discarded = model._finish_beams(tokens, precursors, step)
-
+    # Last beam discarded for being too short
     assert torch.equal(
-        finished, torch.tensor([False, True, False, True], device=device)
-    )
-    assert torch.equal(
-        fits, torch.tensor([False, False, False, False], device=device)
+        finished, torch.tensor([False, False, False, True], device=device)
     )
     assert torch.equal(
         discarded, torch.tensor([False, False, False, True], device=device)
     )
-
-
-def test_peptide_too_short_too_heavy(tiny_config):
-    config = Config(tiny_config)
-    model = Spec2Pep(
-        n_beams=1,
-        min_peptide_len=20,
-        tokenizer=depthcharge.tokenizers.peptides.PeptideTokenizer(
-            residues=config.residues
-        ),
-    )
-
-    # Mass of "peptid"
-    precursors = torch.tensor([[670.31737, 2.0, 336.16596]])
-    peptide = "PEPTIDE"
-    tokens = model.tokenizer.tokenize(peptide)
-    step = len(peptide) - 1
-    # This needs to be initialized, but is recalculated anyway so the value
-    # doesn't matter
-    model._cumulative_masses = torch.tensor([42.424242])
-
-    finished_beams, beam_fits_precursor, discarded_beams = model._finish_beams(
-        tokens, precursors, step
-    )
-
-    assert finished_beams.item()
-    assert discarded_beams.item()
-    assert not beam_fits_precursor.item()
 
 
 def test_cache_finished_beams(tiny_config):
@@ -2210,10 +2214,9 @@ def test_cache_finished_beams(tiny_config):
 
     finished = torch.tensor([False, True, False, False], device=device)
     discarded = torch.tensor([False, False, False, False], device=device)
-    fits = torch.tensor([False, False, False, False], device=device)
 
     model._cache_finished_beams(
-        tokens, scores, step, finished & ~discarded, fits, pred_cache
+        tokens, scores, step, finished & ~discarded, pred_cache
     )
 
     cached = [
@@ -2334,39 +2337,6 @@ def test_get_topk_beams(tiny_config):
     assert not torch.equal(new_tokens[0], new_tokens[1])
 
 
-def test_finish_beams_negative_mods(tiny_config):
-    config = Config(tiny_config)
-    model = Spec2Pep(
-        n_beams=2,
-        tokenizer=depthcharge.tokenizers.peptides.MskbPeptideTokenizer(
-            residues=config.residues
-        ),
-        residues=config.residues,
-        min_peptide_len=0,
-    )
-    batch = 1
-    beam = 2
-    device = model.device
-
-    model._batch_size = batch
-    model._beam_size = beam
-    model._cumulative_masses = torch.zeros(batch * beam, device=device)
-
-    length = model.max_peptide_len + 1
-    step = 1
-    tokens = torch.zeros((beam, length), dtype=torch.int64, device=device)
-    tokens[:, : step + 1] = model.tokenizer.tokenize(["GK", "AK"])
-    precursors = torch.tensor(
-        [186.10044, 2.0, 94.05750], device=device
-    ).repeat(beam, 1)
-    finished, fits, disc = model._finish_beams(tokens, precursors, step)
-
-    # Ground truth peptide is "-17.027GK".
-    assert torch.equal(finished, torch.tensor([False, True], device=device))
-    assert torch.equal(fits, torch.tensor([False, False], device=device))
-    assert torch.equal(disc, torch.tensor([False, False], device=device))
-
-
 def test_beam_search_decode_early_termination(tiny_config):
     config = Config(tiny_config)
     model = Spec2Pep(
@@ -2423,7 +2393,6 @@ def test_duplicate_peptide_scores(tiny_config):
         tokens,
         scores,
         step,
-        torch.ones(batch * beam, dtype=torch.bool, device=device),
         torch.ones(batch * beam, dtype=torch.bool, device=device),
         pred_cache,
     )
@@ -2483,53 +2452,6 @@ def _build_model(tok, cls=Spec2Pep, ppm_tol=20):
         [tok.residues["P"]], dtype=torch.float64
     )
     return model
-
-
-def test_precursor_rescue():
-    """
-    Verifies that the current Spec2Pep keeps a rescuable beam alive,
-    while the legacy-style logic still terminates it.
-    """
-    tok = MiniTok()
-    charge = 2
-    target_mass = tok.residues["P"] + tok.residues["NLoss2"] + 18.01056
-    precursor_mz = target_mass / charge + 1.007276
-    # Sequence “P” + padding
-    TOKENS = torch.tensor([[tok.index["P"], 0, 0]])
-    PRECURSOR = torch.tensor(
-        [[target_mass, charge, precursor_mz]], dtype=torch.float64
-    )
-    STEP = 0
-
-    new_model = _build_model(tok)
-    finished, _, _ = new_model._finish_beams(TOKENS, PRECURSOR, STEP)
-    assert (
-        not finished.item()
-    ), "New logic failed and beam terminated unexpectedly!"
-
-    class PrematureSpec2Pep(Spec2Pep):
-        """
-        Mimic the legacy behaviour, abort immediately if ppm > tol,
-        without trying negative-mass residues.
-        """
-
-        def _finish_beams(self, tokens, precursors, step):
-            theo = self.tokenizer.calculate_precursor_ions(
-                tokens[:, : step + 1], precursors[:, 1]
-            )
-            delta = (theo - precursors[:, 2]) / precursors[:, 2] * 1e6
-            over = delta.abs() > self.precursor_mass_tol
-            # Terminate all over-tol beams
-            finished = over.clone()
-            beam_fits = ~over
-            discarded = torch.zeros_like(over)
-            return finished, beam_fits, discarded
-
-    old_like = _build_model(tok, PrematureSpec2Pep)
-    finished_old, _, _ = old_like._finish_beams(TOKENS, PRECURSOR, STEP)
-    assert (
-        finished_old.item()
-    ), "Old logic was expected to terminate the beam but did not"
 
 
 def test_db_spec2pep_forward_no_cache(tiny_config):

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2139,6 +2139,55 @@ def test_finish_beams(tiny_config):
     )
 
 
+@pytest.mark.parametrize("reverse", [True, False])
+def test_invalid_n_term_mod(tiny_config, reverse):
+    config = Config(tiny_config)
+    model = Spec2Pep(
+        n_beams=4,
+        residues="massivekb",
+        tokenizer=depthcharge.tokenizers.peptides.PeptideTokenizer(
+            residues=config.residues
+        ),
+    )
+
+    model.tokenizer.reverse = reverse
+    length = model.max_peptide_len + 1
+    step = 4
+    device = model.device
+    model.min_peptide_len = 3
+
+    # (peptide, should_be_discarded)
+    peptides = [
+        (["P", "E", "P", "K", "K"], False),
+        (["[Acetyl]-", "P", "E", "P", "K"], not reverse),
+        (["[Acetyl]-", "[Acetyl]-", "P", "E", "P"], True),
+        (["[Acetyl]-", "P", "E", "P", "[Acetyl]-"], True),
+        (["P", "E", "P", "K", "[Acetyl]-"], reverse),
+        (["P", "E", "P", "[Acetyl]-", "$"], reverse),
+        (["P", "E", "[Acetyl]-", "P", "K"], True),
+    ]
+
+    tokens = torch.zeros(
+        len(peptides), length, dtype=torch.int64, device=device
+    )
+
+    # Stop the tokenizer from protecting against invalid n-term mods
+    index = model.tokenizer.index
+    index["$"] = model.tokenizer.stop_int
+    for i, (pep, _) in enumerate(peptides):
+        toks = torch.tensor([index[aa] for aa in pep], device=device)
+        tokens[i, : step + 1] = toks
+
+    expected_discarded = torch.tensor([c for _, c in peptides], device=device)
+    expected_finished = torch.tensor(
+        [pep[-1] == "$" for pep, _ in peptides], device=device
+    )
+    finished, discarded = model._finish_beams(tokens, step)
+
+    assert torch.equal(discarded, expected_discarded)
+    assert torch.equal(finished, expected_finished)
+
+
 def test_cache_finished_beams(tiny_config):
     config = Config(tiny_config)
     model = Spec2Pep(

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -696,49 +696,6 @@ def test_peptide_score_batch_requires_lengths():
         _peptide_score(aa_scores_batch, None)
 
 
-def test_peptide_score():
-    """
-    Test the calculation of amino acid and peptide scores from the raw amino
-    acid scores.
-    """
-    aa_scores_raw = np.asarray([0.0, 0.5, 1.0])
-
-    peptide_score = _peptide_score(aa_scores_raw, True)
-    assert peptide_score == pytest.approx(0.0)
-
-    peptide_score = _peptide_score(aa_scores_raw, False)
-    assert peptide_score == pytest.approx(-1.0)
-
-    aa_scores_raw = np.asarray([1.0, 0.25])
-    peptide_score = _peptide_score(aa_scores_raw, True)
-    assert peptide_score == pytest.approx(0.25)
-
-    aa_scores_batch = np.array([[0.5, 0.8, 0.0], [0.9, 0.7, 0.6]])
-    lengths_batch = np.array([2, 3])
-
-    peptide_scores = _peptide_score(aa_scores_batch, True, lengths_batch)
-    expected_scores = np.array([0.5 * 0.8, 0.9 * 0.7 * 0.6])
-    assert np.allclose(peptide_scores, expected_scores)
-
-    peptide_scores_no_fit = _peptide_score(
-        aa_scores_batch, False, lengths_batch
-    )
-    assert np.allclose(peptide_scores_no_fit, expected_scores - 1)
-
-    fits_array = np.array([True, False])
-    peptide_scores_mixed_fit = _peptide_score(
-        aa_scores_batch, fits_array, lengths_batch
-    )
-    expected_mixed_scores = expected_scores.copy()
-    expected_mixed_scores[~fits_array] -= 1
-    assert np.allclose(peptide_scores_mixed_fit, expected_mixed_scores)
-
-    with pytest.raises(
-        ValueError, match="`lengths` must be provided for batched input."
-    ):
-        _peptide_score(aa_scores_batch, True, None)
-
-
 def test_peptide_generator_errors(tiny_fasta_file):
     residues_dict = (
         depthcharge.tokenizers.PeptideTokenizer.from_massivekb().residues

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2208,6 +2208,7 @@ def test_get_top_peptide_ranking(tiny_config):
 
 @pytest.mark.parametrize("topk", [1, 2, 3])
 def test_get_top_peptide_multiple(topk, tiny_config):
+    # foo
     config = Config(tiny_config)
     model = Spec2Pep(
         top_match=topk,

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -650,7 +650,7 @@ def test_is_valid_url():
 
 
 @pytest.mark.parametrize(
-    "aa_scores_raw, expected",
+    ("aa_scores_raw", "expected"),
     [
         (np.asarray([0.0, 0.5, 1.0]), 0.0),
         (np.asarray([1.0, 0.25]), 0.25),
@@ -691,7 +691,7 @@ def test_peptide_score_batch_requires_lengths():
 
     with pytest.raises(
         ValueError,
-        match="`lengths` must be provided for batched input.",
+        match="`lengths` must be provided for batched input\.",
     ):
         _peptide_score(aa_scores_batch, None)
 


### PR DESCRIPTION
- Removed all precursor mass checks from the beam search code path
- The `precursor_mass_tol` config option will now only be used in *de novo* mode
- Refactored the peptide score unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * De novo decoding simplified by removing mass-based gating and related mass-tracking logic.
* **Configuration**
  * precursor_mass_tol and isotope_error_range now apply only to database-search mode.
* **Breaking Changes**
  * Package no longer exposes a version string on import; some module-level loggers removed which may affect runtime logging.
* **Tests**
  * Unit tests updated for simplified de novo APIs and batched peptide scoring.
* **Chores**
  * Updated code formatter pin (Black).
* **Documentation**
  * CHANGELOG updated to reflect de novo precursor filter removal and logging wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->