### PR TITLE
Add Fourier embeddings for mass spectrometry

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -84,6 +84,7 @@ class Config:
         dim_feedforward=int,
         n_layers=int,
         dropout=float,
+        encoding_type=str,
         dim_intensity=int,
         warmup_iters=int,
         cosine_schedule_period_iters=int,

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -121,6 +121,10 @@ dim_feedforward: 1024
 n_layers: 9
 # Dropout rate for model weights.
 dropout: 0.0
+# Type of positional encoding for m/z and intensity values.
+# "sinusoidal" uses the default fixed sinusoidal encoding.
+# "fourier" uses learnable Fourier embeddings with trained frequencies.
+encoding_type: "sinusoidal"
 # Number of dimensions to use for encoding peak intensity.
 dim_intensity:
 # The number of iterations for the linear warm-up of the learning rate.

--- a/casanovo/denovo/fourier.py
+++ b/casanovo/denovo/fourier.py
@@ -1,0 +1,189 @@
+"""Fourier positional encodings for mass spectrometry data."""
+
+import math
+
+import torch
+
+
+def _build_fourier_frequencies(
+    m_min: float = 1e-4,
+    m_max: float = 1000.0,
+) -> torch.Tensor:
+    """Build the predefined Fourier frequency vector.
+
+    Constructs frequencies as described in the DreaMS paper (Eq. 4):
+
+    - Low frequencies:  1/m_max, 1/(m_max-1), ..., 1
+       (captures integer part of mass)
+    - High frequencies: 1/(k*m_min), 1/((k-1)*m_min), ..., 1/m_min
+       (captures decimal part of mass)
+
+    Parameters:
+    m_min : float, optional
+        Minimum decimal mass of interest (absolute instrument accuracy).
+        Default is 1e-4 as used for GeMS datasets.
+    m_max : float, optional
+        Maximum integer mass of interest.
+        Default is 1000 as used for GeMS datasets.
+
+    Returns:
+    torch.Tensor
+        The 1D frequency vector b of shape (B,).
+    """
+    # Low frequencies: 1/m_max, 1/(m_max-1), ..., 1/1
+    # These capture integer mass differences.
+    low_denom = torch.arange(m_max, 0, -1, dtype=torch.float32)
+    low_freqs = 1.0 / low_denom
+
+    # High frequencies: 1/(k*m_min), ..., 1/m_min
+    # k is such that k*m_min is closest to 1.
+    k = round(1.0 / m_min)
+    high_denom = torch.arange(k, 0, -1, dtype=torch.float32) * m_min
+    high_freqs = 1.0 / high_denom
+
+    return torch.cat([low_freqs, high_freqs])
+
+
+class FourierEncoder(torch.nn.Module):
+    """Encode floating-point values using predefined Fourier features.
+
+    Implements the Fourier feature encoding from the DreaMS paper:
+
+        Φ(m)_i     = sin(2π · b_i · m)
+        Φ(m)_{i+1} = cos(2π · b_i · m)
+
+    where b is a vector of predefined frequencies split into low
+    (integer mass) and high (decimal mass) components, followed by
+    a feed-forward network to project from 2B dimensions to d_model.
+
+    Parameters:
+    d_model : int
+        The output embedding dimensionality.
+    m_min : float, optional
+        Minimum decimal mass of interest (instrument accuracy).
+    m_max : float, optional
+        Maximum integer mass of interest.
+    n_layers_ffn : int, optional
+        Number of hidden layers in the projection FFN.
+    """
+
+    def __init__(
+        self,
+        d_model: int = 128,
+        m_min: float = 1e-4,
+        m_max: float = 1000.0,
+        n_layers_ffn: int = 1,
+    ) -> None:
+        """Initialize a FourierEncoder."""
+        super().__init__()
+
+        # Build and register the predefined frequencies (not learned).
+        freqs = _build_fourier_frequencies(m_min, m_max)
+        self.register_buffer("frequencies", freqs)
+        n_fourier = 2 * len(freqs)  # sin + cos for each frequency
+
+        # Feed-forward network to project Fourier features to d_model.
+        layers = []
+        in_dim = n_fourier
+        for _ in range(n_layers_ffn):
+            layers.append(torch.nn.Linear(in_dim, d_model))
+            layers.append(torch.nn.GELU())
+            in_dim = d_model
+        layers.append(torch.nn.Linear(in_dim, d_model))
+        self.ffn = torch.nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Encode floating-point values with Fourier features.
+
+        Parameters:
+        x : torch.Tensor of shape (...)
+            Floating-point values to encode (e.g. masses or m/z).
+
+        Returns:
+        torch.Tensor of shape (..., d_model)
+            The Fourier embeddings projected to d_model dimensions.
+        """
+        # x: (...,) -> (..., 1) for broadcasting with frequencies
+        x = x.unsqueeze(-1).float()
+        # (..., B) angles
+        angles = 2.0 * math.pi * self.frequencies * x
+        # Concatenate sin and cos -> (..., 2B)
+        fourier_features = torch.cat(
+            [torch.sin(angles), torch.cos(angles)], dim=-1
+        )
+        # Project to d_model via FFN -> (..., d_model)
+        return self.ffn(fourier_features)
+
+
+class FourierPeakEncoder(torch.nn.Module):
+    """Encode (m/z, intensity) peak pairs using Fourier features.
+
+    Implements the PeakEncoder from the DreaMS paper (Eq. 5):
+
+        PeakEncoder(m, i) = FFN_F(Φ(m)) || FFN_P(m, i)
+
+    The m/z values are encoded via Fourier features followed by FFN_F,
+    and the raw m/z + intensity are processed by a separate FFN_P. The
+    outputs are concatenated and projected to d_model.
+
+    Parameters:
+    d_model : int
+        The output embedding dimensionality.
+    m_min : float, optional
+        Minimum decimal mass of interest (instrument accuracy).
+    m_max : float, optional
+        Maximum integer mass of interest.
+    """
+
+    def __init__(
+        self,
+        d_model: int = 128,
+        m_min: float = 1e-4,
+        m_max: float = 1000.0,
+    ) -> None:
+        """Initialize a FourierPeakEncoder."""
+        super().__init__()
+        self.d_model = d_model
+
+        # FFN_F: Fourier features of m/z -> d_m dimensional
+        d_fourier_out = d_model // 2
+        self.fourier_encoder = FourierEncoder(d_fourier_out, m_min, m_max)
+
+        # FFN_P: raw (m/z, intensity) -> d_p dimensional
+        d_raw_out = d_model - d_fourier_out
+        self.raw_ffn = torch.nn.Sequential(
+            torch.nn.Linear(2, d_raw_out),
+            torch.nn.GELU(),
+            torch.nn.Linear(d_raw_out, d_raw_out),
+        )
+
+        # Final projection after concatenation.
+        self.output_proj = torch.nn.Linear(d_model, d_model)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+    ) -> torch.Tensor:
+        """Encode m/z and intensity pairs.
+
+        Parameters:
+        x : torch.Tensor of shape (n_spectra, n_peaks)
+            The m/z values for each peak.
+        y : torch.Tensor of shape (n_spectra, n_peaks)
+            The intensity values for each peak.
+
+        Returns:
+        torch.Tensor of shape (n_spectra, n_peaks, d_model)
+            The encoded peaks.
+        """
+        # FFN_F(Φ(m/z))  -> (n_spectra, n_peaks, d_fourier_out)
+        fourier_emb = self.fourier_encoder(x)
+
+        # FFN_P(m/z, intensity) -> (n_spectra, n_peaks, d_raw_out)
+        raw_input = torch.stack([x.float(), y.float()], dim=-1)  # (..., 2)
+        raw_emb = self.raw_ffn(raw_input)
+
+        # Concatenate and project -> (n_spectra, n_peaks, d_model)
+        combined = torch.cat([fourier_emb, raw_emb], dim=-1)
+        return self.output_proj(combined)

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -91,6 +91,10 @@ class Spec2Pep(pl.LightningModule):
         This is expensive.
     tokenizer: PeptideTokenizer | None
         Tokenizer object to process peptide sequences.
+    encoding_type : str, optional
+        The type of positional encoding to use. ``"sinusoidal"`` uses
+        the default fixed sinusoidal encoding. ``"fourier"`` uses
+        learnable Fourier embeddings.
     **kwargs : Dict
         Additional keyword arguments passed to the Adam optimizer.
     """
@@ -117,6 +121,7 @@ class Spec2Pep(pl.LightningModule):
         out_writer: Optional[ms_io.MztabWriter] = None,
         calculate_precision: bool = False,
         tokenizer: PeptideTokenizer | None = None,
+        encoding_type: str = "sinusoidal",
         **kwargs: Dict,
     ):
         super().__init__()
@@ -131,6 +136,7 @@ class Spec2Pep(pl.LightningModule):
             dim_feedforward=dim_feedforward,
             n_layers=n_layers,
             dropout=dropout,
+            encoding_type=encoding_type,
         )
         self.decoder = PeptideDecoder(
             n_tokens=self.tokenizer,
@@ -140,6 +146,7 @@ class Spec2Pep(pl.LightningModule):
             n_layers=n_layers,
             dropout=dropout,
             max_charge=max_charge,
+            encoding_type=encoding_type,
         )
         self.softmax = torch.nn.Softmax(2)
         ignore_index = 0

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -525,10 +525,14 @@ class ModelRunner:
                 loaded_model_params.keys()
             )
             for param in architecture_params:
-                if model_params[param] != self.model.hparams[param]:
+                checkpoint_value = self.model.hparams.get(param)
+                if checkpoint_value is None:
+                    # New param not in old checkpoint; use config value.
+                    continue
+                if model_params[param] != checkpoint_value:
                     warnings.warn(
                         f"Mismatching {param} parameter in "
-                        f"model checkpoint ({self.model.hparams[param]}) "
+                        f"model checkpoint ({checkpoint_value}) "
                         f"vs config file ({model_params[param]}); "
                         "using the checkpoint."
                     )

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -463,6 +463,7 @@ class ModelRunner:
             calculate_precision=self.config.calculate_precision,
             out_writer=self.writer,
             tokenizer=tokenizer,
+            encoding_type=self.config.encoding_type,
         )
 
         # Reconfigurable non-architecture related parameters for a

--- a/casanovo/denovo/transformers.py
+++ b/casanovo/denovo/transformers.py
@@ -77,6 +77,12 @@ class PeptideDecoder(AnalyteTransformerDecoder):
         )
 
         self.charge_encoder = torch.nn.Embedding(max_charge, d_model)
+        _VALID_ENCODING_TYPES = {"sinusoidal", "fourier"}
+        if encoding_type not in _VALID_ENCODING_TYPES:
+            raise ValueError(
+                f"Invalid encoding_type '{encoding_type}'. "
+                f"Must be one of: {_VALID_ENCODING_TYPES}"
+            )
         if encoding_type == "fourier":
             self.mass_encoder = FourierEncoder(d_model)
         else:
@@ -164,6 +170,12 @@ class SpectrumEncoder(SpectrumTransformerEncoder):
         encoding_type: str = "sinusoidal",
     ):
         """Initialize a SpectrumEncoder."""
+        _VALID_ENCODING_TYPES = {"sinusoidal", "fourier"}
+        if encoding_type not in _VALID_ENCODING_TYPES:
+            raise ValueError(
+                f"Invalid encoding_type '{encoding_type}'. "
+                f"Must be one of: {_VALID_ENCODING_TYPES}"
+            )
         if encoding_type == "fourier":
             peak_encoder = FourierPeakEncoder(d_model)
         super().__init__(

--- a/casanovo/denovo/transformers.py
+++ b/casanovo/denovo/transformers.py
@@ -10,6 +10,8 @@ from depthcharge.transformers import (
     SpectrumTransformerEncoder,
 )
 
+from .fourier import FourierEncoder, FourierPeakEncoder
+
 
 class PeptideDecoder(AnalyteTransformerDecoder):
     """
@@ -42,6 +44,10 @@ class PeptideDecoder(AnalyteTransformerDecoder):
         Required only if ``n_tokens`` was provided as an ``int``.
     max_charge : int, optional
         The maximum charge state for peptide sequences.
+    encoding_type : str, optional
+        The type of positional encoding to use. ``"sinusoidal"`` uses
+        the default fixed sinusoidal encoding. ``"fourier"`` uses
+        learnable Fourier embeddings.
     """
 
     def __init__(
@@ -55,6 +61,7 @@ class PeptideDecoder(AnalyteTransformerDecoder):
         positional_encoder: PositionalEncoder | bool = True,
         padding_int: int | None = None,
         max_charge: int = 4,
+        encoding_type: str = "sinusoidal",
     ) -> None:
         """Initialize a PeptideDecoder."""
 
@@ -70,7 +77,10 @@ class PeptideDecoder(AnalyteTransformerDecoder):
         )
 
         self.charge_encoder = torch.nn.Embedding(max_charge, d_model)
-        self.mass_encoder = FloatEncoder(d_model)
+        if encoding_type == "fourier":
+            self.mass_encoder = FourierEncoder(d_model)
+        else:
+            self.mass_encoder = FloatEncoder(d_model)
 
         # Override the output layer to have +1 in the second dimension
         # compared to the AnalyteTransformerDecoder to account for
@@ -137,6 +147,10 @@ class SpectrumEncoder(SpectrumTransformerEncoder):
         The function to encode the (m/z, intensity) tuples of each mass
         spectrum. `True` uses the default sinusoidal encoding and `False`
         instead performs a 1 to `d_model` learned linear projection.
+    encoding_type : str, optional
+        The type of positional encoding to use. ``"sinusoidal"`` uses
+        the default sinusoidal encoding. ``"fourier"`` uses learnable
+        Fourier embeddings for the peak encoder.
     """
 
     def __init__(
@@ -147,8 +161,11 @@ class SpectrumEncoder(SpectrumTransformerEncoder):
         n_layers: int = 1,
         dropout: float = 0,
         peak_encoder: PeakEncoder | Callable | bool = True,
+        encoding_type: str = "sinusoidal",
     ):
         """Initialize a SpectrumEncoder."""
+        if encoding_type == "fourier":
+            peak_encoder = FourierPeakEncoder(d_model)
         super().__init__(
             d_model, n_head, dim_feedforward, n_layers, dropout, peak_encoder
         )

--- a/tests/unit_tests/test_fourier.py
+++ b/tests/unit_tests/test_fourier.py
@@ -161,8 +161,25 @@ class TestFourierPeakEncoder:
     def test_concatenation_architecture(self):
         """Test that the encoder uses concatenation (not sum)."""
         encoder = FourierPeakEncoder(64, m_min=0.1, m_max=5.0)
-        # Check that fourier_encoder and raw_ffn produce different dims
-        # that must be concatenated
         assert hasattr(encoder, "fourier_encoder")
         assert hasattr(encoder, "raw_ffn")
         assert hasattr(encoder, "output_proj")
+
+        # Verify intermediate dimensions sum to output_proj.in_features
+        d_fourier_out = encoder.fourier_encoder.ffn[-1].out_features
+        d_raw_out = encoder.raw_ffn[-1].out_features
+        assert encoder.output_proj.in_features == d_fourier_out + d_raw_out
+
+        # Verify forward pass actually concatenates (not sums)
+        encoder.eval()
+        mz = torch.randn(2, 5)
+        intensity = torch.randn(2, 5)
+        with torch.no_grad():
+            fourier_out = encoder.fourier_encoder(mz)
+            raw_input = torch.stack([mz.float(), intensity.float()], dim=-1)
+            raw_out = encoder.raw_ffn(raw_input)
+            expected = encoder.output_proj(
+                torch.cat([fourier_out, raw_out], dim=-1)
+            )
+            actual = encoder(mz, intensity)
+        assert torch.allclose(actual, expected)

--- a/tests/unit_tests/test_fourier.py
+++ b/tests/unit_tests/test_fourier.py
@@ -1,0 +1,168 @@
+"""Unit tests for Fourier positional encodings."""
+
+import pytest
+import torch
+
+from casanovo.denovo.fourier import (
+    FourierEncoder,
+    FourierPeakEncoder,
+    _build_fourier_frequencies,
+)
+
+
+class TestBuildFourierFrequencies:
+    """Tests for the frequency vector construction."""
+
+    def test_default_frequency_count(self):
+        """Test the expected number of frequencies with default params."""
+        freqs = _build_fourier_frequencies(m_min=1e-4, m_max=1000.0)
+        # Low freqs: 1000 (from m_max=1000 down to 1)
+        # High freqs: round(1/1e-4) = 10000
+        assert len(freqs) == 1000 + 10000
+
+    def test_small_frequency_count(self):
+        """Test frequency count with small params for faster tests."""
+        freqs = _build_fourier_frequencies(m_min=0.1, m_max=5.0)
+        # Low freqs: 5 (5, 4, 3, 2, 1)
+        # High freqs: round(1/0.1) = 10
+        assert len(freqs) == 5 + 10
+
+    def test_low_frequencies_range(self):
+        """Test that low frequencies span 1/m_max to 1."""
+        freqs = _build_fourier_frequencies(m_min=0.1, m_max=5.0)
+        low_freqs = freqs[:5]
+        assert torch.isclose(low_freqs[0], torch.tensor(1.0 / 5.0))
+        assert torch.isclose(low_freqs[-1], torch.tensor(1.0))
+
+    def test_high_frequencies_range(self):
+        """Test that high frequencies span to 1/m_min."""
+        freqs = _build_fourier_frequencies(m_min=0.1, m_max=5.0)
+        high_freqs = freqs[5:]
+        assert torch.isclose(high_freqs[-1], torch.tensor(1.0 / 0.1))
+
+    def test_frequencies_are_positive(self):
+        """Test that all frequencies are positive."""
+        freqs = _build_fourier_frequencies(m_min=0.1, m_max=10.0)
+        assert torch.all(freqs > 0)
+
+
+class TestFourierEncoder:
+    """Tests for the FourierEncoder class."""
+
+    def test_output_shape(self):
+        """Test that the output shape is correct for various inputs."""
+        d_model = 64
+        encoder = FourierEncoder(d_model, m_min=0.1, m_max=5.0)
+
+        # Single value
+        x = torch.tensor([100.0])
+        out = encoder(x)
+        assert out.shape == (1, d_model)
+
+        # Batch of values
+        x = torch.tensor([100.0, 200.0, 300.0])
+        out = encoder(x)
+        assert out.shape == (3, d_model)
+
+        # 2D input (batch, n_peaks)
+        x = torch.randn(4, 10)
+        out = encoder(x)
+        assert out.shape == (4, 10, d_model)
+
+    def test_frequencies_are_not_learned(self):
+        """Test that frequencies are buffers, not parameters."""
+        encoder = FourierEncoder(64, m_min=0.1, m_max=5.0)
+        param_names = [name for name, _ in encoder.named_parameters()]
+        # Frequencies should NOT be in parameters (they're buffers)
+        assert not any("frequencies" in name for name in param_names)
+        # But the FFN should have learnable parameters
+        assert any("ffn" in name for name in param_names)
+
+    def test_ffn_has_gradients(self):
+        """Test that gradients flow through the FFN."""
+        encoder = FourierEncoder(64, m_min=0.1, m_max=5.0)
+        x = torch.tensor([100.0, 200.0])
+        out = encoder(x)
+        loss = out.sum()
+        loss.backward()
+
+        # FFN weights should have gradients
+        for name, param in encoder.ffn.named_parameters():
+            if "weight" in name:
+                assert param.grad is not None
+
+    def test_different_inputs_different_outputs(self):
+        """Test that different inputs produce different embeddings."""
+        encoder = FourierEncoder(64, m_min=0.1, m_max=5.0)
+        x1 = torch.tensor([100.0])
+        x2 = torch.tensor([200.0])
+        out1 = encoder(x1)
+        out2 = encoder(x2)
+        assert not torch.allclose(out1, out2)
+
+    def test_deterministic(self):
+        """Test that the same input produces the same output."""
+        encoder = FourierEncoder(64, m_min=0.1, m_max=5.0)
+        encoder.eval()
+        x = torch.tensor([100.0, 200.0])
+        out1 = encoder(x)
+        out2 = encoder(x)
+        assert torch.allclose(out1, out2)
+
+    def test_different_d_model(self):
+        """Test correct output shape with different d_model values."""
+        for d_model in [32, 64, 128]:
+            encoder = FourierEncoder(d_model, m_min=0.1, m_max=5.0)
+            x = torch.randn(2, 5)
+            out = encoder(x)
+            assert out.shape == (2, 5, d_model)
+
+
+class TestFourierPeakEncoder:
+    """Tests for the FourierPeakEncoder class."""
+
+    def test_output_shape(self):
+        """Test the output shape for peak encoding."""
+        d_model = 64
+        encoder = FourierPeakEncoder(d_model, m_min=0.1, m_max=5.0)
+
+        mz = torch.randn(4, 10)
+        intensity = torch.randn(4, 10)
+        out = encoder(mz, intensity)
+        assert out.shape == (4, 10, d_model)
+
+    def test_gradients_flow(self):
+        """Test that gradients flow through both branches."""
+        encoder = FourierPeakEncoder(64, m_min=0.1, m_max=5.0)
+        mz = torch.randn(2, 5)
+        intensity = torch.randn(2, 5)
+        out = encoder(mz, intensity)
+        loss = out.sum()
+        loss.backward()
+
+        # Both FFN branches should have gradients
+        for param in encoder.fourier_encoder.ffn.parameters():
+            if param.requires_grad:
+                assert param.grad is not None
+        for param in encoder.raw_ffn.parameters():
+            if param.requires_grad:
+                assert param.grad is not None
+
+    def test_different_intensities_different_outputs(self):
+        """Test that different intensities produce different embeddings."""
+        encoder = FourierPeakEncoder(64, m_min=0.1, m_max=5.0)
+        mz = torch.tensor([[100.0, 200.0]])
+        int1 = torch.tensor([[0.5, 0.8]])
+        int2 = torch.tensor([[0.1, 0.2]])
+        out1 = encoder(mz, int1)
+        out2 = encoder(mz, int2)
+        assert not torch.allclose(out1, out2)
+
+    def test_concatenation_architecture(self):
+        """Test that the encoder uses concatenation (not sum)."""
+        encoder = FourierPeakEncoder(64, m_min=0.1, m_max=5.0)
+        # Check that fourier_encoder and raw_ffn produce different dims
+        # that must be concatenated
+        assert hasattr(encoder, "fourier_encoder")
+        assert hasattr(encoder, "raw_ffn")
+        assert hasattr(encoder, "output_proj")


### PR DESCRIPTION
Implement Fourier feature encodings based on the DreaMS paper:
- Predefined frequencies with low/high split (Eq. 4)
- sin/cos encoding without phase offset (Eq. 3)
- FFN projection after Fourier features
- Concatenation-based PeakEncoder (Eq. 5)
- New encoding_type config option (sinusoidal/fourier)
- 15 unit tests

Addresses Issue #345 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable encoding types: choose "sinusoidal" (default) or new learnable "fourier" encoding for spectrum/peptide representations via the `encoding_type` setting.

* **Tests**
  * Added comprehensive unit tests validating Fourier encoding behaviors, shapes, gradients, and deterministic evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->