### PR TITLE
Remove configured residues not in model alphabet warning (final)

### DIFF
--- a/casanovo/__init__.py
+++ b/casanovo/__init__.py
@@ -1,4 +1,3 @@
 from .version import _get_version
 
-
 __version__ = _get_version()

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -10,7 +10,6 @@ import yaml
 
 from . import utils
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -21,7 +21,6 @@ from depthcharge.tokenizers import PeptideTokenizer
 from torch.utils.data import DataLoader
 from torch.utils.data.datapipes.iter.combinatorics import ShufflerIterDataPipe
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -18,7 +18,6 @@ from ..data import ms_io, psm
 from ..denovo.transformers import PeptideDecoder, SpectrumEncoder
 from . import evaluate
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -408,15 +408,6 @@ class ModelRunner:
         else:
             tokenizer_clss = PeptideTokenizer
 
-        missing_aa = list(
-            set(self.config.residues) - set(tokenizer_clss.residues)
-        )
-        if missing_aa:
-            logger.warning(
-                "Configured residue(s) not in model alphabet: %s",
-                ", ".join(missing_aa),
-            )
-
         self.tokenizer = tokenizer_clss(
             residues=self.config.residues,
             replace_isoleucine_with_leucine=self.config.replace_isoleucine_with_leucine,

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -25,7 +25,6 @@ from ..denovo.dataloaders import DeNovoDataModule
 from ..denovo.evaluate import aa_match_batch, aa_match_metrics
 from ..denovo.model import DbSpec2Pep, Spec2Pep
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -581,4 +581,3 @@ def test_verify_tokenizer(
     else:
         # Ensure no warnings were logged
         assert not any(rec.levelname == "WARNING" for rec in caplog.records)
-

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -582,17 +582,3 @@ def test_verify_tokenizer(
         # Ensure no warnings were logged
         assert not any(rec.levelname == "WARNING" for rec in caplog.records)
 
-
-def test_initialize_tokenizer(caplog):
-    mock_config = unittest.mock.MagicMock()
-    mock_config.residues = {"foo": 100}
-
-    runner = ModelRunner(config=mock_config)
-
-    with caplog.at_level("WARNING"):
-        runner.initialize_tokenizer()
-
-    assert any(
-        "Configured residue(s) not in model alphabet: foo" in msg
-        for msg in caplog.messages
-    )


### PR DESCRIPTION
### Description
Removes the unnecessary warning raised when configured residues are not found in the base tokenizer alphabet. This warning was misleading as the tokenizer still initializes correctly with custom residues passed via `residues` config.

---

### Linked Issue
Closes #566 

---

### Changes Made
| File | Change |
|------|--------|
| `casanovo/denovo/model_runner.py` | Removed `missing_aa` check and `logger.warning()` block in `initialize_tokenizer()` |
| `tests/unit_tests/test_runner.py` | Removed `test_initialize_tokenizer` test |

---

### Before
```
WARNING: Configured residue(s) not in model alphabet: 
M[Oxidation], [Ammonia-loss]-, [Acetyl]-, C[Carbamidomethyl]
```

### After
No warning is raised. Tokenizer initializes cleanly with custom residues.

---

### Testing
```bash
# Reinstall
pip install -e .

# Run test suite
pytest tests/unit_tests/test_runner.py -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal logger initialization across modules
  * Removed residue validation warning during model initialization
  * Removed associated unit test and formatting adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->