### PR TITLE
Add inference profiling infrastructure and benchmark command

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -35,6 +35,7 @@ import appdirs
 import github
 import requests
 import rich_click as click
+import torch
 import tqdm
 from lightning.pytorch import seed_everything
 
@@ -151,11 +152,18 @@ def main() -> None:
     is_flag=True,
     default=False,
     help="""
-    Run in evaluation mode. When this flag is set the peptide and amino acid  
-    precision will be calculated and logged at the end of the sequencing run. 
-    All input files must be annotated MGF files if running in evaluation 
+    Run in evaluation mode. When this flag is set the peptide and amino acid
+    precision will be calculated and logged at the end of the sequencing run.
+    All input files must be annotated MGF files if running in evaluation
     mode.
     """,
+)
+@click.option(
+    "--profile",
+    "profile_output",
+    default=None,
+    type=click.Path(dir_okay=False, writable=True),
+    help="Write a PyTorch Profiler Chrome trace to this path after inference.",
 )
 def sequence(
     peak_path: Tuple[str],
@@ -166,6 +174,7 @@ def sequence(
     verbosity: str,
     force_overwrite: bool,
     evaluate: bool,
+    profile_output: Optional[str],
 ) -> None:
     """De novo sequence peptides from tandem mass spectra.
 
@@ -202,9 +211,17 @@ def sequence(
             logger.info("  %s", peak_file)
 
         results_path = output_path / f"{output_root_name}.mztab"
-        runner.predict(peak_path, str(results_path), evaluate=evaluate)
+        stage_times = runner.predict(
+            peak_path,
+            str(results_path),
+            evaluate=evaluate,
+            profile_output=profile_output,
+        )
         utils.log_annotate_report(
-            runner.writer.psms, start_time=start_time, end_time=time.time()
+            runner.writer.psms,
+            start_time=start_time,
+            end_time=time.time(),
+            stage_times=stage_times,
         )
 
 
@@ -372,6 +389,131 @@ def train(
         )
 
         utils.log_run_report(start_time=start_time, end_time=time.time())
+
+
+@main.command(cls=_SharedParams)
+@click.argument(
+    "peak_path",
+    required=True,
+    nargs=-1,
+    type=click.Path(exists=True, dir_okay=True),
+)
+@click.option(
+    "--n_iter",
+    default=3,
+    show_default=True,
+    type=int,
+    help="Number of timed benchmark iterations (excluding warmup).",
+)
+@click.option(
+    "--warmup",
+    default=1,
+    show_default=True,
+    type=int,
+    help="Number of untimed warmup iterations before benchmarking.",
+)
+@click.option(
+    "--batch_sizes",
+    default="256,512,1024",
+    show_default=True,
+    help="Comma-separated list of predict batch sizes to sweep.",
+)
+@click.option(
+    "--n_beams_list",
+    default="1",
+    show_default=True,
+    help="Comma-separated list of beam widths to sweep.",
+)
+def benchmark(
+    peak_path: Tuple[str],
+    model: Optional[str],
+    config: Optional[str],
+    output_dir: Optional[str],
+    output_root: Optional[str],
+    verbosity: str,
+    force_overwrite: bool,
+    n_iter: int,
+    warmup: int,
+    batch_sizes: str,
+    n_beams_list: str,
+) -> None:
+    """Benchmark inference throughput across a configuration matrix.
+
+    Sweeps over combinations of batch size and beam width, measuring
+    spectra/second, ms/spectrum, and peak GPU memory. Results are printed
+    as a table to stdout and logged.
+
+    PEAK_PATH must be one or more mzML, mzXML, or MGF files.
+    """
+    import statistics
+    import tempfile
+
+    output_path, output_root_name = _setup_output(
+        output_dir, output_root, force_overwrite, verbosity
+    )
+    utils.log_system_info()
+
+    parsed_batch_sizes = [int(b.strip()) for b in batch_sizes.split(",")]
+    parsed_beams = [int(b.strip()) for b in n_beams_list.split(",")]
+
+    base_config, model_path = setup_model(
+        model, config, output_path, output_root_name, False
+    )
+
+    header = (
+        f"{'batch_size':>12} {'n_beams':>8} {'spectra/s':>12} "
+        f"{'ms/spectrum':>13} {'peak_gpu_mb':>12}"
+    )
+    divider = "-" * len(header)
+    click.echo(header)
+    click.echo(divider)
+
+    for batch_size in parsed_batch_sizes:
+        for n_beams in parsed_beams:
+            cfg = Config.__new__(Config)
+            cfg.file = base_config.file
+            cfg._params = dict(base_config._params)
+            cfg._user_config = base_config._user_config
+            cfg._params["predict_batch_size"] = batch_size
+            cfg._params["n_beams"] = n_beams
+
+            throughputs = []
+            peak_mem_mb = 0
+
+            total_iters = warmup + n_iter
+            for i in range(total_iters):
+                is_timed = i >= warmup
+                if is_timed and torch.cuda.is_available():
+                    torch.cuda.reset_peak_memory_stats()
+
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    results_path = os.path.join(tmp_dir, "bench.mztab")
+                    with ModelRunner(
+                        cfg, model_path, output_path, None, False
+                    ) as runner:
+                        tput = runner.predict_timed(peak_path, results_path)
+
+                if is_timed:
+                    throughputs.append(tput)
+                    if torch.cuda.is_available():
+                        peak_mem_mb = max(
+                            peak_mem_mb,
+                            torch.cuda.max_memory_allocated() >> 20,
+                        )
+
+            if throughputs:
+                mean_tput = statistics.mean(throughputs)
+                ms_per_spec = (
+                    (1000.0 / mean_tput) if mean_tput > 0 else float("inf")
+                )
+            else:
+                mean_tput, ms_per_spec = 0.0, float("inf")
+
+            row = (
+                f"{batch_size:>12} {n_beams:>8} {mean_tput:>12.1f} "
+                f"{ms_per_spec:>13.2f} {peak_mem_mb:>12}"
+            )
+            click.echo(row)
 
 
 @main.command()

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -462,7 +462,7 @@ def benchmark(
 
     header = (
         f"{'batch_size':>12} {'n_beams':>8} {'spectra/s':>12} "
-        f"{'ms/spectrum':>13} {'peak_gpu_mb':>12}"
+        f"{'ms/spectrum':>13} {'peak_gpu_mib':>13}"
     )
     divider = "-" * len(header)
     click.echo(header)
@@ -471,35 +471,36 @@ def benchmark(
     for batch_size in parsed_batch_sizes:
         for n_beams in parsed_beams:
             cfg = Config.__new__(Config)
-            cfg.file = base_config.file
+            cfg.__dict__.update(base_config.__dict__)
             cfg._params = dict(base_config._params)
-            cfg._user_config = base_config._user_config
             cfg._params["predict_batch_size"] = batch_size
             cfg._params["n_beams"] = n_beams
 
             throughputs = []
-            peak_mem_mb = 0
+            peak_mem_mib = 0
 
             total_iters = warmup + n_iter
-            for i in range(total_iters):
-                is_timed = i >= warmup
-                if is_timed and torch.cuda.is_available():
-                    torch.cuda.reset_peak_memory_stats()
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                with ModelRunner(
+                    cfg, model_path, output_path, None, False
+                ) as runner:
+                    for i in range(total_iters):
+                        is_timed = i >= warmup
+                        if is_timed and torch.cuda.is_available():
+                            torch.cuda.reset_peak_memory_stats()
 
-                with tempfile.TemporaryDirectory() as tmp_dir:
-                    results_path = os.path.join(tmp_dir, "bench.mztab")
-                    with ModelRunner(
-                        cfg, model_path, output_path, None, False
-                    ) as runner:
+                        results_path = os.path.join(
+                            tmp_dir, f"bench_{i}.mztab"
+                        )
                         tput = runner.predict_timed(peak_path, results_path)
 
-                if is_timed:
-                    throughputs.append(tput)
-                    if torch.cuda.is_available():
-                        peak_mem_mb = max(
-                            peak_mem_mb,
-                            torch.cuda.max_memory_allocated() >> 20,
-                        )
+                        if is_timed:
+                            throughputs.append(tput)
+                            if torch.cuda.is_available():
+                                peak_mem_mib = max(
+                                    peak_mem_mib,
+                                    torch.cuda.max_memory_allocated() >> 20,
+                                )
 
             if throughputs:
                 mean_tput = statistics.mean(throughputs)
@@ -511,7 +512,7 @@ def benchmark(
 
             row = (
                 f"{batch_size:>12} {n_beams:>8} {mean_tput:>12.1f} "
-                f"{ms_per_spec:>13.2f} {peak_mem_mb:>12}"
+                f"{ms_per_spec:>13.2f} {peak_mem_mib:>13}"
             )
             click.echo(row)
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -231,7 +231,8 @@ class Spec2Pep(pl.LightningModule):
             sequence.
         """
         mzs, ints, precursors, _ = self._process_batch(batch)
-        return self.beam_search_decode(mzs, ints, precursors)
+        with torch.profiler.record_function("casanovo::forward"):
+            return self.beam_search_decode(mzs, ints, precursors)
 
     def beam_search_decode(
         self,
@@ -268,7 +269,8 @@ class Spec2Pep(pl.LightningModule):
             score, the amino acid scores, and the predicted peptide
             sequence.
         """
-        memories, mem_masks = self.encoder(mzs, intensities)
+        with torch.profiler.record_function("casanovo::encoder"):
+            memories, mem_masks = self.encoder(mzs, intensities)
 
         # Get device from self for consistent placement
         device = self.device

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -362,9 +362,11 @@ class ModelRunner:
         results_path: str,
     ) -> float:
         """Run inference and return spectra/second throughput."""
-        self.initialize_trainer(train=False)
-        self.initialize_tokenizer()
-        self.initialize_model(train=False)
+        if self.trainer is None:
+            self.initialize_trainer(train=False)
+        if self.model is None:
+            self.initialize_tokenizer()
+            self.initialize_model(train=False)
         self.writer = ms_io.MztabWriter(results_path)
         self.writer.set_metadata(
             self.config,

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -1,17 +1,20 @@
 """Training and testing functionality for the de novo peptide sequencing
 model."""
 
+import contextlib
 import glob
 import logging
 import os
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Iterable, List, Optional, Sequence, Union
+from typing import Dict, Iterable, List, Optional, Sequence, Union
 
 import lightning.pytorch as pl
 import lightning.pytorch.loggers
 import torch
+import torch.utils.data
+from torch.profiler import ProfilerActivity
 from depthcharge.tokenizers import PeptideTokenizer
 from depthcharge.tokenizers.peptides import MskbPeptideTokenizer
 from lightning.pytorch.callbacks import LearningRateMonitor, ModelCheckpoint
@@ -269,7 +272,8 @@ class ModelRunner:
         peak_path: Iterable[str],
         results_path: str,
         evaluate: bool = False,
-    ) -> None:
+        profile_output: Optional[str] = None,
+    ) -> Dict[str, float]:
         """
         Predict peptide sequences with a trained Casanovo model.
 
@@ -288,6 +292,8 @@ class ModelRunner:
             Note: peak_path must point to annotated MS data files when
             running model evaluation. Files that are not an annotated
             peak file format will be ignored if evaluate is set to true.
+        profile_output : str, optional
+            If set, write a PyTorch Profiler Chrome trace to this path.
         """
         self.writer = ms_io.MztabWriter(results_path)
         self.writer.set_metadata(
@@ -303,30 +309,91 @@ class ModelRunner:
 
         test_paths = self._get_input_paths(peak_path, False, "test")
         self.writer.set_ms_run(test_paths)
-        self.initialize_data_module(test_paths=test_paths)
 
-        try:
-            self.loaders.setup(stage="test", annotated=evaluate)
-        except (KeyError, OSError, TypeError) as e:
-            if evaluate:
-                error_message = (
-                    "Error creating annotated spectrum dataloaders. This may "
-                    "be the result of having an unannotated peak file present "
-                    "in the validation peak file path list. Check that the input "
-                    "spectrum files are annotated, and if they are that the "
-                    "format is correct."
-                )
+        stage_times: Dict[str, float] = {}
 
-                logger.error(error_message)
-                raise TypeError(error_message) from e
-
-            raise
+        with utils.stage_timer("data_loading", stage_times):
+            self.initialize_data_module(test_paths=test_paths)
+            try:
+                self.loaders.setup(stage="test", annotated=evaluate)
+            except (KeyError, OSError, TypeError) as e:
+                if evaluate:
+                    error_message = (
+                        "Error creating annotated spectrum dataloaders. This "
+                        "may be the result of having an unannotated peak file "
+                        "present in the validation peak file path list. Check "
+                        "that the input spectrum files are annotated, and if "
+                        "they are that the format is correct."
+                    )
+                    logger.error(error_message)
+                    raise TypeError(error_message) from e
+                raise
 
         predict_dataloader = self.loaders.predict_dataloader()
-        self.trainer.predict(self.model, predict_dataloader)
+
+        if profile_output is not None:
+            profiler_ctx = torch.profiler.profile(
+                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                record_shapes=True,
+                profile_memory=True,
+                with_stack=False,
+            )
+        else:
+            profiler_ctx = contextlib.nullcontext()
+
+        with utils.stage_timer("inference", stage_times):
+            with profiler_ctx as prof:
+                self.trainer.predict(self.model, predict_dataloader)
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+
+        if profile_output is not None and prof is not None:
+            prof.export_chrome_trace(profile_output)
+            logger.info("Profiler trace written to %s", profile_output)
 
         if evaluate:
             self.log_metrics(predict_dataloader)
+
+        return stage_times
+
+    def predict_timed(
+        self,
+        peak_path: Iterable[str],
+        results_path: str,
+    ) -> float:
+        """Run inference and return spectra/second throughput."""
+        self.initialize_trainer(train=False)
+        self.initialize_tokenizer()
+        self.initialize_model(train=False)
+        self.writer = ms_io.MztabWriter(results_path)
+        self.writer.set_metadata(
+            self.config,
+            model=str(self.model_filename),
+            config_filename=self.config.file,
+        )
+        self.model.out_writer = self.writer
+
+        test_paths = self._get_input_paths(peak_path, False, "test")
+        self.writer.set_ms_run(test_paths)
+        self.initialize_data_module(test_paths=test_paths)
+        self.loaders.setup(stage="test", annotated=False)
+
+        predict_dataloader = self.loaders.predict_dataloader()
+        try:
+            n_spectra = len(predict_dataloader.dataset)
+        except TypeError:
+            n_spectra = sum(1 for _ in predict_dataloader.dataset)
+
+        stage_times: Dict[str, float] = {}
+        with utils.stage_timer("inference", stage_times):
+            self.trainer.predict(self.model, predict_dataloader)
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+
+        elapsed = stage_times.get("inference", 0.0)
+        if elapsed > 0 and n_spectra > 0:
+            return n_spectra / elapsed
+        return 0.0
 
     def initialize_trainer(self, train: bool) -> None:
         """

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -7,6 +7,8 @@ import platform
 import re
 import socket
 import sys
+import time
+from contextlib import contextmanager
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional, Tuple
 
@@ -22,6 +24,16 @@ from .data.psm import PepSpecMatch
 SCORE_BINS = (0.0, 0.5, 0.9, 0.95, 0.99)
 
 logger = logging.getLogger("casanovo")
+
+
+@contextmanager
+def stage_timer(label: str, timings: Dict[str, float]):
+    """Record wall-clock time for a named stage into a shared dict."""
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        timings[label] = time.perf_counter() - t0
 
 
 def n_workers() -> int:
@@ -143,7 +155,9 @@ def log_system_info() -> None:
 
 
 def log_run_report(
-    start_time: Optional[float] = None, end_time: Optional[float] = None
+    start_time: Optional[float] = None,
+    end_time: Optional[float] = None,
+    stage_times: Optional[Dict[str, float]] = None,
 ) -> None:
     """
     Log general run report.
@@ -154,6 +168,8 @@ def log_run_report(
         The start time of the sequencing run in seconds since the epoch.
     end_time : Optional[float], default=None
         The end time of the sequencing run in seconds since the epoch.
+    stage_times : Optional[Dict[str, float]], default=None
+        Per-stage timings to include in the report.
     """
     logger.info("======= End of Run Report =======")
     if start_time is not None and end_time is not None:
@@ -169,6 +185,11 @@ def log_run_report(
         )
         logger.info("Time Elapsed: %s", delta_datetime)
 
+    if stage_times:
+        logger.info("Stage timings:")
+        for stage, elapsed in stage_times.items():
+            logger.info("  %s: %.3f s", stage, elapsed)
+
     if torch.cuda.is_available():
         gpu_util = torch.cuda.max_memory_allocated()
         logger.info("Max GPU Memory Utilization: %d MiB", gpu_util >> 20)
@@ -179,6 +200,7 @@ def log_annotate_report(
     start_time: Optional[float] = None,
     end_time: Optional[float] = None,
     score_bins: Iterable[float] = SCORE_BINS,
+    stage_times: Optional[Dict[str, float]] = None,
 ) -> None:
     """
     Log run annotation report.
@@ -193,8 +215,12 @@ def log_annotate_report(
         The end time of the sequencing run in seconds since the epoch.
     score_bins: Iterable[float], Optional
         Confidence scores for creating confidence score distribution.
+    stage_times : Optional[Dict[str, float]], default=None
+        Per-stage timings to include in the report.
     """
-    log_run_report(start_time=start_time, end_time=end_time)
+    log_run_report(
+        start_time=start_time, end_time=end_time, stage_times=stage_times
+    )
     run_report = _get_report_dict(
         pd.DataFrame(
             {

--- a/tests/unit_tests/test_profiling.py
+++ b/tests/unit_tests/test_profiling.py
@@ -1,0 +1,181 @@
+"""Tests for profiling utilities and benchmark command."""
+
+import json
+import logging
+import time
+from unittest import mock
+
+import pytest
+
+from casanovo import utils
+from casanovo.config import Config
+from casanovo.denovo.model_runner import ModelRunner
+
+
+def test_stage_timer_records_elapsed():
+    timings = {}
+    with utils.stage_timer("test_stage", timings):
+        time.sleep(0.01)
+    assert "test_stage" in timings
+    assert timings["test_stage"] >= 0.01
+
+
+def test_stage_timer_multiple_stages():
+    timings = {}
+    with utils.stage_timer("stage_a", timings):
+        pass
+    with utils.stage_timer("stage_b", timings):
+        pass
+    assert set(timings.keys()) == {"stage_a", "stage_b"}
+    assert all(v >= 0 for v in timings.values())
+
+
+def test_stage_timer_records_on_exception():
+    timings = {}
+    with pytest.raises(ValueError):
+        with utils.stage_timer("boom", timings):
+            raise ValueError("oops")
+    assert "boom" in timings
+
+
+def test_log_run_report_stage_times(caplog):
+    stage_times = {"data_loading": 0.123, "inference": 4.567}
+    with caplog.at_level(logging.INFO, logger="casanovo"):
+        utils.log_run_report(stage_times=stage_times)
+    assert "data_loading" in caplog.text
+    assert "inference" in caplog.text
+
+
+def test_log_run_report_no_stage_times(caplog):
+    with caplog.at_level(logging.INFO, logger="casanovo"):
+        utils.log_run_report()
+    assert "End of Run Report" in caplog.text
+
+
+def test_predict_creates_profile_trace(tmp_path, mgf_small, tiny_config):
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    ckpt = tmp_path / "model.ckpt"
+    mztab = tmp_path / "results.mztab"
+    trace_path = tmp_path / "trace.json"
+
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+        runner.trainer.save_checkpoint(ckpt)
+
+    with ModelRunner(config=config, model_filename=str(ckpt)) as runner:
+        stage_times = runner.predict(
+            [mgf_small], str(mztab), profile_output=str(trace_path)
+        )
+
+    assert trace_path.exists()
+    with open(trace_path) as f:
+        trace = json.load(f)
+    assert isinstance(trace, (dict, list))
+    assert "data_loading" in stage_times
+    assert "inference" in stage_times
+    assert stage_times["inference"] > 0
+
+
+def test_predict_no_profile_output(tmp_path, mgf_small, tiny_config):
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    ckpt = tmp_path / "model.ckpt"
+    mztab = tmp_path / "results.mztab"
+
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+        runner.trainer.save_checkpoint(ckpt)
+
+    with ModelRunner(config=config, model_filename=str(ckpt)) as runner:
+        stage_times = runner.predict([mgf_small], str(mztab))
+
+    assert len(list(tmp_path.glob("*.json"))) == 0
+    assert "data_loading" in stage_times
+    assert "inference" in stage_times
+
+
+def test_sequence_cli_profile_flag(tmp_path, mgf_small, tiny_config):
+    from click.testing import CliRunner
+    from casanovo.casanovo import sequence
+
+    trace_path = tmp_path / "cli_trace.json"
+    runner = CliRunner()
+
+    with (
+        mock.patch("casanovo.casanovo.setup_model") as mock_setup,
+        mock.patch("casanovo.casanovo.ModelRunner") as MockRunner,
+    ):
+        mock_setup.return_value = (Config(tiny_config), None)
+        mock_instance = mock.MagicMock()
+        mock_instance.__enter__ = mock.Mock(return_value=mock_instance)
+        mock_instance.__exit__ = mock.Mock(return_value=False)
+        mock_instance.predict.return_value = {
+            "data_loading": 0.1,
+            "inference": 1.0,
+        }
+        mock_instance.writer.psms = []
+        MockRunner.return_value = mock_instance
+
+        result = runner.invoke(
+            sequence,
+            [
+                str(mgf_small),
+                "--profile",
+                str(trace_path),
+                "--config",
+                str(tiny_config),
+                "--output_dir",
+                str(tmp_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    _, call_kwargs = mock_instance.predict.call_args
+    assert call_kwargs.get("profile_output") == str(trace_path)
+
+
+def test_benchmark_cli_smoke(tmp_path, mgf_small, tiny_config):
+    from click.testing import CliRunner
+    from casanovo.casanovo import benchmark
+
+    runner = CliRunner()
+
+    with (
+        mock.patch("casanovo.casanovo.setup_model") as mock_setup,
+        mock.patch("casanovo.casanovo.ModelRunner") as MockRunner,
+    ):
+        mock_setup.return_value = (Config(tiny_config), None)
+        mock_instance = mock.MagicMock()
+        mock_instance.__enter__ = mock.Mock(return_value=mock_instance)
+        mock_instance.__exit__ = mock.Mock(return_value=False)
+        mock_instance.predict_timed.return_value = 150.0
+        MockRunner.return_value = mock_instance
+
+        result = runner.invoke(
+            benchmark,
+            [
+                str(mgf_small),
+                "--config",
+                str(tiny_config),
+                "--output_dir",
+                str(tmp_path),
+                "--batch_sizes",
+                "256",
+                "--n_beams_list",
+                "1",
+                "--n_iter",
+                "1",
+                "--warmup",
+                "0",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "spectra/s" in result.output
+    assert "256" in result.output
+    mock_instance.predict_timed.assert_called_once()


### PR DESCRIPTION
## Summary

This PR adds the observability and benchmarking infrastructure needed
for real-time inference optimization of Casanovo.

**Changes:**
- `utils.py`: `stage_timer()` context manager for per-stage wall-clock timing; `log_run_report()` now logs a per-stage breakdown (data loading, inference).
- `model.py`: `torch.profiler.record_function` annotations on the encoder and full forward pass for Chrome trace visibility.
- `model_runner.py`: `predict()` accepts `--profile-output`; wraps inference with `torch.profiler.profile` and exports a Chrome trace. Returns `stage_times` dict. New `predict_timed()` returns spectra/second.
- `casanovo.py`: `--profile PATH` option on `sequence` command; new `benchmark` command sweeps batch_size × n_beams and prints a throughput table (spectra/s, ms/spectrum, peak GPU MB).
- `tests/unit_tests/test_profiling.py`: 7 unit tests covering all new functionality.

**Motivation:**  
Before optimizing Casanovo's inference pipeline for real-time use (20–100 Hz), we need reproducible tools to measure *where time actually goes*. This PR provides exactly that a `--profile` flag that exports a Chrome trace, per-stage timings in every run report, and a `benchmark` command for systematic throughput measurement across configurations.

## Test plan
- [ ] `pytest tests/unit_tests/test_profiling.py -v`
- [ ] `casanovo sequence sample_data/sample_preprocessed_spectra.mgf --profile trace.json` → verify `trace.json` opens in `chrome://tracing`
- [ ] `casanovo benchmark sample_data/sample_preprocessed_spectra.mgf` → verify throughput table prints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI profiling flag to export performance traces and stage-level timings.
  * Added a benchmark subcommand that sweeps batch/beam settings, reports throughput, ms/spectrum, and peak GPU memory in a formatted table.

* **Improvements**
  * Inference now records distinct stage timings (e.g., data loading vs. inference).

* **Tests**
  * New tests covering profiling, trace export, timing reports, and CLI benchmark behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->