### PR TITLE
Address several minor issues (#587, #568, #583)

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -63,7 +63,7 @@ class _SharedFileIOParams(click.RichCommand):
             click.Option(
                 ("-o", "--output_root"),
                 help="The root name for all output files.",
-                type=click.Path(dir_okay=False),
+                type=click.Path(),
             ),
             click.Option(
                 ("-f", "--force_overwrite"),

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -195,9 +195,12 @@ class ModelRunner:
         self.initialize_data_module(train_paths, valid_paths)
         self.loaders.setup()
 
+        train_loader = self.loaders.train_dataloader()
+        logger.info("Training set size: %d spectra", len(train_loader.dataset))
+
         self.trainer.fit(
             self.model,
-            self.loaders.train_dataloader(),
+            train_loader,
             self.loaders.val_dataloader(),
         )
 

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -40,10 +40,6 @@ def n_workers() -> int:
     int
         The number of workers.
     """
-    # FIXME: remove multiprocessing Linux deadlock issue workaround when
-    # deadlock issue is resolved.
-    return 0
-
     # Windows or MacOS: no multiprocessing.
     if platform.system() in ["Windows", "Darwin"]:
         logger.warning(


### PR DESCRIPTION
- Resolve #587: Re-enable dataloader multiprocessing by removing stale PyTorch workaround in utils.py.
- Resolve #568: Remove unneeded directory check from output_root argument in casanovo.py.
- Resolve #583: Log training set size upon dataloader initialization in model_runner.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--output_root` command-line parameter now accepts directory paths as valid output locations, expanding configuration flexibility.

* **Bug Fixes**
  * Improved worker process detection to reliably determine optimal process counts across all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->