### PR TITLE
Fix minimum length off by one bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed an issue which led the reported peptide precision to be 0 during evaluation mode.
 - Peptide predictions failing the minimum peptide length are not reported, irrespective of whether they match or exceed the precursor mass.
 - Setting `--output_root` to a directory will no longer cause an error.
+- Fixed an issue where some predictions that are one residue less than the configured minimum peptide length are reported.
 
 ## [5.1.2] - 2025-12-11
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -455,15 +455,9 @@ class Spec2Pep(pl.LightningModule):
                 # Only discard beams we have actually checked
                 discarded_beams[has_n_term] |= multiple_mods | internal_mods
 
-        # Calculate peptide lengths
+        # Calculate peptide lengths, and adjust for stop tokens
         peptide_lens = torch.full((batch_size,), step + 1, device=device)
-        # Adjust for stop tokens
-        if self.tokenizer.reverse:
-            has_stop_at_start = tokens[:, 0] == self.stop_token
-            peptide_lens[has_stop_at_start] -= 1
-        else:
-            has_stop_at_end = ends_stop_token
-            peptide_lens[has_stop_at_end] -= 1
+        peptide_lens[ends_stop_token] -= 1
 
         # Discard beams that don't meet minimum peptide length
         too_short = peptide_lens < self.min_peptide_len

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2307,7 +2307,6 @@ def test_get_top_peptide_ranking(tiny_config):
 
 @pytest.mark.parametrize("topk", [1, 2, 3])
 def test_get_top_peptide_multiple(topk, tiny_config):
-    # foo
     config = Config(tiny_config)
     model = Spec2Pep(
         top_match=topk,

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2307,6 +2307,7 @@ def test_get_top_peptide_ranking(tiny_config):
 
 @pytest.mark.parametrize("topk", [1, 2, 3])
 def test_get_top_peptide_multiple(topk, tiny_config):
+    # foo
     config = Config(tiny_config)
     model = Spec2Pep(
         top_match=topk,


### PR DESCRIPTION
This bug was caused by this code block:

```python
if self.tokenizer.reverse:
    has_stop_at_start = tokens[:, 0] == self.stop_token
    peptide_lens[has_stop_at_start] -= 1
else:
    has_stop_at_end = ends_stop_token
    peptide_lens[has_stop_at_end] -= 1
```

Regardless of the decoding direction stop tokens are always predicted at the end of their corresponding vector in the tokens tensor. However, in reverse mode this block looks for stop tokens at the beginning of the token vectors, hence it doesn't properly adjust the length for the stop token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fix**
  * Fixed an issue where some predicted peptides were reported one residue shorter than the configured minimum; these predictions are now correctly filtered.

* **Refactor**
  * Simplified internal peptide-length handling during beam finishing to remove special-case behavior and make length decisions more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->