### PR TITLE
Updated gradient_clip_val and gradient_clip_algorithm default, batch size comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files.
 - Upgraded minimum Lightning version to 2.6
 - Changed default value for gradient_clip_val to be 1.0 
-- Changed default algorithm gradient_clip_algorithm to be "norm", and added more specific description to algorithm descriptions 
-- Updated batch_size to appropriately reflect per-batch computation
+- Changed default gradient_clip_algorithm to "norm", and clarified algorithm descriptions
+- Updated train_batch_size documentation to reflect per-device/effective batch computation
 
 ## [5.1.1] - 2025-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files.
+- Upgraded minimum Lightning version to 2.6
+- Changed default value for gradient_clip_val to be 1.0 
+- Changed default algorithm gradient_clip_algorithm to be "norm", and added more specific description to algorithm descriptions 
+- Updated batch_size to appropriately reflect per-batch computation
 
 ## [5.1.1] - 2025-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed default value for gradient_clip_val to be 1.0 
 - Changed default gradient_clip_algorithm to "norm", and clarified algorithm descriptions
 - Updated train_batch_size documentation to reflect per-device/effective batch computation
+- Black version upgraded for python 3.10
 
 ## [5.1.1] - 2025-11-27
 

--- a/casanovo/__init__.py
+++ b/casanovo/__init__.py
@@ -1,4 +1,3 @@
 from .version import _get_version
 
-
 __version__ = _get_version()

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -10,7 +10,6 @@ import yaml
 
 from . import utils
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -136,6 +136,9 @@ train_label_smoothing: 0.01
 
 # TRAINING/INFERENCE OPTIONS
 # Number of spectra in one training batch.
+# Per-device micro-batch is train_batch_size // n on n GPUs.
+# Effective optimization batch size is:
+# (per-device micro-batch) * n * accumulate_grad_batches.
 train_batch_size: 32
 # Max number of training epochs.
 max_epochs: 30
@@ -152,10 +155,13 @@ calculate_precision: false
 # Accumulates gradients over `k` batches before stepping the optimizer.
 accumulate_grad_batches: 1
 # The value at which to clip gradients. `None` disables gradient clipping.
-gradient_clip_val:
+gradient_clip_val: 1.0
 # The gradient clipping algorithm to use.
 # Must be one of: "value", "norm", or `None`.
-gradient_clip_algorithm:
+# "value": The gradient values are clipped to the range [-gradient_clip_val, gradient_clip_val]
+# "norm": If the total L2 norm of the gradients exceeds gradient_clip_val, the gradients 
+#         are rescaled so the total L2 norm equals gradient_clip_val
+gradient_clip_algorithm: "norm"
 # Floating point precision.
 # Must be one of: "16-true", "16-mixed", "bf16-true", "bf16-mixed", "32-true",
 # "64-true", "64", "32", "16", or "bf16".

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -21,7 +21,6 @@ from depthcharge.tokenizers import PeptideTokenizer
 from torch.utils.data import DataLoader
 from torch.utils.data.datapipes.iter.combinatorics import ShufflerIterDataPipe
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -18,7 +18,6 @@ from ..data import ms_io, psm
 from ..denovo.transformers import PeptideDecoder, SpectrumEncoder
 from . import evaluate
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -26,7 +26,6 @@ from ..denovo.dataloaders import DeNovoDataModule
 from ..denovo.evaluate import aa_match_batch, aa_match_metrics
 from ..denovo.model import DbSpec2Pep, Spec2Pep
 
-
 logger = logging.getLogger("casanovo")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ exclude = ["docs", "tests", "sample_data"]
 
 [tool.black]
 line-length = 79
-target-version = ['py10']
+target-version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "appdirs",
-    "lightning>=2.4",
+    "lightning>=2.6",
     "click",
     "depthcharge-ms>=0.4.8,<0.5.0",
     "natsort",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
 ]
 dev = [
     "pre-commit>=2.7.1",
-    "black>=19.10b0",
+    "black>=26.3.0",
     "ppx",
     "psims",
     "pyteomics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "appdirs",
     "lightning>=2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ exclude = ["docs", "tests", "sample_data"]
 
 [tool.black]
 line-length = 79
-target-version = ['py38']
+target-version = ['py10']
 include = '\.pyi?$'
 exclude = '''
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -80,7 +80,7 @@ def test_train_and_run(
     # Verify that the spectrum predictions are correct and indexed
     # according to the peak input file type.
     psms = mztab.spectrum_match_table
-    assert psms.loc[1, "sequence"] == "LESLLEK"
+    assert psms.loc[1, "sequence"] == "LESLEK"
     assert psms.loc[1, "spectra_ref"] == "ms_run[1]:index=0"
     assert psms.loc[2, "sequence"] == "PEPTLDEK"
     assert psms.loc[2, "spectra_ref"] == "ms_run[1]:index=1"
@@ -89,7 +89,7 @@ def test_train_and_run(
         psms.loc[3, "spectra_ref"]
         == "ms_run[2]:merged=11 frame=12 scanStart=763 scanEnd=787"
     )
-    assert psms.loc[4, "sequence"] == "LESLLEK"
+    assert psms.loc[4, "sequence"] == "LESLEK"
     assert psms.loc[4, "spectra_ref"] == "ms_run[2]:scan=17"
 
     # Run Casanovo in de novo evaluation mode.
@@ -123,7 +123,7 @@ def test_train_and_run(
     # Verify that the spectrum predictions are correct and indexed
     # according to the peak input file type.
     psms = mztab.spectrum_match_table
-    assert psms.loc[1, "sequence"] == "LESLLEK"
+    assert psms.loc[1, "sequence"] == "LESLEK"
     assert psms.loc[1, "spectra_ref"] == "ms_run[1]:index=0"
     assert psms.loc[2, "sequence"] == "PEPTLDEK"
     assert psms.loc[2, "spectra_ref"] == "ms_run[1]:index=1"

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -1609,10 +1609,10 @@ def test_spectrum_id_mgf(mgf_small, tmp_path):
     ]:
         for i, (filename, scan_id) in enumerate(
             [
-                (mgf_small, "0"),
-                (mgf_small, "1"),
-                (mgf_small2, "0"),
-                (mgf_small2, "1"),
+                (mgf_small, "index=0"),
+                (mgf_small, "index=1"),
+                (mgf_small2, "index=0"),
+                (mgf_small2, "index=1"),
             ]
         ):
             assert dataset[i]["peak_file"][0] == filename.name

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -1609,14 +1609,14 @@ def test_spectrum_id_mgf(mgf_small, tmp_path):
     ]:
         for i, (filename, scan_id) in enumerate(
             [
-                (mgf_small, "index=0"),
-                (mgf_small, "index=1"),
-                (mgf_small2, "index=0"),
-                (mgf_small2, "index=1"),
+                (mgf_small, "0"),
+                (mgf_small, "1"),
+                (mgf_small2, "0"),
+                (mgf_small2, "1"),
             ]
         ):
             assert dataset[i]["peak_file"][0] == filename.name
-            assert dataset[i]["scan_id"][0] == scan_id
+            assert dataset[i]["scan_id"][0] == f"index={scan_id}"
 
 
 def test_spectrum_id_mzml(mzml_small, tmp_path):

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -1609,14 +1609,14 @@ def test_spectrum_id_mgf(mgf_small, tmp_path):
     ]:
         for i, (filename, scan_id) in enumerate(
             [
-                (mgf_small, "0"),
-                (mgf_small, "1"),
-                (mgf_small2, "0"),
-                (mgf_small2, "1"),
+                (mgf_small, "index=0"),
+                (mgf_small, "index=1"),
+                (mgf_small2, "index=0"),
+                (mgf_small2, "index=1"),
             ]
         ):
             assert dataset[i]["peak_file"][0] == filename.name
-            assert dataset[i]["scan_id"][0] == f"index={scan_id}"
+            assert dataset[i]["scan_id"][0] == scan_id
 
 
 def test_spectrum_id_mzml(mzml_small, tmp_path):


### PR DESCRIPTION
Changes made:
- Updated gradient_clip_val and gradient_clip_algorithm default 
- Updated batch size comment 
- Updated changelog
- Upgraded pytorch lightning version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Minimum Lightning requirement raised to 2.6
  * Minimum Python requirement raised to 3.10

* **Changed**
  * Gradient clipping defaults set: gradient_clip_val = 1.0 and gradient_clip_algorithm = "norm"
  * Batch size documentation clarified to explain per-device micro-batch sizing and effective optimization batch size in multi-GPU setups

* **Tests**
  * Updated expected de novo prediction strings and scan identifier format in tests

* **Changelog**
  * Release notes updated to reflect the above defaults and documentation clarifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->