### PR TITLE
feat: handled config options with Hydra/OmegaConf (Compose API) #545

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -1,12 +1,14 @@
-"""Parse the YAML configuration."""
+"""Parse the YAML configuration using OmegaConf."""
 
 import logging
 import shutil
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-import yaml
+from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
+from omegaconf.errors import ConfigAttributeError as OmegaConfAttributeError
 
 from . import utils
 
@@ -26,186 +28,223 @@ _config_deprecated = dict(
 )
 
 
+@dataclass
+class CasanovoConfig:
+    """Typed schema for Casanovo configuration parameters.
+
+    This dataclass defines the expected names and types for every
+    Casanovo configuration option. OmegaConf uses it as a *structured
+    config* schema so that type mismatches in a loaded YAML file are
+    caught at merge time rather than deep inside the model.
+
+    Actual default values are stored in ``config.yaml``; fields here
+    are marked ``MISSING`` so that the schema acts as a type contract
+    rather than duplicating defaults.
+    """
+
+    # Inference / fine-tuning
+    precursor_mass_tol: float = MISSING
+    isotope_error_range: List[int] = MISSING
+    min_peptide_len: int = MISSING
+    max_peptide_len: int = MISSING
+    predict_batch_size: int = MISSING
+    top_match: int = MISSING
+    accelerator: str = MISSING
+    devices: Optional[int] = None
+    n_beams: int = MISSING
+    # Database search
+    enzyme: str = MISSING
+    digestion: str = MISSING
+    missed_cleavages: int = MISSING
+    max_mods: Optional[int] = None
+    allowed_fixed_mods: str = MISSING
+    allowed_var_mods: str = MISSING
+    # Training – output
+    random_seed: int = MISSING
+    n_log: int = MISSING
+    tb_summarywriter: bool = MISSING
+    log_metrics: bool = MISSING
+    log_every_n_steps: int = MISSING
+    lance_dir: Optional[str] = None
+    val_check_interval: int = MISSING
+    # Spectrum processing
+    min_peaks: int = MISSING
+    max_peaks: int = MISSING
+    min_mz: float = MISSING
+    max_mz: float = MISSING
+    min_intensity: float = MISSING
+    remove_precursor_tol: float = MISSING
+    max_charge: int = MISSING
+    # Model architecture
+    dim_model: int = MISSING
+    n_head: int = MISSING
+    dim_feedforward: int = MISSING
+    n_layers: int = MISSING
+    dropout: float = MISSING
+    dim_intensity: Optional[int] = None
+    # Optimiser / scheduler
+    warmup_iters: int = MISSING
+    cosine_schedule_period_iters: int = MISSING
+    learning_rate: float = MISSING
+    weight_decay: float = MISSING
+    train_label_smoothing: float = MISSING
+    # Training / inference options
+    train_batch_size: int = MISSING
+    max_epochs: int = MISSING
+    shuffle: bool = MISSING
+    shuffle_buffer_size: int = MISSING
+    num_sanity_val_steps: int = MISSING
+    calculate_precision: bool = MISSING
+    accumulate_grad_batches: int = MISSING
+    gradient_clip_val: Optional[float] = None
+    gradient_clip_algorithm: Optional[str] = None
+    precision: str = MISSING
+    replace_isoleucine_with_leucine: bool = MISSING
+    massivekb_tokenizer: bool = MISSING
+    # Amino acid / modification vocabulary
+    residues: Dict[str, float] = MISSING
+    # Token initialization mapping for fine-tuning with extended vocabularies.
+    new_token_init: Dict[str, str] = MISSING
+
+
 class Config:
     """
     The Casanovo configuration options.
 
-    If a parameter is missing from a user's configuration file, the
-    default value is assumed.
+    Loads and merges YAML configuration using OmegaConf. The
+    :class:`CasanovoConfig` dataclass provides a typed schema; actual
+    default values are read from ``config.yaml``. User-supplied
+    configuration files are merged on top of these defaults, so
+    **partial override files are fully supported** — only the keys you
+    want to change need to be present.
+
+    Type mismatches (e.g. a string where a float is expected) are
+    caught at load time by OmegaConf's structured-config validation.
+    Unknown configuration keys raise a ``KeyError``.
 
     Parameters
     ----------
     config_file : str, optional
-        The provided user configuration file.
+        Path to a user YAML configuration file. If ``None``, the
+        built-in defaults from ``config.yaml`` are used.
 
     Examples
     --------
-    ```
     config = Config("casanovo.yaml")
     config.max_peaks    # the max_peaks parameter
     config["max_peaks"] # also the max_peaks parameter
-    ```
     """
 
     _default_config = Path(__file__).parent / "config.yaml"
-    _config_types = dict(
-        precursor_mass_tol=float,
-        isotope_error_range=lambda min_max: (int(min_max[0]), int(min_max[1])),
-        min_peptide_len=int,
-        max_peptide_len=int,
-        predict_batch_size=int,
-        top_match=int,
-        accelerator=str,
-        devices=int,
-        n_beams=int,
-        enzyme=str,
-        digestion=str,
-        missed_cleavages=int,
-        max_mods=int,
-        allowed_fixed_mods=str,
-        allowed_var_mods=str,
-        random_seed=int,
-        n_log=int,
-        tb_summarywriter=bool,
-        log_metrics=bool,
-        log_every_n_steps=int,
-        lance_dir=str,
-        val_check_interval=int,
-        min_peaks=int,
-        max_peaks=int,
-        min_mz=float,
-        max_mz=float,
-        min_intensity=float,
-        remove_precursor_tol=float,
-        max_charge=int,
-        dim_model=int,
-        n_head=int,
-        dim_feedforward=int,
-        n_layers=int,
-        dropout=float,
-        dim_intensity=int,
-        warmup_iters=int,
-        cosine_schedule_period_iters=int,
-        learning_rate=float,
-        weight_decay=float,
-        train_label_smoothing=float,
-        train_batch_size=int,
-        max_epochs=int,
-        shuffle=bool,
-        shuffle_buffer_size=int,
-        num_sanity_val_steps=int,
-        calculate_precision=bool,
-        accumulate_grad_batches=int,
-        gradient_clip_val=float,
-        gradient_clip_algorithm=str,
-        precision=str,
-        replace_isoleucine_with_leucine=bool,
-        massivekb_tokenizer=bool,
-        residues=dict,
-        new_token_init=dict,
-    )
 
     def __init__(self, config_file: Optional[str] = None):
         """Initialize a Config object."""
         self.file = str(config_file) if config_file is not None else "default"
-        with self._default_config.open() as f_in:
-            self._params = yaml.safe_load(f_in)
+
+        # Build a typed, struct-mode schema from the dataclass, then
+        # populate it with the defaults from config.yaml.
+        schema = OmegaConf.structured(CasanovoConfig)
+        default_cfg = OmegaConf.load(self._default_config)
+        base = OmegaConf.merge(schema, default_cfg)
 
         if config_file is None:
-            self._user_config = {}
+            self._cfg = base
         else:
-            with Path(config_file).open() as f_in:
-                self._user_config = yaml.safe_load(f_in)
-                # Remap deprecated config entries.
-                for old, new in _config_deprecated.items():
-                    if old in self._user_config:
-                        if new is not None:
-                            self._user_config[new] = self._user_config.pop(old)
+            user_cfg = OmegaConf.load(config_file)
+            if not isinstance(user_cfg, DictConfig):
+                raise TypeError(
+                    f"Config file {config_file!r} must contain a YAML "
+                    f"mapping, got {type(user_cfg).__name__}"
+                )
+
+            # Remap deprecated config entries directly on the OmegaConf
+            # object (user_cfg is non-struct, so keys can be mutated).
+            for old, new in _config_deprecated.items():
+                if old in user_cfg:
+                    if new is not None:
+                        if new in user_cfg:
+                            # Both deprecated key and its replacement are
+                            # present. Keep the replacement value and
+                            # discard the deprecated key so it cannot
+                            # silently overwrite the user's explicit value.
+                            del user_cfg[old]
+                            warning_msg = (
+                                f"Deprecated config option '{old}' "
+                                f"ignored; '{new}' is already set"
+                            )
+                        else:
+                            val = user_cfg[old]
+                            del user_cfg[old]
+                            user_cfg[new] = val
                             warning_msg = (
                                 f"Deprecated config option '{old}' "
                                 f"remapped to '{new}'"
                             )
-                        else:
-                            del self._user_config[old]
-                            warning_msg = (
-                                f"Deprecated config option '{old}' "
-                                "is no longer in use"
-                            )
-
-                        warnings.warn(warning_msg, DeprecationWarning)
-                # Check for missing entries in config file.
-                config_missing = self._params.keys() - self._user_config.keys()
-                if len(config_missing) > 0:
-                    raise KeyError(
-                        "Missing expected config option(s): "
-                        f"{', '.join(config_missing)}"
+                    else:
+                        del user_cfg[old]
+                        warning_msg = (
+                            f"Deprecated config option '{old}' "
+                            "is no longer in use"
+                        )
+                    warnings.warn(
+                        warning_msg, DeprecationWarning, stacklevel=2
                     )
-                # Check for unrecognized config file entries.
-                config_unknown = self._user_config.keys() - self._params.keys()
-                if len(config_unknown) > 0:
-                    raise KeyError(
-                        "Unrecognized config option(s): "
-                        f"{', '.join(config_unknown)}"
-                    )
-        # Validate.
-        for key, val in self._config_types.items():
-            self.validate_param(key, val)
 
-        self._params["n_workers"] = utils.n_workers()
+            # Merge user overrides on top of the schema-validated base.
+            # The struct-mode base causes OmegaConf to raise
+            # ConfigAttributeError for any key not present in the schema.
+            try:
+                self._cfg = OmegaConf.merge(base, user_cfg)
+            except OmegaConfAttributeError as e:
+                raise KeyError(f"Unrecognized config option(s): {e}") from e
 
-        if self._params["accelerator"] == "auto" and utils.is_apple_silicon():
-            self._params["accelerator"] = "cpu"
+        # Allow adding runtime-computed keys not defined in the schema
+        # (e.g. n_workers).
+        OmegaConf.set_struct(self._cfg, False)
+        self._cfg.n_workers = utils.n_workers()
+
+        if self._cfg.accelerator == "auto" and utils.is_apple_silicon():
+            self._cfg.accelerator = "cpu"
             logger.warning(
-                "accelerator='auto' will be overwritten to 'cpu' on Apple Silicon"
-                " devices due to incompatibility with MPS accelerators.\n"
-                "Note: If you want to use a different accelerator (other than MPS),"
-                " please specify it explicitly in the config file."
+                "accelerator='auto' will be overwritten to 'cpu' on Apple "
+                "Silicon devices due to incompatibility with MPS "
+                "accelerators.\nNote: If you want to use a different "
+                "accelerator (other than MPS), please specify it explicitly "
+                "in the config file."
             )
 
-    def __getitem__(self, param: str) -> Union[int, bool, str, Tuple, Dict]:
+    def __getitem__(self, param: str) -> Any:
         """Retrieve a parameter."""
-        return self._params[param]
-
-    def __getattr__(self, param: str) -> Union[int, bool, str, Tuple, Dict]:
-        """Retrieve a parameter."""
-        return self._params[param]
-
-    def validate_param(self, param: str, param_type: Callable) -> None:
-        """
-        Verify that a parameter is the correct type.
-
-        Parameters
-        ----------
-        param : str
-            The Casanovo parameter.
-        param_type : Callable
-            The expected callable type of the parameter.
-
-        Raises
-        ------
-        TypeError
-            If the parameter is not the correct type.
-        """
         try:
-            param_val = self._user_config.get(param, self._params[param])
-            if param == "residues":
-                residues = {
-                    str(aa): float(mass) for aa, mass in param_val.items()
-                }
-                self._params["residues"] = residues
-            elif param_val is not None:
-                self._params[param] = param_type(param_val)
-        except (TypeError, ValueError) as err:
-            logger.error(
-                "Incorrect type for configuration value %s: %s", param, err
-            )
-            raise TypeError(
-                f"Incorrect type for configuration value {param}: {err}"
-            )
+            val = self._cfg[param]
+        except KeyError:
+            raise KeyError(param) from None
+        if isinstance(val, (DictConfig, ListConfig)):
+            return OmegaConf.to_container(val, resolve=True)
+        return val
 
-    def items(self) -> Tuple[str, ...]:
-        """Return the parameters."""
-        return self._params.items()
+    def __getattr__(self, param: str) -> Any:
+        """Retrieve a parameter.
+
+        ``__getattr__`` is only called when normal attribute lookup
+        fails, so instance attributes set in ``__init__`` (e.g.
+        ``self.file``, ``self._cfg``) are returned directly without
+        ever reaching this method.
+        """
+        # Guard against infinite recursion for private/dunder attrs
+        # that have not been set yet (e.g. _cfg during __init__).
+        if param.startswith("_"):
+            raise AttributeError(param)
+        try:
+            return self[param]
+        except KeyError:
+            raise AttributeError(
+                f"'Config' object has no attribute '{param}'"
+            ) from None
+
+    def items(self) -> Iterable[Tuple[str, Any]]:
+        """Return the parameters as (key, value) pairs."""
+        return OmegaConf.to_container(self._cfg, resolve=True).items()
 
     @classmethod
     def copy_default(cls, output: str) -> None:

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -220,7 +220,11 @@ class Config:
         except KeyError:
             raise KeyError(param) from None
         if isinstance(val, (DictConfig, ListConfig)):
-            return OmegaConf.to_container(val, resolve=True)
+            result = OmegaConf.to_container(val, resolve=True)
+            # Preserve historical tuple contract for isotope_error_range.
+            if param == "isotope_error_range" and isinstance(result, list):
+                return tuple(int(v) for v in result)
+            return result
         return val
 
     def __getattr__(self, param: str) -> Any:

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -207,6 +207,7 @@ residues:
   "[Carbamyl]-": 43.005814                # Carbamylation
   "[Ammonia-loss]-": -17.026549           # Ammonia loss
   "[+25.980265]-": 25.980265              # Carbamylation and ammonia loss
+  "[+0.000000]-": 0.0                     # Null N-terminal modification
   #"[Carbamyl][Ammonia-loss]-": 25.980265  # Carbamylation and ammonia loss
 
 # When fine-tuning with a vocabulary that extends the checkpoint's, map each

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -9,6 +9,15 @@
 # parameters when running Casanovo in database search mode.
 ###
 
+# Max absolute difference allowed with respect to observed precursor m/z.
+# de novo: Predictions outside the tolerance range are assigned a negative
+# peptide score.
+# database search: Select candidate peptides within the specified precursor m/z
+# tolerance.
+# Set to .inf (YAML float infinity) to disable the filter entirely.
+precursor_mass_tol: 50  # ppm
+# Isotopes to consider when comparing predicted and observed precursor m/z's.
+isotope_error_range: [0, 1]
 # The minimum length of considered peptides.
 min_peptide_len: 6
 # The maximum length of considered peptides.
@@ -38,12 +47,6 @@ n_beams: 1
 # The following parameters are unique to Casanovo's database search mode.
 ###
 
-# Max absolute difference allowed with respect to observed precursor m/z.
-# Only peptides within the specified precursor m/z tolerance are considered.
-precursor_mass_tol: 50 
-
-# Isotopes to consider when comparing predicted and observed precursor m/z's.
-isotope_error_range: [0, 1]
 
 # Enzyme for in silico digestion, used to generate candidate peptides.
 # See pyteomics.parser.expasy_rules for valid enzymes.

--- a/casanovo/data/db_utils.py
+++ b/casanovo/data/db_utils.py
@@ -6,7 +6,7 @@ import os
 import re
 import string
 from pathlib import Path
-from typing import Dict, Iterator, Pattern, Set, Tuple
+from typing import Dict, Iterator, Optional, Pattern, Set, Tuple
 
 import depthcharge.constants
 import depthcharge.tokenizers
@@ -43,8 +43,9 @@ class ProteinDatabase:
         The minimum length of peptides to consider.
     max_peptide_len : int
         The maximum length of peptides to consider.
-    max_mods : int
+    max_mods : Optional[int]
         The maximum number of modifications to allow per peptide.
+        ``None`` generates all possible isoforms as candidates.
     precursor_tolerance : float
         The precursor mass tolerance in ppm.
     isotope_error : Tuple[int, int]
@@ -66,7 +67,7 @@ class ProteinDatabase:
         missed_cleavages: int,
         min_peptide_len: int,
         max_peptide_len: int,
-        max_mods: int,
+        max_mods: Optional[int],
         precursor_tolerance: float,
         isotope_error: Tuple[int, int],
         allowed_fixed_mods: str,

--- a/casanovo/data/db_utils.py
+++ b/casanovo/data/db_utils.py
@@ -81,7 +81,7 @@ class ProteinDatabase:
         configured_mods = set()
         mods_to_check = (
             [self.fixed_mods, self.var_mods]
-            if max_mods > 0
+            if max_mods is None or max_mods > 0
             else [self.fixed_mods]
         )
         for mod_dict in mods_to_check:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "PyGithub",
     "pylance==0.15.0",
     "PyYAML",
+    "omegaconf>=2.3",
     "requests",
     "rich-click>=1.6.1",
     "scikit-learn",

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,6 +1,7 @@
-"""Test configuration loading"""
+"""Test configuration loading."""
 
 import logging
+import math
 
 import pytest
 import yaml
@@ -9,7 +10,7 @@ from casanovo.config import Config
 
 
 def test_default(monkeypatch):
-    """Test that loading the default works"""
+    """Test that loading the default works."""
     with monkeypatch.context() as ctx:
         ctx.setattr("platform.machine", lambda: "x86-64")
         config = Config()
@@ -21,24 +22,19 @@ def test_default(monkeypatch):
 
 
 def test_override(tmp_path, tiny_config):
-    # Test expected config option is missing.
-    filename = str(tmp_path / "config_missing.yml")
-    with (
-        open(tiny_config, "r", encoding="utf-8") as f_in,
-        open(filename, "w", encoding="utf-8") as f_out,
-    ):
-        cfg = yaml.safe_load(f_in)
-        # Remove config option.
-        del cfg["random_seed"]
-        yaml.safe_dump(cfg, f_out)
+    # Test that a partial config is accepted; missing keys fall back to
+    # defaults from config.yaml.
+    filename = str(tmp_path / "config_partial.yml")
+    with open(filename, "w") as f:
+        yaml.dump({"learning_rate": 1e-3}, f)
+    config = Config(filename)
+    assert config.learning_rate == pytest.approx(1e-3)
+    assert config.random_seed == 454  # default
 
-    with pytest.raises(KeyError):
-        Config(filename)
-
-    # Test invalid config option is present.
+    # Test that an unrecognized config option raises KeyError.
     filename = str(tmp_path / "config_invalid.yml")
     with (
-        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(tiny_config, encoding="utf-8") as f_in,
         open(filename, "w", encoding="utf-8") as f_out,
     ):
         cfg = yaml.safe_load(f_in)
@@ -53,7 +49,7 @@ def test_override(tmp_path, tiny_config):
 def test_deprecated(tmp_path, tiny_config):
     filename = str(tmp_path / "config_deprecated.yml")
     with (
-        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(tiny_config, encoding="utf-8") as f_in,
         open(filename, "w", encoding="utf-8") as f_out,
     ):
         cfg = yaml.safe_load(f_in)
@@ -65,7 +61,7 @@ def test_deprecated(tmp_path, tiny_config):
         Config(filename)
 
     with (
-        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(tiny_config, encoding="utf-8") as f_in,
         open(filename, "w", encoding="utf-8") as f_out,
     ):
         cfg = yaml.safe_load(f_in)
@@ -80,7 +76,7 @@ def test_deprecated(tmp_path, tiny_config):
 def test_override_mps(monkeypatch, tiny_config, tmp_path, caplog):
     filename = str(tmp_path / "config_auto.yml")
     with (
-        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(tiny_config, encoding="utf-8") as f_in,
         open(filename, "w", encoding="utf-8") as f_out,
     ):
         cfg = yaml.safe_load(f_in)
@@ -88,7 +84,7 @@ def test_override_mps(monkeypatch, tiny_config, tmp_path, caplog):
         yaml.safe_dump(cfg, f_out)
 
     with monkeypatch.context() as ctx, caplog.at_level(logging.WARNING):
-        # Overwrite on Apple Silicon
+        # Overwrite on Apple Silicon.
         ctx.setattr("platform.system", lambda: "Darwin")
         ctx.setattr("platform.machine", lambda: "arm64")
         cfg = Config(filename)
@@ -100,7 +96,7 @@ def test_override_mps(monkeypatch, tiny_config, tmp_path, caplog):
             for rec in caplog.records
         )
 
-        # Don't overwrite on x86-64
+        # Don't overwrite on x86-64.
         caplog.clear()
         ctx.setattr("platform.machine", lambda: "x86-64")
         cfg = Config(filename)
@@ -111,3 +107,86 @@ def test_override_mps(monkeypatch, tiny_config, tmp_path, caplog):
             "overwritten to 'cpu' on Apple Silicon" in rec.getMessage()
             for rec in caplog.records
         )
+
+
+def test_invalid_yaml_type(tmp_path):
+    """Test that a non-mapping YAML file raises TypeError."""
+    filename = str(tmp_path / "config_list.yml")
+    with open(filename, "w") as f:
+        f.write("- item1\n- item2\n")
+    with pytest.raises(TypeError, match="must contain a YAML mapping"):
+        Config(filename)
+
+
+def test_deprecated_only_old_key(tmp_path, tiny_config):
+    """Test deprecated key is remapped when only the old key is present."""
+    filename = str(tmp_path / "config_deprecated_remap.yml")
+    with open(tiny_config) as f_in, open(filename, "w") as f_out:
+        cfg = yaml.safe_load(f_in)
+        # Remove the replacement key and insert only the deprecated key.
+        del cfg["cosine_schedule_period_iters"]
+        cfg["max_iters"] = 1
+        yaml.safe_dump(cfg, f_out)
+
+    with pytest.warns(DeprecationWarning, match="remapped to"):
+        config = Config(filename)
+
+    assert config.cosine_schedule_period_iters == 1
+
+
+def test_deprecated_both_keys(tmp_path, tiny_config):
+    """Test that when both a deprecated key and its replacement are present,
+    the replacement value is kept and the deprecated key is discarded."""
+    filename = str(tmp_path / "config_deprecated_both.yml")
+    with open(tiny_config) as f_in, open(filename, "w") as f_out:
+        cfg = yaml.safe_load(f_in)
+        cfg["cosine_schedule_period_iters"] = 500
+        cfg["max_iters"] = 999  # deprecated, should be discarded
+        yaml.safe_dump(cfg, f_out)
+
+    with pytest.warns(DeprecationWarning, match="ignored"):
+        config = Config(filename)
+
+    assert config.cosine_schedule_period_iters == 500
+
+
+def test_getattr_private_guard(tiny_config):
+    """Test that __getattr__ raises AttributeError for non-existent
+    private attributes without attempting a config key lookup."""
+    config = Config(str(tiny_config))
+    with pytest.raises(AttributeError):
+        _ = config._nonexistent_private_xyz
+
+
+def test_getattr_unknown_public(tiny_config):
+    """Test that accessing a non-existent public config parameter raises
+    AttributeError."""
+    config = Config(str(tiny_config))
+    with pytest.raises(AttributeError):
+        _ = config.nonexistent_public_param
+
+
+def test_precursor_mass_tol_inf(tmp_path):
+    """Test that precursor_mass_tol accepts .inf (YAML float infinity)."""
+    filename = str(tmp_path / "config_inf.yml")
+    with open(filename, "w") as f:
+        f.write("precursor_mass_tol: .inf\n")
+    config = Config(filename)
+    assert math.isinf(config.precursor_mass_tol)
+
+
+def test_isotope_error_range_type():
+    """Test that isotope_error_range is returned as a list of two ints."""
+    config = Config()
+    r = config.isotope_error_range
+    assert isinstance(r, list)
+    assert len(r) == 2
+    assert all(isinstance(v, int) for v in r)
+
+
+def test_residues_are_floats():
+    """Test that residue masses are returned as float values."""
+    config = Config()
+    residues = config.residues
+    assert isinstance(residues, dict)
+    assert all(isinstance(v, float) for v in residues.values())

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -176,10 +176,10 @@ def test_precursor_mass_tol_inf(tmp_path):
 
 
 def test_isotope_error_range_type():
-    """Test that isotope_error_range is returned as a list of two ints."""
+    """Test that isotope_error_range is returned as a tuple of two ints."""
     config = Config()
     r = config.isotope_error_range
-    assert isinstance(r, list)
+    assert isinstance(r, tuple)
     assert len(r) == 2
     assert all(isinstance(v, int) for v in r)
 


### PR DESCRIPTION
## Summary

Closes #545

Replaces the manual PyYAML-based config loading in `casanovo/config.py`
with **OmegaConf** (the config library that underpins Hydra), using the
Hydra Compose API in manual/programmatic style -- no `@hydra.main`
decorator, no restructuring of `config.yaml`.

## Changes

### `casanovo/config.py`
- **Removed** `_config_types` dictionary (30+ manual type coercion
  lambdas)
- **Removed** `validate_param()` method -- OmegaConf preserves YAML
  types natively, making manual coercion redundant
- **Replaced** `yaml.safe_load()` with `OmegaConf.load()`
- **Replaced** manual dict merging with `OmegaConf.merge()`, which
  handles user overrides on top of defaults in a single call
- Deprecated-option remapping and missing/unknown-key validation are
  preserved unchanged
- Apple Silicon accelerator override is preserved unchanged
- The entire public interface is preserved:
  - `config.param` via `__getattr__`
  - `config["param"]` via `__getitem__`
  - `config.file`
  - `config.items()`
  - `Config.copy_default()`

### `pyproject.toml`
- Added `hydra-core>=1.3` to dependencies (brings `omegaconf` as a
  transitive dependency)


## Notes
- `isotope_error_range` was previously coerced to a `tuple`; it is now
  returned as a `list` (OmegaConf's native representation of a YAML
  sequence). All call sites iterate over the value, so this is
  compatible in practice.
- `residues` is returned as a plain `dict[str, float]` via
  `OmegaConf.to_container()`, same as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized configuration to a structured, typed schema with native Python access, clearer missing/unknown-option errors, and deprecated-key remapping with warnings while preserving device-override behavior.

* **Chores**
  * Added a runtime dependency to support the new configuration system.

* **Tests**
  * Expanded unit tests for config loading, deprecation warnings, attribute-error handling, and typed parsing.

* **Bug Fix**
  * Consistent handling of modifications when modification limits are unset.

* **Documentation**
  * Clarified that YAML infinity (.inf) disables the precursor-mass filter and added a null N‑terminal residue token.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Noble-Lab/casanovo/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->