### PR TITLE
Addressed the duplicate prediction TODO asked in the code

### DIFF
--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -563,7 +563,7 @@ class Spec2Pep(pl.LightningModule):
                     heapadd = heapq.heappush
                 else:
                     heapadd = heapq.heappushpop
-                
+
                 heapadd(pred_cache[spec_idx], peptide_entry)
 
     def _get_topk_beams(

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -502,7 +502,7 @@ class Spec2Pep(pl.LightningModule):
         ]
             Priority queue with finished beams for each spectrum,
             ordered by peptide score. For each finished beam, a tuple
-            with the (negated) peptide score, a random tie-breaking
+            with the peptide score, a random tie-breaking
             float, the amino acid-level scores, and the predicted tokens
             is stored.
         """
@@ -525,18 +525,6 @@ class Spec2Pep(pl.LightningModule):
             has_stop_token = pred_tokens[-1] == self.stop_token
             pred_peptide = pred_tokens[:-1] if has_stop_token else pred_tokens
 
-            # Don't cache this peptide if it was already predicted previously.
-            pred_peptide_cpu = pred_peptide.cpu()
-            duplicate = False
-            for pred_cached in pred_cache[spec_idx]:
-                # TODO: Add duplicate predictions with their highest score.
-                if torch.equal(pred_cached[-1], pred_peptide_cpu):
-                    duplicate = True
-                    break
-
-            if duplicate:
-                continue
-
             # Calculate softmax scores directly with proper indexing
             smx = self.softmax(scores[i : i + 1, : step + 1, :])
 
@@ -553,24 +541,37 @@ class Spec2Pep(pl.LightningModule):
 
             # Omit the stop token from the amino acid-level scores.
             aa_scores = aa_scores[:-1]
-            # Add the prediction to the cache (minimum priority queue,
-            # maximum the number of beams elements).
-            if len(pred_cache[spec_idx]) < self.n_beams:
-                heapadd = heapq.heappush
-            else:
-                heapadd = heapq.heappushpop
 
-            heapadd(
-                pred_cache[spec_idx],
-                (
-                    peptide_score,
-                    np.random.random_sample(),
-                    aa_scores,
-                    torch.clone(
-                        pred_peptide_cpu
-                    ),  # Ensure tensor is on CPU for storage
-                ),
-            )
+            # Check for duplicate predictions and update with highest score.
+            pred_peptide_cpu = pred_peptide.cpu()
+            for j, pred_cached in enumerate(pred_cache[spec_idx]):
+                if torch.equal(pred_cached[-1], pred_peptide_cpu):
+                    if peptide_score > pred_cached[0]:
+                        pred_cache[spec_idx][j] = (
+                            peptide_score,
+                            np.random.random_sample(),
+                            aa_scores,
+                            torch.clone(pred_peptide_cpu),
+                        )
+                        heapq.heapify(pred_cache[spec_idx])
+                    break
+            else:
+                # Add the prediction to the cache (minimum priority queue,
+                # maximum the number of beams elements).
+                if len(pred_cache[spec_idx]) < self.n_beams:
+                    heapadd = heapq.heappush
+                else:
+                    heapadd = heapq.heappushpop
+
+                heapadd(
+                    pred_cache[spec_idx],
+                    (
+                        peptide_score,
+                        np.random.random_sample(),
+                        aa_scores,
+                        torch.clone(pred_peptide_cpu),
+                    ),
+                )
 
     def _get_topk_beams(
         self,

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -542,17 +542,18 @@ class Spec2Pep(pl.LightningModule):
             # Omit the stop token from the amino acid-level scores.
             aa_scores = aa_scores[:-1]
 
-            # Check for duplicate predictions and update with highest score.
             pred_peptide_cpu = pred_peptide.cpu()
+            peptide_entry = (
+                peptide_score,
+                np.random.random_sample(),
+                aa_scores,
+                torch.clone(pred_peptide_cpu),
+            )
+            # Check for duplicate predictions and update with highest score.
             for j, pred_cached in enumerate(pred_cache[spec_idx]):
                 if torch.equal(pred_cached[-1], pred_peptide_cpu):
                     if peptide_score > pred_cached[0]:
-                        pred_cache[spec_idx][j] = (
-                            peptide_score,
-                            np.random.random_sample(),
-                            aa_scores,
-                            torch.clone(pred_peptide_cpu),
-                        )
+                        pred_cache[spec_idx][j] = peptide_entry
                         heapq.heapify(pred_cache[spec_idx])
                     break
             else:
@@ -562,16 +563,8 @@ class Spec2Pep(pl.LightningModule):
                     heapadd = heapq.heappush
                 else:
                     heapadd = heapq.heappushpop
-
-                heapadd(
-                    pred_cache[spec_idx],
-                    (
-                        peptide_score,
-                        np.random.random_sample(),
-                        aa_scores,
-                        torch.clone(pred_peptide_cpu),
-                    ),
-                )
+                
+                heapadd(pred_cache[spec_idx], peptide_entry)
 
     def _get_topk_beams(
         self,


### PR DESCRIPTION
**Title:** Fix: Retain highest score for duplicate peptide predictions in beam search

**Description:**
This PR resolves a `TODO` in the beam search decoding process (`_cache_finished_beams`) where duplicate peptide sequences were not being evaluated for their highest score, and it corrects stale documentation regarding how scores are stored in the cache. 

**Changes Made:**
* **Duplicate Prediction Handling:** Updated the caching logic in `model.py`. When a finished beam produces a peptide sequence that is already in the prediction cache, the model now compares their scores. If the newly predicted duplicate has a higher confidence score, it replaces the older entry and re-heapifies the priority queue to maintain bounds and order. 
* **Docstring Correction:** Fixed the `pred_cache` docstring to accurately reflect that the heap stores *positive* `peptide_score` values, removing the outdated reference to "(negated) peptide score".

**Motivation / Context:**
During beam search, different decoding paths can sometimes converge on the exact same final amino acid sequence but with different probability scores. Previously, duplicates were bypassed. This change ensures that if a spectrum produces the same peptide via multiple beams, the prediction with the highest possible confidence score is the one retained and reported to the user.

**Testing:**
* Verified that targeted unit tests (e.g., `test_duplicate_peptide_scores`, `test_cache_finished_beams`) pass successfully and enforce the new duplicate-updating behavior.
* Confirmed that the `pred_cache` heap maintains its maximum `n_beams` length.

This was made with the help of AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beam-search caching so identical candidate sequences are now compared and the higher-scoring prediction is preserved, preventing valid peptides from being discarded and improving final prediction quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->