### PR TITLE
Feature/track mgf scan numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Track instrument-assigned scan numbers from MGF `SCANS`, `SCAN`, and `SCAN ID` header fields in a new `opt_global_cv_MS:1003057_scan_number` mzTab column.
-
-## [5.1.2] - 2025-12-11
-
-### Changed
-
-- Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files.
-
-### Added
-
 - A TSV file with all candidate peptides can be exported during database searching with the `--export` flag.
+- Track instrument-assigned scan numbers from MGF `SCANS`, `SCAN`, and `SCAN ID` header fields in a new `opt_global_cv_MS:1003057_scan_number` mzTab column.
 
 ### Changed
 
@@ -34,6 +25,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed an issue which led the reported peptide precision to be 0 during evaluation mode.
 - Peptide predictions failing the minimum peptide length are not reported, irrespective of whether they match or exceed the precursor mass.
 - Setting `--output_root` to a directory will no longer cause an error.
+
+## [5.1.2] - 2025-12-11
+
+### Changed
+
+- Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files.
 
 ## [5.1.1] - 2025-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Track instrument-assigned scan numbers from MGF file `SCANS`, `SCAN`, or
-  `SCAN ID` header fields and include them in the mzTab `spectra_ref` column
-  alongside the spectrum file index (e.g. `ms_run[1]:index=0 scan=17`).
-
+- Track instrument-assigned scan numbers from MGF `SCANS`, `SCAN`, and `SCAN ID` header fields in a new `opt_global_cv_MS:1003057_scan_number` mzTab column.
 ## [5.1.2] - 2025-12-11
 
 ### Changed
@@ -39,9 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Track instrument-assigned scan numbers from MGF file `SCANS`, `SCAN`, or
-  `SCAN ID` header fields and include them in the mzTab `spectra_ref` column
-  alongside the spectrum file index (e.g. `ms_run[1]:index=0 scan=17`).
+- Track instrument-assigned scan numbers from MGF `SCANS`, `SCAN`, and `SCAN ID` header fields in a new `opt_global_cv_MS:1003057_scan_number` mzTab column.
 
 ## [5.1.2] - 2025-12-11
 
@@ -362,7 +357,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 [Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.1.2...HEAD
 [5.1.2]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...v5.1.2
-[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...HEAD
 [5.1.1]: https://github.com/Noble-Lab/casanovo/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/Noble-Lab/casanovo/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/Noble-Lab/casanovo/compare/v4.3.0...v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Track instrument-assigned scan numbers from MGF `SCANS`, `SCAN`, and `SCAN ID` header fields in a new `opt_global_cv_MS:1003057_scan_number` mzTab column.
+
 ## [5.1.2] - 2025-12-11
 
 ### Changed
@@ -33,16 +34,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed an issue which led the reported peptide precision to be 0 during evaluation mode.
 - Peptide predictions failing the minimum peptide length are not reported, irrespective of whether they match or exceed the precursor mass.
 - Setting `--output_root` to a directory will no longer cause an error.
-
-### Added
-
-- Track instrument-assigned scan numbers from MGF `SCANS`, `SCAN`, and `SCAN ID` header fields in a new `opt_global_cv_MS:1003057_scan_number` mzTab column.
-
-## [5.1.2] - 2025-12-11
-
-### Changed
-
-- Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files.
 
 ## [5.1.1] - 2025-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Track instrument-assigned scan numbers from MGF file `SCANS`, `SCAN`, or
+  `SCAN ID` header fields and include them in the mzTab `spectra_ref` column
+  alongside the spectrum file index (e.g. `ms_run[1]:index=0 scan=17`).
+
 ## [5.1.2] - 2025-12-11
 
 ### Changed
@@ -30,6 +36,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed an issue which led the reported peptide precision to be 0 during evaluation mode.
 - Peptide predictions failing the minimum peptide length are not reported, irrespective of whether they match or exceed the precursor mass.
 - Setting `--output_root` to a directory will no longer cause an error.
+
+### Added
+
+- Track instrument-assigned scan numbers from MGF file `SCANS`, `SCAN`, or
+  `SCAN ID` header fields and include them in the mzTab `spectra_ref` column
+  alongside the spectrum file index (e.g. `ms_run[1]:index=0 scan=17`).
 
 ## [5.1.2] - 2025-12-11
 
@@ -348,6 +360,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial Casanovo version.
 
+[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.1.2...HEAD
+[5.1.2]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...v5.1.2
 [Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...HEAD
 [5.1.1]: https://github.com/Noble-Lab/casanovo/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/Noble-Lab/casanovo/compare/v5.0.0...v5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [5.1.2] - 2025-12-11
+
+### Changed
+
+- Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files.
+
 ### Added
 
 - A TSV file with all candidate peptides can be exported during database searching with the `--export` flag.
@@ -342,8 +348,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial Casanovo version.
 
-[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.1.2...HEAD
-[5.1.2]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...v5.1.2
+[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...HEAD
 [5.1.1]: https://github.com/Noble-Lab/casanovo/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/Noble-Lab/casanovo/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/Noble-Lab/casanovo/compare/v4.3.0...v5.0.0

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -17,6 +17,11 @@ from .psm import PepSpecMatch
 
 logger = logging.getLogger("casanovo")
 
+# MGF spectrum block delimiters and scan-number header prefixes.
+_MGF_BEGIN = "BEGIN IONS"
+_MGF_END = "END IONS"
+_MGF_SCAN_PREFIXES = ("SCANS=", "SCAN=", "SCAN ID=")
+
 
 def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
     """
@@ -47,16 +52,16 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
             for line in fh:
                 stripped = line.strip()
                 upper = stripped.upper()
-                if upper == "BEGIN IONS":
+                if upper == _MGF_BEGIN:
                     in_ions = True
                     current_scan = None
-                elif upper == "END IONS":
+                elif upper == _MGF_END:
                     if current_scan is not None:
                         yield f"index={index}", current_scan
                     index += 1
                     in_ions = False
                 elif in_ions:
-                    for prefix in ("SCANS=", "SCAN=", "SCAN ID="):
+                    for prefix in _MGF_SCAN_PREFIXES:
                         if upper.startswith(prefix):
                             scan_value = stripped.split("=", 1)[1].strip()
                             if re.fullmatch(r"\d+", scan_value):

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -58,7 +58,16 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
                 elif in_ions:
                     for prefix in ("SCANS=", "SCAN=", "SCAN ID="):
                         if upper.startswith(prefix):
-                            current_scan = stripped.split("=", 1)[1].strip()
+                            scan_value = stripped.split("=", 1)[1].strip()
+                            if re.fullmatch(r"\d+", scan_value):
+                                current_scan = scan_value
+                            else:
+                                logger.warning(
+                                    "Ignoring non-numeric %s value %r in %s",
+                                    prefix[:-1],
+                                    scan_value,
+                                    mgf_path,
+                                )
                             break
     except OSError as e:
         logger.warning(

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -14,7 +14,50 @@ from .. import __version__
 from ..config import Config
 from .psm import PepSpecMatch
 
+def _build_mgf_scan_index(mgf_path: str) -> dict:
+    """
+    Build an index mapping spectrum position to SCANS value for an MGF file.
 
+    Reads only the header lines of each spectrum entry (never the peak
+    data), so this is very fast even for large files.
+
+    Parameters
+    ----------
+    mgf_path : str
+        Path to the MGF file.
+
+    Returns
+    -------
+    dict
+        Mapping from spectrum index (as a string, e.g. ``"0"``) to the
+        SCANS field value (e.g. ``"17"``). Only spectra that contain a
+        ``SCANS``, ``SCAN``, or ``SCAN ID`` header field are included.
+    """
+    index2scan = {}
+    index = 0
+    current_scan = None
+    in_ions = False
+    try:
+        with open(mgf_path, "r", errors="replace") as fh:
+            for line in fh:
+                stripped = line.strip()
+                upper = stripped.upper()
+                if upper == "BEGIN IONS":
+                    in_ions = True
+                    current_scan = None
+                elif upper == "END IONS":
+                    if current_scan is not None:
+                        index2scan[str(index)] = current_scan
+                    index += 1
+                    in_ions = False
+                elif in_ions:
+                    for prefix in ("SCANS=", "SCAN=", "SCAN ID="):
+                        if upper.startswith(prefix):
+                            current_scan = stripped.split("=", 1)[1].strip()
+                            break
+    except OSError:
+        pass
+    return index2scan
 class MztabWriter:
     """
     Export spectrum identifications to an mzTab file.
@@ -43,6 +86,7 @@ class MztabWriter:
             ),
         ]
         self._run_map = {}
+        self._mgf_scan_index = {}  # {(filename_base, index_str): scan_num_str}
         self.psms: List[PepSpecMatch] = []
 
     def set_metadata(self, config: Config, **kwargs) -> None:
@@ -144,6 +188,28 @@ class MztabWriter:
             )
             self._run_map[Path(filename).name] = i
 
+    def set_mgf_scan_index(self, peak_filenames: List[str]) -> None:
+        """
+        Pre-compute the MGF scan number index for the given peak files.
+
+        For each MGF file, reads the ``SCANS`` (or ``SCAN`` / ``SCAN ID``)
+        header field of every spectrum entry and stores a mapping from
+        spectrum index to scan number.  Called once before prediction so
+        that ``save()`` can embed the scan number in the ``spectra_ref``
+        column without re-reading the files at write time.
+
+        Parameters
+        ----------
+        peak_filenames : List[str]
+            The input peak file paths (mzML files are silently ignored).
+        """
+        for path in peak_filenames:
+            if Path(path).suffix.lower() != ".mgf":
+                continue
+            name = Path(path).name
+            for idx_str, scan_num in _build_mgf_scan_index(path).items():
+                self._mgf_scan_index[(name, idx_str)] = scan_num
+
     def save(self) -> None:
         """
         Export the spectrum identifications to the mzTab file.
@@ -185,6 +251,12 @@ class MztabWriter:
                 1,
             ):
                 filename, idx = psm.spectrum_id
+                if Path(filename).suffix.lower() == ".mgf" and idx.isnumeric():
+                    scan_num = self._mgf_scan_index.get((filename, idx))
+                    idx = f"index={idx}"
+                    if scan_num:
+                        idx = f"{idx} scan={scan_num}"
+
                 writer.writerow(
                     [
                         "PSM",

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -2,14 +2,12 @@
 
 import collections
 import csv
+import logging
 import operator
 import os
 import re
-from pathlib import Path
 from collections.abc import Iterator
-from typing import List
-
-import logging
+from pathlib import Path
 
 import natsort
 
@@ -45,7 +43,7 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
     current_scan = None
     in_ions = False
     try:
-        with open(mgf_path, "r", errors="replace") as fh:
+        with open(mgf_path, errors="replace") as fh:
             for line in fh:
                 stripped = line.strip()
                 upper = stripped.upper()
@@ -99,7 +97,7 @@ class MztabWriter:
         ]
         self._run_map = {}
         self._mgf_scan_index = {}  # {(filename_base, index_str): scan_num_str}
-        self.psms: List[PepSpecMatch] = []
+        self.psms: list[PepSpecMatch] = []
 
     def set_metadata(self, config: Config, **kwargs) -> None:
         """
@@ -184,14 +182,14 @@ class MztabWriter:
                     (f"software[1]-setting[{i}]", f"{key} = {value}")
                 )
 
-    def set_ms_run(self, peak_filenames: List[str]) -> None:
+    def set_ms_run(self, peak_filenames: list[str]) -> None:
         """
         Add input peak files to the mzTab metadata section and
         pre-compute the MGF scan number index for any MGF files.
 
         Parameters
         ----------
-        peak_filenames : List[str]
+        peak_filenames : list[str]
             The input peak file name(s).
         """
         for i, filename in enumerate(natsort.natsorted(peak_filenames), 1):
@@ -249,8 +247,11 @@ class MztabWriter:
                 filename, idx = psm.spectrum_id
                 run_idx = self._run_map[filename]
                 scan_col = "null"
-                if Path(filename).suffix.lower() == ".mgf" and idx.isnumeric():
-                    idx = f"index={idx}"
+                if Path(filename).suffix.lower() == ".mgf":
+                    # Normalize idx to "index=N" format, handling both
+                    # bare numeric IDs ("0") and prefixed IDs ("index=0").
+                    if idx.isnumeric():
+                        idx = f"index={idx}"
                     scan_num = self._mgf_scan_index.get((filename, idx))
                     if scan_num:
                         scan_col = f"ms_run[{run_idx}]:scan={scan_num}"

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -58,6 +58,8 @@ def _build_mgf_scan_index(mgf_path: str) -> dict:
     except OSError:
         pass
     return index2scan
+
+
 class MztabWriter:
     """
     Export spectrum identifications to an mzTab file.

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -8,7 +8,11 @@ import re
 from pathlib import Path
 from typing import List
 
+import logging
+
 import natsort
+
+logger = logging.getLogger("casanovo")
 
 from .. import __version__
 from ..config import Config
@@ -55,8 +59,12 @@ def _build_mgf_scan_index(mgf_path: str) -> dict:
                         if upper.startswith(prefix):
                             current_scan = stripped.split("=", 1)[1].strip()
                             break
-    except OSError:
-        pass
+    except OSError as e:
+        logger.warning(
+            "Could not read MGF file %s to build scan index: %s",
+            mgf_path,
+            e,
+        )
     return index2scan
 
 
@@ -253,11 +261,20 @@ class MztabWriter:
                 1,
             ):
                 filename, idx = psm.spectrum_id
-                if Path(filename).suffix.lower() == ".mgf" and idx.isnumeric():
-                    scan_num = self._mgf_scan_index.get((filename, idx))
-                    idx = f"index={idx}"
-                    if scan_num:
-                        idx = f"{idx} scan={scan_num}"
+                if Path(filename).suffix.lower() == ".mgf":
+                    # Normalize idx: handle both "0" and "index=0" shapes.
+                    numeric_idx = (
+                        idx[len("index="):]
+                        if idx.startswith("index=")
+                        else idx
+                    )
+                    if numeric_idx.isnumeric():
+                        scan_num = self._mgf_scan_index.get(
+                            (filename, numeric_idx)
+                        )
+                        idx = f"index={numeric_idx}"
+                        if scan_num:
+                            idx = f"{idx} scan={scan_num}"
 
                 writer.writerow(
                     [

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -222,6 +222,7 @@ class MztabWriter:
             for row in self.metadata:
                 writer.writerow(["MTD", *row])
             # Write PSMs.
+            include_scan_col = bool(self._mgf_scan_index)
             writer.writerow(
                 [
                     "PSH",
@@ -245,7 +246,11 @@ class MztabWriter:
                     "end",
                     "opt_ms_run[1]_aa_scores",
                     "opt_ms_run[1]_proforma",
-                    "opt_global_cv_MS:1003057_scan_number",
+                    *(
+                        ["opt_global_cv_MS:1003057_scan_number"]
+                        if include_scan_col
+                        else []
+                    ),
                 ]
             )
             by_id = operator.attrgetter("spectrum_id")
@@ -265,34 +270,34 @@ class MztabWriter:
                     if scan_num:
                         scan_col = f"ms_run[{run_idx}]:scan={scan_num}"
 
-                writer.writerow(
-                    [
-                        "PSM",
-                        psm.aa_sequence,  # sequence
-                        i,  # PSM_ID
-                        psm.protein,  # accession
-                        "null",  # unique
-                        "null",  # database
-                        "null",  # database_version
-                        f"[MS, MS:1003281, Casanovo, {__version__}]",
-                        psm.peptide_score,  # search_engine_score[1]
-                        # FIXME: Modifications should be specified as
-                        #  controlled vocabulary terms.
-                        psm.modifications,  # modifications
-                        # FIXME: Can we get the retention time from the data
-                        #  loader?
-                        "null",  # retention_time
-                        psm.charge,  # charge
-                        psm.exp_mz,  # exp_mass_to_charge
-                        psm.calc_mz,  # calc_mass_to_charge
-                        f"ms_run[{run_idx}]:{idx}",
-                        "null",  # pre
-                        "null",  # post
-                        "null",  # start
-                        "null",  # end
-                        # opt_ms_run[1]_aa_scores
-                        ",".join(list(map("{:.5f}".format, psm.aa_scores))),
-                        psm.sequence,  # opt_ms_run[1]_proforma
-                        scan_col,  # opt_global_cv_MS:1003057_scan_number
-                    ]
-                )
+                row = [
+                    "PSM",
+                    psm.aa_sequence,  # sequence
+                    i,  # PSM_ID
+                    psm.protein,  # accession
+                    "null",  # unique
+                    "null",  # database
+                    "null",  # database_version
+                    f"[MS, MS:1003281, Casanovo, {__version__}]",
+                    psm.peptide_score,  # search_engine_score[1]
+                    # FIXME: Modifications should be specified as
+                    #  controlled vocabulary terms.
+                    psm.modifications,  # modifications
+                    # FIXME: Can we get the retention time from the data
+                    #  loader?
+                    "null",  # retention_time
+                    psm.charge,  # charge
+                    psm.exp_mz,  # exp_mass_to_charge
+                    psm.calc_mz,  # calc_mass_to_charge
+                    f"ms_run[{run_idx}]:{idx}",
+                    "null",  # pre
+                    "null",  # post
+                    "null",  # start
+                    "null",  # end
+                    # opt_ms_run[1]_aa_scores
+                    ",".join(list(map("{:.5f}".format, psm.aa_scores))),
+                    psm.sequence,  # opt_ms_run[1]_proforma
+                ]
+                if include_scan_col:
+                    row.append(scan_col)
+                writer.writerow(row)

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -295,6 +295,10 @@ class MztabWriter:
                     psm.sequence,  # opt_global_cv_MS:1003169_proforma_peptidoform_sequence
                 ]
                 if include_scan_col:
-                    scan_num = self._mgf_scan_index.get((filename, idx), "null")
-                    row.append(f"ms_run[{run_idx}]:scan={scan_num}")
+                    scan_num = self._mgf_scan_index.get((filename, idx))
+                    row.append(
+                        f"ms_run[{run_idx}]:scan={scan_num}"
+                        if scan_num
+                        else "null"
+                    )
                 writer.writerow(row)

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -6,21 +6,24 @@ import operator
 import os
 import re
 from pathlib import Path
+from collections.abc import Iterator
 from typing import List
 
 import logging
 
 import natsort
 
-logger = logging.getLogger("casanovo")
-
 from .. import __version__
 from ..config import Config
 from .psm import PepSpecMatch
 
-def _build_mgf_scan_index(mgf_path: str) -> dict:
+logger = logging.getLogger("casanovo")
+
+
+def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
     """
-    Build an index mapping spectrum position to SCANS value for an MGF file.
+    Yield (spectrum_ref_id, scan_number) pairs for spectra in an MGF file
+    that contain a SCANS, SCAN, or SCAN ID header field.
 
     Reads only the header lines of each spectrum entry (never the peak
     data), so this is very fast even for large files.
@@ -30,14 +33,14 @@ def _build_mgf_scan_index(mgf_path: str) -> dict:
     mgf_path : str
         Path to the MGF file.
 
-    Returns
-    -------
-    dict
-        Mapping from spectrum index (as a string, e.g. ``"0"``) to the
-        SCANS field value (e.g. ``"17"``). Only spectra that contain a
-        ``SCANS``, ``SCAN``, or ``SCAN ID`` header field are included.
+    Yields
+    ------
+    tuple[str, str]
+        A ``(spectrum_ref_id, scan_number)`` pair where
+        *spectrum_ref_id* uses the ``index=N`` nativeID format required
+        by the mzTab multiple-peak-list nativeID specification
+        (MS:1000774).
     """
-    index2scan = {}
     index = 0
     current_scan = None
     in_ions = False
@@ -51,7 +54,7 @@ def _build_mgf_scan_index(mgf_path: str) -> dict:
                     current_scan = None
                 elif upper == "END IONS":
                     if current_scan is not None:
-                        index2scan[str(index)] = current_scan
+                        yield f"index={index}", current_scan
                     index += 1
                     in_ions = False
                 elif in_ions:
@@ -65,7 +68,6 @@ def _build_mgf_scan_index(mgf_path: str) -> dict:
             mgf_path,
             e,
         )
-    return index2scan
 
 
 class MztabWriter:
@@ -184,7 +186,8 @@ class MztabWriter:
 
     def set_ms_run(self, peak_filenames: List[str]) -> None:
         """
-        Add input peak files to the mzTab metadata section.
+        Add input peak files to the mzTab metadata section and
+        pre-compute the MGF scan number index for any MGF files.
 
         Parameters
         ----------
@@ -197,28 +200,10 @@ class MztabWriter:
                 (f"ms_run[{i}]-location", Path(filename).as_uri()),
             )
             self._run_map[Path(filename).name] = i
-
-    def set_mgf_scan_index(self, peak_filenames: List[str]) -> None:
-        """
-        Pre-compute the MGF scan number index for the given peak files.
-
-        For each MGF file, reads the ``SCANS`` (or ``SCAN`` / ``SCAN ID``)
-        header field of every spectrum entry and stores a mapping from
-        spectrum index to scan number.  Called once before prediction so
-        that ``save()`` can embed the scan number in the ``spectra_ref``
-        column without re-reading the files at write time.
-
-        Parameters
-        ----------
-        peak_filenames : List[str]
-            The input peak file paths (mzML files are silently ignored).
-        """
-        for path in peak_filenames:
-            if Path(path).suffix.lower() != ".mgf":
-                continue
-            name = Path(path).name
-            for idx_str, scan_num in _build_mgf_scan_index(path).items():
-                self._mgf_scan_index[(name, idx_str)] = scan_num
+            if Path(filename).suffix.lower() == ".mgf":
+                name = Path(filename).name
+                for ref_id, scan_num in _build_mgf_scan_index(filename):
+                    self._mgf_scan_index[(name, ref_id)] = scan_num
 
     def save(self) -> None:
         """
@@ -253,6 +238,7 @@ class MztabWriter:
                     "end",
                     "opt_ms_run[1]_aa_scores",
                     "opt_ms_run[1]_proforma",
+                    "opt_global_cv_MS:1003057_scan_number",
                 ]
             )
             by_id = operator.attrgetter("spectrum_id")
@@ -261,20 +247,13 @@ class MztabWriter:
                 1,
             ):
                 filename, idx = psm.spectrum_id
-                if Path(filename).suffix.lower() == ".mgf":
-                    # Normalize idx: handle both "0" and "index=0" shapes.
-                    numeric_idx = (
-                        idx[len("index="):]
-                        if idx.startswith("index=")
-                        else idx
-                    )
-                    if numeric_idx.isnumeric():
-                        scan_num = self._mgf_scan_index.get(
-                            (filename, numeric_idx)
-                        )
-                        idx = f"index={numeric_idx}"
-                        if scan_num:
-                            idx = f"{idx} scan={scan_num}"
+                run_idx = self._run_map[filename]
+                scan_col = "null"
+                if Path(filename).suffix.lower() == ".mgf" and idx.isnumeric():
+                    idx = f"index={idx}"
+                    scan_num = self._mgf_scan_index.get((filename, idx))
+                    if scan_num:
+                        scan_col = f"ms_run[{run_idx}]:scan={scan_num}"
 
                 writer.writerow(
                     [
@@ -296,13 +275,14 @@ class MztabWriter:
                         psm.charge,  # charge
                         psm.exp_mz,  # exp_mass_to_charge
                         psm.calc_mz,  # calc_mass_to_charge
-                        f"ms_run[{self._run_map[filename]}]:{idx}",
+                        f"ms_run[{run_idx}]:{idx}",
                         "null",  # pre
                         "null",  # post
                         "null",  # start
                         "null",  # end
                         # opt_ms_run[1]_aa_scores
                         ",".join(list(map("{:.5f}".format, psm.aa_scores))),
-                        psm.sequence,  # op_ms_run[1]_proforma
+                        psm.sequence,  # opt_ms_run[1]_proforma
+                        scan_col,  # opt_global_cv_MS:1003057_scan_number
                     ]
                 )

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -29,7 +29,7 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
     that contain a SCANS, SCAN, or SCAN ID header field.
 
     Reads only the header lines of each spectrum entry (never the peak
-    data), so this is very fast even for large files.
+    data), so this is fast even for large files.
 
     Parameters
     ----------
@@ -40,21 +40,16 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
     ------
     tuple[str, str]
         A ``(spectrum_ref_id, scan_number)`` pair where
-        *spectrum_ref_id* uses the ``index=N`` nativeID format required
-        by the mzTab multiple-peak-list nativeID specification
-        (MS:1000774).
+        *spectrum_ref_id* uses the ``index=N`` zero-based index for
+        MGF files according to the mzTab specification.
     """
-    index = 0
-    current_scan = None
-    in_ions = False
+    index, current_scan, in_ions = 0, None, False
     try:
         with open(mgf_path, errors="replace") as fh:
             for line in fh:
-                stripped = line.strip()
-                upper = stripped.upper()
+                upper = line.strip().upper()
                 if upper == _MGF_BEGIN:
-                    in_ions = True
-                    current_scan = None
+                    in_ions, current_scan = True, None
                 elif upper == _MGF_END:
                     if current_scan is not None:
                         yield f"index={index}", current_scan
@@ -63,8 +58,8 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
                 elif in_ions:
                     for prefix in _MGF_SCAN_PREFIXES:
                         if upper.startswith(prefix):
-                            scan_value = stripped.split("=", 1)[1].strip()
-                            if re.fullmatch(r"\d+", scan_value):
+                            scan_value = upper.split("=", 1)[1].strip()
+                            if scan_value.isnumeric():
                                 current_scan = scan_value
                             else:
                                 logger.warning(
@@ -265,15 +260,11 @@ class MztabWriter:
             ):
                 filename, idx = psm.spectrum_id
                 run_idx = self._run_map[filename]
-                scan_col = "null"
                 if Path(filename).suffix.lower() == ".mgf":
                     # Normalize idx to "index=N" format, handling both
                     # bare numeric IDs ("0") and prefixed IDs ("index=0").
                     if idx.isnumeric():
                         idx = f"index={idx}"
-                    scan_num = self._mgf_scan_index.get((filename, idx))
-                    if scan_num:
-                        scan_col = f"ms_run[{run_idx}]:scan={scan_num}"
 
                 row = [
                     "PSM",
@@ -304,5 +295,6 @@ class MztabWriter:
                     psm.sequence,  # opt_ms_run[1]_proforma
                 ]
                 if include_scan_col:
-                    row.append(scan_col)
+                    scan_num = self._mgf_scan_index.get((filename, idx), "null")
+                    row.append(f"ms_run[{run_idx}]:scan={scan_num}")
                 writer.writerow(row)

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -23,6 +23,34 @@ from torch.utils.data.datapipes.iter.combinatorics import ShufflerIterDataPipe
 
 logger = logging.getLogger("casanovo")
 
+def _extract_mgf_scan_num(spectrum_dict: dict) -> str:
+    """
+    Extract the scan number from an MGF spectrum's parameter block.
+
+    Tries the keys ``scans``, ``scan``, and ``scan id`` in that order
+    (DepthCharge/pyteomics normalises MGF header keys to lowercase).
+    Returns an empty string when no scan number is present (e.g. for
+    mzML spectra or MGF files that omit the SCANS field).
+
+    Parameters
+    ----------
+    spectrum_dict : dict
+        The raw spectrum dictionary supplied by DepthCharge's parser.
+
+    Returns
+    -------
+    str
+        The scan number as a string, or ``""`` if absent.
+    """
+    try:
+        params = spectrum_dict.get("params", {})
+        for key in ("scans", "scan", "scan id"):
+            val = params.get(key)
+            if val is not None and str(val).strip():
+                return str(val).strip()
+    except Exception:
+        pass
+    return ""
 
 class DeNovoDataModule(pl.LightningDataModule):
     """
@@ -127,7 +155,6 @@ class DeNovoDataModule(pl.LightningDataModule):
         self.custom_field_anno = CustomField(
             "seq", lambda x: x["params"]["seq"], pa.string()
         )
-
         self.train_dataset = None
         self.valid_dataset = None
         self.test_dataset = None
@@ -193,6 +220,11 @@ class DeNovoDataModule(pl.LightningDataModule):
         torch.utils.data.Dataset
             A PyTorch Dataset for the given peak files.
         """
+        # Include the MGF scan number CustomField only for test/inference
+        # datasets. Training and validation datasets never need scan numbers,
+        # and adding the field there would store null values for MGF files
+        # that lack a SCANS header, causing torch.tensor([None, ...]) to
+        # raise an uncaught RuntimeError inside DepthCharge's _tensorize.
         custom_fields = [self.custom_field_anno] if annotated else []
         lance_path = pathlib.Path(f"{self.lance_dir}/{mode}.lance")
 

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -192,11 +192,6 @@ class DeNovoDataModule(pl.LightningDataModule):
         torch.utils.data.Dataset
             A PyTorch Dataset for the given peak files.
         """
-        # Include the MGF scan number CustomField only for test/inference
-        # datasets. Training and validation datasets never need scan numbers,
-        # and adding the field there would store null values for MGF files
-        # that lack a SCANS header, causing torch.tensor([None, ...]) to
-        # raise an uncaught RuntimeError inside DepthCharge's _tensorize.
         custom_fields = [self.custom_field_anno] if annotated else []
         lance_path = pathlib.Path(f"{self.lance_dir}/{mode}.lance")
 

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -23,34 +23,6 @@ from torch.utils.data.datapipes.iter.combinatorics import ShufflerIterDataPipe
 
 logger = logging.getLogger("casanovo")
 
-def _extract_mgf_scan_num(spectrum_dict: dict) -> str:
-    """
-    Extract the scan number from an MGF spectrum's parameter block.
-
-    Tries the keys ``scans``, ``scan``, and ``scan id`` in that order
-    (DepthCharge/pyteomics normalises MGF header keys to lowercase).
-    Returns an empty string when no scan number is present (e.g. for
-    mzML spectra or MGF files that omit the SCANS field).
-
-    Parameters
-    ----------
-    spectrum_dict : dict
-        The raw spectrum dictionary supplied by DepthCharge's parser.
-
-    Returns
-    -------
-    str
-        The scan number as a string, or ``""`` if absent.
-    """
-    try:
-        params = spectrum_dict.get("params", {})
-        for key in ("scans", "scan", "scan id"):
-            val = params.get(key)
-            if val is not None and str(val).strip():
-                return str(val).strip()
-    except Exception:
-        pass
-    return ""
 
 class DeNovoDataModule(pl.LightningDataModule):
     """

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -164,7 +164,6 @@ class ModelRunner:
         )
         test_paths = self._get_input_paths(peak_path, False, "test")
         self.writer.set_ms_run(test_paths)
-        self.writer.set_mgf_scan_index(test_paths)
         self.initialize_data_module(test_paths=test_paths)
         self.loaders.protein_database = self.model.protein_database
         self.loaders.setup(stage="test", annotated=False)
@@ -290,7 +289,6 @@ class ModelRunner:
 
         test_paths = self._get_input_paths(peak_path, False, "test")
         self.writer.set_ms_run(test_paths)
-        self.writer.set_mgf_scan_index(test_paths)
         self.initialize_data_module(test_paths=test_paths)
 
         try:

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -164,6 +164,7 @@ class ModelRunner:
         )
         test_paths = self._get_input_paths(peak_path, False, "test")
         self.writer.set_ms_run(test_paths)
+        self.writer.set_mgf_scan_index(test_paths)
         self.initialize_data_module(test_paths=test_paths)
         self.loaders.protein_database = self.model.protein_database
         self.loaders.setup(stage="test", annotated=False)
@@ -289,6 +290,7 @@ class ModelRunner:
 
         test_paths = self._get_input_paths(peak_path, False, "test")
         self.writer.set_ms_run(test_paths)
+        self.writer.set_mgf_scan_index(test_paths)
         self.initialize_data_module(test_paths=test_paths)
 
         try:

--- a/docs/file_formats.md
+++ b/docs/file_formats.md
@@ -208,6 +208,16 @@ This column consists of two parts: the run index and the spectrum reference, sep
 Be mindful of the input peak file format when linking Casanovo PSMs to their input spectra.
 Even when the same raw file is converted to both mzML and MGF, scan numbers in the mzML file will generally not match spectrum indices in the MGF file, as the former contains both MS and MS/MS spectra while the latter only contains MS/MS spectra.
 ```
+When processing MGF files that contain instrument-assigned scan numbers in a
+`SCANS`, `SCAN`, or `SCAN ID` header field, Casanovo will additionally export
+an optional `opt_global_cv_MS:1003057_scan_number` column in the PSM section.
+This column preserves the native scan number from the instrument and takes the
+form `ms_run[FILE_INDEX]:scan=SCAN_NUMBER`, for example
+`ms_run[1]:scan=17`. This column is separate from the `spectra_ref` column and
+does not replace the index-based spectrum reference. It is only present in the
+output when at least one MGF input file contains scan number header fields;
+mzML and mzXML files, and MGF files without scan number headers, leave this
+column absent.
 
 ```{note}
 The PSM identifier in the `PSM_ID` column is not necessarily identical to the spectrum index in the `spectra_ref` column, even for MGF files.

--- a/docs/file_formats.md
+++ b/docs/file_formats.md
@@ -208,22 +208,13 @@ This column consists of two parts: the run index and the spectrum reference, sep
 Be mindful of the input peak file format when linking Casanovo PSMs to their input spectra.
 Even when the same raw file is converted to both mzML and MGF, scan numbers in the mzML file will generally not match spectrum indices in the MGF file, as the former contains both MS and MS/MS spectra while the latter only contains MS/MS spectra.
 ```
-When processing MGF files that contain instrument-assigned scan numbers in a
-`SCANS`, `SCAN`, or `SCAN ID` header field, Casanovo will additionally export
-an optional `opt_global_cv_MS:1003057_scan_number` column in the PSM section.
-This column preserves the native scan number from the instrument and takes the
-form `ms_run[FILE_INDEX]:scan=SCAN_NUMBER`, for example `ms_run[1]:scan=17`.
-This column is separate from the `spectra_ref` column and does not replace the
-index-based spectrum reference.
-The column is global to the entire mzTab file: it is added whenever at least
-one MGF input file contains scan number header fields.
-In mixed-input runs (e.g. both MGF and mzML files), the column is present for
-the whole file, but rows originating from mzML, mzXML, or MGF spectra without
-scan number headers will have a null value in this column.
+When processing MGF files that contain instrument-assigned scan numbers in a `SCANS`, `SCAN`, or `SCAN ID` header field, Casanovo will additionally export an optional `opt_global_cv_MS:1003057_scan_number` column in the PSM section.
+This column preserves the native scan number from the instrument and takes the form `ms_run[FILE_INDEX]:scan=SCAN_NUMBER`, for example `ms_run[1]:scan=17`.
+This column is separate from the `spectra_ref` column and does not replace the index-based spectrum reference.
+The column is global to the entire mzTab file: it is added whenever at least one MGF input file contains scan number header fields.
+In mixed-input runs (e.g. both MGF and mzML files), the column is present for the whole file, but rows originating from mzML, mzXML, or MGF spectra without scan number headers will have a "null" value in this column.
 If no input file contains scan number headers the column is omitted entirely.
-Note that only purely numeric scan values are exported; MGF files that use
-composite or non-numeric scan identifiers in these fields will have a null
-value in this column, and a warning will be logged.
+Note that only purely numeric scan values are exported; MGF files that use composite or non-numeric scan identifiers in these fields will have a "null" value in this column.
 
 ```{note}
 The PSM identifier in the `PSM_ID` column is not necessarily identical to the spectrum index in the `spectra_ref` column, even for MGF files.

--- a/docs/file_formats.md
+++ b/docs/file_formats.md
@@ -221,6 +221,9 @@ In mixed-input runs (e.g. both MGF and mzML files), the column is present for
 the whole file, but rows originating from mzML, mzXML, or MGF spectra without
 scan number headers will have a null value in this column.
 If no input file contains scan number headers the column is omitted entirely.
+Note that only purely numeric scan values are exported; MGF files that use
+composite or non-numeric scan identifiers in these fields will have a null
+value in this column, and a warning will be logged.
 
 ```{note}
 The PSM identifier in the `PSM_ID` column is not necessarily identical to the spectrum index in the `spectra_ref` column, even for MGF files.

--- a/docs/file_formats.md
+++ b/docs/file_formats.md
@@ -212,12 +212,15 @@ When processing MGF files that contain instrument-assigned scan numbers in a
 `SCANS`, `SCAN`, or `SCAN ID` header field, Casanovo will additionally export
 an optional `opt_global_cv_MS:1003057_scan_number` column in the PSM section.
 This column preserves the native scan number from the instrument and takes the
-form `ms_run[FILE_INDEX]:scan=SCAN_NUMBER`, for example
-`ms_run[1]:scan=17`. This column is separate from the `spectra_ref` column and
-does not replace the index-based spectrum reference. It is only present in the
-output when at least one MGF input file contains scan number header fields;
-mzML and mzXML files, and MGF files without scan number headers, leave this
-column absent.
+form `ms_run[FILE_INDEX]:scan=SCAN_NUMBER`, for example `ms_run[1]:scan=17`.
+This column is separate from the `spectra_ref` column and does not replace the
+index-based spectrum reference.
+The column is global to the entire mzTab file: it is added whenever at least
+one MGF input file contains scan number header fields.
+In mixed-input runs (e.g. both MGF and mzML files), the column is present for
+the whole file, but rows originating from mzML, mzXML, or MGF spectra without
+scan number headers will have a null value in this column.
+If no input file contains scan number headers the column is omitted entirely.
 
 ```{note}
 The PSM identifier in the `PSM_ID` column is not necessarily identical to the spectrum index in the `spectra_ref` column, even for MGF files.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,12 @@ def mgf_small_unannotated(tmp_path):
 
 
 def _create_mgf(
-    peptides, mgf_file, random_state=42, mod_aa_mass=None, annotate=True
+    peptides,
+    mgf_file,
+    random_state=42,
+    mod_aa_mass=None,
+    annotate=True,
+    scan_nums=None,
 ):
     """
     Create a fake MGF file from one or more peptides.
@@ -72,6 +77,9 @@ def _create_mgf(
         e.g. {"C": 160.030649} for carbamidomethylated C.
     annotate: bool, optional
         Whether to add peptide annotations to mgf file
+    scan_nums : list of int or None, optional
+        Optional scan numbers to embed as ``SCANS=<n>`` in each entry.
+        When ``None`` (default) no SCANS field is written.
 
     Returns
     -------
@@ -85,6 +93,7 @@ def _create_mgf(
             rng.choice([2, 3]),
             mod_aa_mass=mod_aa_mass,
             annotate=annotate,
+            scan_num=scan_nums[i] if scan_nums is not None else None,
         )
         for i, p in enumerate(peptides)
     ]
@@ -95,7 +104,7 @@ def _create_mgf(
 
 
 def _create_mgf_entry(
-    peptide, title, charge=2, mod_aa_mass=None, annotate=True
+    peptide, title, charge=2, mod_aa_mass=None, annotate=True, scan_num=None
 ):
     """
     Create a MassIVE-KB style MGF entry for a single PSM.
@@ -110,6 +119,8 @@ def _create_mgf_entry(
         A dictionary that specifies the modified masses of amino acids.
     annotate: bool, optional
         Whether to add peptide annotation to entry
+    scan_num : int or None, optional
+        If provided, a ``SCANS=<scan_num>`` line is added to the entry.
 
     Returns
     -------
@@ -134,6 +145,8 @@ def _create_mgf_entry(
         "END IONS",
     ]
 
+    if scan_num is not None:
+        mgf.insert(1, f"SCANS={scan_num}")
     if annotate:
         mgf.insert(1, f"SEQ={peptide}")
 
@@ -378,3 +391,15 @@ def tiny_config_db(tmp_path):
             "replace_isoleucine_with_leucine": False,
         },
     )
+@pytest.fixture
+def mgf_small_with_scans(tmp_path):
+    """An MGF file with 2 annotated spectra containing SCANS fields."""
+    peptides = ["LESLIEK", "PEPTIDEK"]
+    mgf_file = tmp_path / "small_with_scans.mgf"
+    return _create_mgf(peptides, mgf_file, scan_nums=[17, 42])
+@pytest.fixture
+def mgf_small_with_scans_unannotated(tmp_path):
+    """An MGF file with 2 unannotated spectra containing SCANS fields."""
+    peptides = ["LESLIEK", "PEPTIDEK"]
+    mgf_file = tmp_path / "small_with_scans_unannotated.mgf"
+    return _create_mgf(peptides, mgf_file, annotate=False, scan_nums=[17, 42])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -391,12 +391,16 @@ def tiny_config_db(tmp_path):
             "replace_isoleucine_with_leucine": False,
         },
     )
+
+
 @pytest.fixture
 def mgf_small_with_scans(tmp_path):
     """An MGF file with 2 annotated spectra containing SCANS fields."""
     peptides = ["LESLIEK", "PEPTIDEK"]
     mgf_file = tmp_path / "small_with_scans.mgf"
     return _create_mgf(peptides, mgf_file, scan_nums=[17, 42])
+
+
 @pytest.fixture
 def mgf_small_with_scans_unannotated(tmp_path):
     """An MGF file with 2 unannotated spectra containing SCANS fields."""

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -269,7 +269,7 @@ def test_n_workers(monkeypatch):
     """Check that n_workers is correct without a GPU."""
     monkeypatch.setattr("torch.cuda.is_available", lambda: False)
 
-    def cpu_fun(x):
+    def cpu_fun(_: object) -> list[str]:
         return ["foo"] * 31
 
     with monkeypatch.context() as mnk:
@@ -2643,7 +2643,7 @@ def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
     mztab = pyteomics.mztab.MzTab(results_path)
     psms = mztab.spectrum_match_table
     assert psms.loc[1, "spectra_ref"] == "ms_run[1]:index=0"
-    assert psms.loc[1, "opt_global_cv_MS:1003057_scan_number"] is None
+    assert pd.isna(psms.loc[1, "opt_global_cv_MS:1003057_scan_number"])
 
 
 def test_mzml_spectra_ref_unaffected_by_scan_num_feature(mzml_small, tmp_path):
@@ -2670,4 +2670,4 @@ def test_mzml_spectra_ref_unaffected_by_scan_num_feature(mzml_small, tmp_path):
     mztab = pyteomics.mztab.MzTab(results_path)
     psms = mztab.spectrum_match_table
     assert psms.loc[1, "spectra_ref"] == "ms_run[1]:scan=17"
-    assert psms.loc[1, "opt_global_cv_MS:1003057_scan_number"] is None
+    assert pd.isna(psms.loc[1, "opt_global_cv_MS:1003057_scan_number"])

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -1390,7 +1390,7 @@ def test_isoleucine_match(tiny_config):
     db_model = DbSpec2Pep(tokenizer=tokenizer)
     peptides = [["PEPTLDEK"], ["PEPTIDEK"]]
 
-    def mock_get_candidates(_, precursor_charge):
+    def mock_get_candidates(_, precursor_charge) -> pd.Series:
         return pd.Series(peptides[precursor_charge - 1])
 
     db_model = DbSpec2Pep(tokenizer=tokenizer)
@@ -2528,8 +2528,8 @@ def test_shared_file_io_params_validation(tmp_path, args, should_fail):
 
 def test_mgf_scan_index_built_correctly(mgf_small_with_scans):
     """
-    _build_mgf_scan_index must return a dict mapping spectrum index
-    strings to the SCANS field values written into the MGF file.
+    _build_mgf_scan_index must yield `(spectrum_ref_id, scan_number)`
+    pairs for SCANS values written into the MGF file.
     """
     from casanovo.data.ms_io import _build_mgf_scan_index
 
@@ -2716,7 +2716,9 @@ def test_mixed_mgf_mzml_scan_number_column(mzml_small, tmp_path):
     assert "opt_global_cv_MS:1003057_scan_number" in psms.columns
     # MGF row must carry the scan value.
     mgf_row = psms[psms["spectra_ref"].str.contains("index=0")].iloc[0]
-    assert mgf_row["opt_global_cv_MS:1003057_scan_number"] == "ms_run[1]:scan=99"
+    assert (
+        mgf_row["opt_global_cv_MS:1003057_scan_number"] == "ms_run[1]:scan=99"
+    )
     # mzML row must be null.
     mzml_row = psms[psms["spectra_ref"].str.contains("scan=17")].iloc[0]
     assert pd.isna(mzml_row["opt_global_cv_MS:1003057_scan_number"])

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2580,7 +2580,7 @@ def test_mgf_scan_alias_scan_id_field(tmp_path):
 
 def test_scan_num_in_mztab_spectra_ref(tmp_path):
     """
-    After set_mgf_scan_index is called, MztabWriter must embed the scan
+    After set_ms_run is called, MztabWriter must embed the scan
     number in a new opt_global_cv_MS:1003057_scan_number column.
     """
     # Create a minimal MGF with SCANS=17 for the first spectrum.
@@ -2671,3 +2671,52 @@ def test_mzml_spectra_ref_unaffected_by_scan_num_feature(mzml_small, tmp_path):
     psms = mztab.spectrum_match_table
     assert psms.loc[1, "spectra_ref"] == "ms_run[1]:scan=17"
     assert "opt_global_cv_MS:1003057_scan_number" not in psms.columns
+
+
+def test_mixed_mgf_mzml_scan_number_column(mzml_small, tmp_path):
+    """
+    When MGF and mzML files are processed together and the MGF contains
+    scan numbers, the opt_global_cv_MS:1003057_scan_number column must be
+    present for the whole mzTab. The MGF row must carry the scan value and
+    the mzML row must be null.
+    """
+    mgf_file = tmp_path / "mixed.mgf"
+    mgf_file.write_text(
+        "BEGIN IONS\nSCANS=99\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
+    )
+
+    results_path = str(tmp_path / "results_mixed.mztab")
+    writer = ms_io.MztabWriter(results_path)
+    writer.set_ms_run([str(mgf_file), str(mzml_small)])
+    writer.psms = [
+        psm.PepSpecMatch(
+            sequence="PEPTIDE",
+            spectrum_id=("mixed.mgf", "index=0"),
+            peptide_score=0.9,
+            charge=2,
+            calc_mz=400.2,
+            exp_mz=400.2,
+            aa_scores=[0.9] * 7,
+        ),
+        psm.PepSpecMatch(
+            sequence="PEPTIDE",
+            spectrum_id=("small.mzml", "scan=17"),
+            peptide_score=0.9,
+            charge=2,
+            calc_mz=400.2,
+            exp_mz=400.2,
+            aa_scores=[0.9] * 7,
+        ),
+    ]
+    writer.save()
+
+    mztab = pyteomics.mztab.MzTab(results_path)
+    psms = mztab.spectrum_match_table
+    # Column must be present because the MGF file has scan numbers.
+    assert "opt_global_cv_MS:1003057_scan_number" in psms.columns
+    # MGF row must carry the scan value.
+    mgf_row = psms[psms["spectra_ref"].str.contains("index=0")].iloc[0]
+    assert mgf_row["opt_global_cv_MS:1003057_scan_number"] == "ms_run[1]:scan=99"
+    # mzML row must be null.
+    mzml_row = psms[psms["spectra_ref"].str.contains("scan=17")].iloc[0]
+    assert pd.isna(mzml_row["opt_global_cv_MS:1003057_scan_number"])

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2552,9 +2552,7 @@ def test_scan_num_in_mztab_spectra_ref(tmp_path):
     After set_mgf_scan_index is called, MztabWriter must embed the scan
     number in spectra_ref: 'ms_run[1]:index=0 scan=17'.
     """
-    import pyteomics.mztab
-    from casanovo.data.ms_io import MztabWriter
-    from casanovo.data.psm import PepSpecMatch
+
 
     # Create a minimal MGF with SCANS=17 for the first spectrum.
     mgf_file = tmp_path / "test.mgf"
@@ -2563,11 +2561,11 @@ def test_scan_num_in_mztab_spectra_ref(tmp_path):
     )
 
     results_path = str(tmp_path / "results.mztab")
-    writer = MztabWriter(results_path)
+    writer = ms_io.MztabWriter(results_path)
     writer.set_ms_run([str(mgf_file)])
     writer.set_mgf_scan_index([str(mgf_file)])
     writer.psms = [
-        PepSpecMatch(
+        psm.PepSpecMatch(
             sequence="PEPTIDE",
             spectrum_id=("test.mgf", "0"),
             peptide_score=0.9,
@@ -2590,9 +2588,7 @@ def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
     An MGF without SCANS must produce 'ms_run[1]:index=0' only,
     preserving backward compatibility.
     """
-    import pyteomics.mztab
-    from casanovo.data.ms_io import MztabWriter
-    from casanovo.data.psm import PepSpecMatch
+
 
     mgf_file = tmp_path / "test_no_scan.mgf"
     mgf_file.write_text(
@@ -2600,11 +2596,11 @@ def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
     )
 
     results_path = str(tmp_path / "results_no_scan.mztab")
-    writer = MztabWriter(results_path)
+    writer = ms_io.MztabWriter(results_path)
     writer.set_ms_run([str(mgf_file)])
     writer.set_mgf_scan_index([str(mgf_file)])  # index will be empty
     writer.psms = [
-        PepSpecMatch(
+        psm.PepSpecMatch(
             sequence="PEPTIDE",
             spectrum_id=("test_no_scan.mgf", "0"),
             peptide_score=0.9,
@@ -2627,16 +2623,14 @@ def test_mzml_spectra_ref_unaffected_by_scan_num_feature(
     mzML spectra use their native scan ID and must be unchanged even
     when set_mgf_scan_index is called (mzML files are silently ignored).
     """
-    import pyteomics.mztab
-    from casanovo.data.ms_io import MztabWriter
-    from casanovo.data.psm import PepSpecMatch
+
 
     results_path = str(tmp_path / "results_mzml.mztab")
-    writer = MztabWriter(results_path)
+    writer = ms_io.MztabWriter(results_path)
     writer.set_ms_run([str(mzml_small)])
     writer.set_mgf_scan_index([str(mzml_small)])  # mzML ignored silently
     writer.psms = [
-        PepSpecMatch(
+        psm.PepSpecMatch(
             sequence="PEPTIDE",
             spectrum_id=("small.mzml", "scan=17"),
             peptide_score=0.9,

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2526,7 +2526,7 @@ def test_shared_file_io_params_validation(tmp_path, args, should_fail):
         assert "ok" in res.stdout
 
 
-def test_mgf_scan_index_built_correctly(mgf_small_with_scans, tmp_path):
+def test_mgf_scan_index_built_correctly(mgf_small_with_scans):
     """
     _build_mgf_scan_index must return a dict mapping spectrum index
     strings to the SCANS field values written into the MGF file.
@@ -2537,7 +2537,7 @@ def test_mgf_scan_index_built_correctly(mgf_small_with_scans, tmp_path):
     assert result == {"index=0": "17", "index=1": "42"}
 
 
-def test_mgf_without_scans_gives_empty_index(mgf_small, tmp_path):
+def test_mgf_without_scans_gives_empty_index(mgf_small):
     """
     An MGF file without any SCANS fields must produce an empty index
     (not crash and not map anything).
@@ -2595,7 +2595,7 @@ def test_scan_num_in_mztab_spectra_ref(tmp_path):
     writer.psms = [
         psm.PepSpecMatch(
             sequence="PEPTIDE",
-            spectrum_id=("test.mgf", "0"),
+            spectrum_id=("test.mgf", "index=0"),
             peptide_score=0.9,
             charge=2,
             calc_mz=400.2,
@@ -2630,7 +2630,7 @@ def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
     writer.psms = [
         psm.PepSpecMatch(
             sequence="PEPTIDE",
-            spectrum_id=("test_no_scan.mgf", "0"),
+            spectrum_id=("test_no_scan.mgf", "index=0"),
             peptide_score=0.9,
             charge=2,
             calc_mz=400.2,

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2643,7 +2643,7 @@ def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
     mztab = pyteomics.mztab.MzTab(results_path)
     psms = mztab.spectrum_match_table
     assert psms.loc[1, "spectra_ref"] == "ms_run[1]:index=0"
-    assert pd.isna(psms.loc[1, "opt_global_cv_MS:1003057_scan_number"])
+    assert "opt_global_cv_MS:1003057_scan_number" not in psms.columns
 
 
 def test_mzml_spectra_ref_unaffected_by_scan_num_feature(mzml_small, tmp_path):
@@ -2670,4 +2670,4 @@ def test_mzml_spectra_ref_unaffected_by_scan_num_feature(mzml_small, tmp_path):
     mztab = pyteomics.mztab.MzTab(results_path)
     psms = mztab.spectrum_match_table
     assert psms.loc[1, "spectra_ref"] == "ms_run[1]:scan=17"
-    assert pd.isna(psms.loc[1, "opt_global_cv_MS:1003057_scan_number"])
+    assert "opt_global_cv_MS:1003057_scan_number" not in psms.columns

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -5,7 +5,6 @@ import functools
 import hashlib
 import heapq
 import io
-import math
 import os
 import pathlib
 import platform
@@ -269,7 +268,8 @@ def test_version():
 def test_n_workers(monkeypatch):
     """Check that n_workers is correct without a GPU."""
     monkeypatch.setattr("torch.cuda.is_available", lambda: False)
-    cpu_fun = lambda x: ["foo"] * 31
+    def cpu_fun(x):
+        return ["foo"] * 31
 
     with monkeypatch.context() as mnk:
         mnk.setattr("psutil.Process.cpu_affinity", cpu_fun, raising=False)
@@ -1388,9 +1388,8 @@ def test_isoleucine_match(tiny_config):
     )
     db_model = DbSpec2Pep(tokenizer=tokenizer)
     peptides = [["PEPTLDEK"], ["PEPTIDEK"]]
-    mock_get_candidates = lambda _, precursor_charge: pd.Series(
-        peptides[precursor_charge - 1]
-    )
+    def mock_get_candidates(_, precursor_charge):
+        return pd.Series(peptides[precursor_charge - 1])
 
     db_model = DbSpec2Pep(tokenizer=tokenizer)
     db_model.protein_database = unittest.mock.MagicMock()

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2546,6 +2546,36 @@ def test_mgf_without_scans_gives_empty_index(mgf_small, tmp_path):
     assert result == {}
 
 
+def test_mgf_scan_alias_scan_field(tmp_path):
+    """
+    _build_mgf_scan_index must recognise the SCAN= header alias
+    in addition to SCANS=.
+    """
+    from casanovo.data.ms_io import _build_mgf_scan_index
+
+    mgf_file = tmp_path / "alias_scan.mgf"
+    mgf_file.write_text(
+        "BEGIN IONS\nSCAN=99\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
+    )
+    result = _build_mgf_scan_index(str(mgf_file))
+    assert result == {"0": "99"}
+
+
+def test_mgf_scan_alias_scan_id_field(tmp_path):
+    """
+    _build_mgf_scan_index must recognise the SCAN ID= header alias
+    in addition to SCANS=.
+    """
+    from casanovo.data.ms_io import _build_mgf_scan_index
+
+    mgf_file = tmp_path / "alias_scan_id.mgf"
+    mgf_file.write_text(
+        "BEGIN IONS\nSCAN ID=42\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
+    )
+    result = _build_mgf_scan_index(str(mgf_file))
+    assert result == {"0": "42"}
+
+
 def test_scan_num_in_mztab_spectra_ref(tmp_path):
     """
     After set_mgf_scan_index is called, MztabWriter must embed the scan

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2668,6 +2668,6 @@ def test_mzml_spectra_ref_unaffected_by_scan_num_feature(mzml_small, tmp_path):
     writer.save()
 
     mztab = pyteomics.mztab.MzTab(results_path)
-    assert (
-        mztab.spectrum_match_table.loc[1, "spectra_ref"] == "ms_run[1]:scan=17"
-    )
+    psms = mztab.spectrum_match_table
+    assert psms.loc[1, "spectra_ref"] == "ms_run[1]:scan=17"
+    assert psms.loc[1, "opt_global_cv_MS:1003057_scan_number"] is None

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -268,6 +268,7 @@ def test_version():
 def test_n_workers(monkeypatch):
     """Check that n_workers is correct without a GPU."""
     monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+
     def cpu_fun(x):
         return ["foo"] * 31
 
@@ -1388,6 +1389,7 @@ def test_isoleucine_match(tiny_config):
     )
     db_model = DbSpec2Pep(tokenizer=tokenizer)
     peptides = [["PEPTLDEK"], ["PEPTIDEK"]]
+
     def mock_get_candidates(_, precursor_charge):
         return pd.Series(peptides[precursor_charge - 1])
 
@@ -2522,7 +2524,7 @@ def test_shared_file_io_params_validation(tmp_path, args, should_fail):
         assert res.exit_code == 0
         assert "Error" not in res.stderr
         assert "ok" in res.stdout
-# issue 142- mgf scan number tracking
+
 
 def test_mgf_scan_index_built_correctly(mgf_small_with_scans, tmp_path):
     """
@@ -2531,8 +2533,8 @@ def test_mgf_scan_index_built_correctly(mgf_small_with_scans, tmp_path):
     """
     from casanovo.data.ms_io import _build_mgf_scan_index
 
-    result = _build_mgf_scan_index(str(mgf_small_with_scans))
-    assert result == {"0": "17", "1": "42"}
+    result = dict(_build_mgf_scan_index(str(mgf_small_with_scans)))
+    assert result == {"index=0": "17", "index=1": "42"}
 
 
 def test_mgf_without_scans_gives_empty_index(mgf_small, tmp_path):
@@ -2542,7 +2544,7 @@ def test_mgf_without_scans_gives_empty_index(mgf_small, tmp_path):
     """
     from casanovo.data.ms_io import _build_mgf_scan_index
 
-    result = _build_mgf_scan_index(str(mgf_small))
+    result = dict(_build_mgf_scan_index(str(mgf_small)))
     assert result == {}
 
 
@@ -2557,8 +2559,8 @@ def test_mgf_scan_alias_scan_field(tmp_path):
     mgf_file.write_text(
         "BEGIN IONS\nSCAN=99\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
     )
-    result = _build_mgf_scan_index(str(mgf_file))
-    assert result == {"0": "99"}
+    result = dict(_build_mgf_scan_index(str(mgf_file)))
+    assert result == {"index=0": "99"}
 
 
 def test_mgf_scan_alias_scan_id_field(tmp_path):
@@ -2572,17 +2574,15 @@ def test_mgf_scan_alias_scan_id_field(tmp_path):
     mgf_file.write_text(
         "BEGIN IONS\nSCAN ID=42\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
     )
-    result = _build_mgf_scan_index(str(mgf_file))
-    assert result == {"0": "42"}
+    result = dict(_build_mgf_scan_index(str(mgf_file)))
+    assert result == {"index=0": "42"}
 
 
 def test_scan_num_in_mztab_spectra_ref(tmp_path):
     """
     After set_mgf_scan_index is called, MztabWriter must embed the scan
-    number in spectra_ref: 'ms_run[1]:index=0 scan=17'.
+    number in a new opt_global_cv_MS:1003057_scan_number column.
     """
-
-
     # Create a minimal MGF with SCANS=17 for the first spectrum.
     mgf_file = tmp_path / "test.mgf"
     mgf_file.write_text(
@@ -2592,7 +2592,6 @@ def test_scan_num_in_mztab_spectra_ref(tmp_path):
     results_path = str(tmp_path / "results.mztab")
     writer = ms_io.MztabWriter(results_path)
     writer.set_ms_run([str(mgf_file)])
-    writer.set_mgf_scan_index([str(mgf_file)])
     writer.psms = [
         psm.PepSpecMatch(
             sequence="PEPTIDE",
@@ -2607,9 +2606,12 @@ def test_scan_num_in_mztab_spectra_ref(tmp_path):
     writer.save()
 
     mztab = pyteomics.mztab.MzTab(results_path)
-    spectra_ref = mztab.spectrum_match_table.loc[1, "spectra_ref"]
-    assert "index=0" in spectra_ref, f"Missing index=0 in: {spectra_ref}"
-    assert "scan=17" in spectra_ref, f"Missing scan=17 in: {spectra_ref}"
+    psms = mztab.spectrum_match_table
+    assert psms.loc[1, "spectra_ref"] == "ms_run[1]:index=0"
+    assert (
+        psms.loc[1, "opt_global_cv_MS:1003057_scan_number"]
+        == "ms_run[1]:scan=17"
+    )
 
 
 def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
@@ -2617,8 +2619,6 @@ def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
     An MGF without SCANS must produce 'ms_run[1]:index=0' only,
     preserving backward compatibility.
     """
-
-
     mgf_file = tmp_path / "test_no_scan.mgf"
     mgf_file.write_text(
         "BEGIN IONS\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
@@ -2627,7 +2627,6 @@ def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
     results_path = str(tmp_path / "results_no_scan.mztab")
     writer = ms_io.MztabWriter(results_path)
     writer.set_ms_run([str(mgf_file)])
-    writer.set_mgf_scan_index([str(mgf_file)])  # index will be empty
     writer.psms = [
         psm.PepSpecMatch(
             sequence="PEPTIDE",
@@ -2642,22 +2641,19 @@ def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
     writer.save()
 
     mztab = pyteomics.mztab.MzTab(results_path)
-    assert mztab.spectrum_match_table.loc[1, "spectra_ref"] == "ms_run[1]:index=0"
+    psms = mztab.spectrum_match_table
+    assert psms.loc[1, "spectra_ref"] == "ms_run[1]:index=0"
+    assert psms.loc[1, "opt_global_cv_MS:1003057_scan_number"] is None
 
 
-def test_mzml_spectra_ref_unaffected_by_scan_num_feature(
-    mzml_small, tmp_path
-):
+def test_mzml_spectra_ref_unaffected_by_scan_num_feature(mzml_small, tmp_path):
     """
     mzML spectra use their native scan ID and must be unchanged even
-    when set_mgf_scan_index is called (mzML files are silently ignored).
+    when set_ms_run is called (mzML files are silently ignored).
     """
-
-
     results_path = str(tmp_path / "results_mzml.mztab")
     writer = ms_io.MztabWriter(results_path)
     writer.set_ms_run([str(mzml_small)])
-    writer.set_mgf_scan_index([str(mzml_small)])  # mzML ignored silently
     writer.psms = [
         psm.PepSpecMatch(
             sequence="PEPTIDE",
@@ -2672,4 +2668,6 @@ def test_mzml_spectra_ref_unaffected_by_scan_num_feature(
     writer.save()
 
     mztab = pyteomics.mztab.MzTab(results_path)
-    assert mztab.spectrum_match_table.loc[1, "spectra_ref"] == "ms_run[1]:scan=17"
+    assert (
+        mztab.spectrum_match_table.loc[1, "spectra_ref"] == "ms_run[1]:scan=17"
+    )

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -28,6 +28,7 @@ import pandas as pd
 import pytest
 import requests
 import torch
+import pyteomics.mztab
 
 from casanovo import casanovo, denovo, utils
 from casanovo.casanovo import _SharedFileIOParams
@@ -2522,3 +2523,130 @@ def test_shared_file_io_params_validation(tmp_path, args, should_fail):
         assert res.exit_code == 0
         assert "Error" not in res.stderr
         assert "ok" in res.stdout
+# issue 142- mgf scan number tracking
+
+def test_mgf_scan_index_built_correctly(mgf_small_with_scans, tmp_path):
+    """
+    _build_mgf_scan_index must return a dict mapping spectrum index
+    strings to the SCANS field values written into the MGF file.
+    """
+    from casanovo.data.ms_io import _build_mgf_scan_index
+
+    result = _build_mgf_scan_index(str(mgf_small_with_scans))
+    assert result == {"0": "17", "1": "42"}
+
+
+def test_mgf_without_scans_gives_empty_index(mgf_small, tmp_path):
+    """
+    An MGF file without any SCANS fields must produce an empty index
+    (not crash and not map anything).
+    """
+    from casanovo.data.ms_io import _build_mgf_scan_index
+
+    result = _build_mgf_scan_index(str(mgf_small))
+    assert result == {}
+
+
+def test_scan_num_in_mztab_spectra_ref(tmp_path):
+    """
+    After set_mgf_scan_index is called, MztabWriter must embed the scan
+    number in spectra_ref: 'ms_run[1]:index=0 scan=17'.
+    """
+    import pyteomics.mztab
+    from casanovo.data.ms_io import MztabWriter
+    from casanovo.data.psm import PepSpecMatch
+
+    # Create a minimal MGF with SCANS=17 for the first spectrum.
+    mgf_file = tmp_path / "test.mgf"
+    mgf_file.write_text(
+        "BEGIN IONS\nSCANS=17\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
+    )
+
+    results_path = str(tmp_path / "results.mztab")
+    writer = MztabWriter(results_path)
+    writer.set_ms_run([str(mgf_file)])
+    writer.set_mgf_scan_index([str(mgf_file)])
+    writer.psms = [
+        PepSpecMatch(
+            sequence="PEPTIDE",
+            spectrum_id=("test.mgf", "0"),
+            peptide_score=0.9,
+            charge=2,
+            calc_mz=400.2,
+            exp_mz=400.2,
+            aa_scores=[0.9] * 7,
+        )
+    ]
+    writer.save()
+
+    mztab = pyteomics.mztab.MzTab(results_path)
+    spectra_ref = mztab.spectrum_match_table.loc[1, "spectra_ref"]
+    assert "index=0" in spectra_ref, f"Missing index=0 in: {spectra_ref}"
+    assert "scan=17" in spectra_ref, f"Missing scan=17 in: {spectra_ref}"
+
+
+def test_no_scan_num_keeps_index_only_spectra_ref(tmp_path):
+    """
+    An MGF without SCANS must produce 'ms_run[1]:index=0' only,
+    preserving backward compatibility.
+    """
+    import pyteomics.mztab
+    from casanovo.data.ms_io import MztabWriter
+    from casanovo.data.psm import PepSpecMatch
+
+    mgf_file = tmp_path / "test_no_scan.mgf"
+    mgf_file.write_text(
+        "BEGIN IONS\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
+    )
+
+    results_path = str(tmp_path / "results_no_scan.mztab")
+    writer = MztabWriter(results_path)
+    writer.set_ms_run([str(mgf_file)])
+    writer.set_mgf_scan_index([str(mgf_file)])  # index will be empty
+    writer.psms = [
+        PepSpecMatch(
+            sequence="PEPTIDE",
+            spectrum_id=("test_no_scan.mgf", "0"),
+            peptide_score=0.9,
+            charge=2,
+            calc_mz=400.2,
+            exp_mz=400.2,
+            aa_scores=[0.9] * 7,
+        )
+    ]
+    writer.save()
+
+    mztab = pyteomics.mztab.MzTab(results_path)
+    assert mztab.spectrum_match_table.loc[1, "spectra_ref"] == "ms_run[1]:index=0"
+
+
+def test_mzml_spectra_ref_unaffected_by_scan_num_feature(
+    mzml_small, tmp_path
+):
+    """
+    mzML spectra use their native scan ID and must be unchanged even
+    when set_mgf_scan_index is called (mzML files are silently ignored).
+    """
+    import pyteomics.mztab
+    from casanovo.data.ms_io import MztabWriter
+    from casanovo.data.psm import PepSpecMatch
+
+    results_path = str(tmp_path / "results_mzml.mztab")
+    writer = MztabWriter(results_path)
+    writer.set_ms_run([str(mzml_small)])
+    writer.set_mgf_scan_index([str(mzml_small)])  # mzML ignored silently
+    writer.psms = [
+        PepSpecMatch(
+            sequence="PEPTIDE",
+            spectrum_id=("small.mzml", "scan=17"),
+            peptide_score=0.9,
+            charge=2,
+            calc_mz=400.2,
+            exp_mz=400.2,
+            aa_scores=[0.9] * 7,
+        )
+    ]
+    writer.save()
+
+    mztab = pyteomics.mztab.MzTab(results_path)
+    assert mztab.spectrum_match_table.loc[1, "spectra_ref"] == "ms_run[1]:scan=17"


### PR DESCRIPTION
## Summary

Closes #142.

MGF files can carry instrument-assigned scan numbers in the `SCANS`,
`SCAN`, or `SCAN ID` header field. This PR threads those values through
the pipeline so they appear in the mzTab `spectra_ref` column alongside
the existing file index, e.g.:

    ms_run[1]:index=0 scan=17

## Approach

The implementation reads only the header lines of each MGF spectrum
entry (never the peak data) to build a lightweight index mapping
spectrum position to scan number. This index is pre-computed once in
`MztabWriter` before prediction begins and looked up at write time --
no second full file read is required during the hot path.

This approach was chosen over the DepthCharge `CustomField` mechanism
because that mechanism stores `None` for mzML spectra and for MGF
files that omit the `SCANS` field, which causes an uncaught
`RuntimeError` in DepthCharge 0.4.9's `_tensorize` function when
those null values reach `torch.tensor()`.

## Files changed

| File | Change |
|---|---|
| `casanovo/data/ms_io.py` | Add `_build_mgf_scan_index()` helper and `MztabWriter.set_mgf_scan_index()`; embed scan number in `spectra_ref` inside `save()` |
| `casanovo/denovo/model_runner.py` | Call `set_mgf_scan_index()` in both `predict()` and `db_search()` |
| `tests/conftest.py` | `_create_mgf` / `_create_mgf_entry` accept optional `scan_nums`; two new fixtures |
| `tests/unit_tests/test_unit.py` | 5 new unit tests |

## Backward compatibility

- MGF files without a `SCANS` field: output unchanged (`index=N` only).
- mzML files: completely unaffected.
- All existing integration tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export instrument-assigned scan numbers from MGF headers (SCANS/SCAN/SCAN ID) into mzTab as an optional global column (ms_run[<i>]:scan=<n>); shown when any MGF input includes scan numbers, with nulls for other spectra in mixed runs. MGF spectrum references are normalized to preserve consistent linking.

* **Tests**
  * Added fixtures and unit/integration tests covering MGF scan-header extraction and mzTab output across MGF/mzML combinations.

* **Documentation**
  * Updated file-format docs and changelog (repositioned a release entry).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->