### PR TITLE
fix: allow val_check_interval to be a float in (0, 1] or an int >= 1

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -28,11 +28,15 @@ _config_deprecated = dict(
 
 
 def _parse_val_check_interval(value) -> Union[int, float]:
-    """Parse val_check_interval as either a float (0, 1] or a positive int.
+    """Parse val_check_interval as either an int >= 1 or a float in (0, 1].
 
     PyTorch Lightning accepts:
-    - float in (0.0, 1.0]: fraction of epoch between validations
     - int >= 1: number of training batches between validations
+    - float in (0.0, 1.0]: fraction of epoch between validations
+
+    The original type is preserved so PyTorch Lightning's strict type
+    semantics are respected: ``int(1)`` stays ``int`` (one-batch interval),
+    while ``float(1.0)`` stays ``float`` (end-of-epoch fraction).
 
     Parameters
     ----------
@@ -47,10 +51,20 @@ def _parse_val_check_interval(value) -> Union[int, float]:
     Raises
     ------
     TypeError
-        If the value cannot be interpreted as a valid interval.
+        If the value is not numeric.
     ValueError
-        If a float is outside (0, 1] or an int is less than 1.
+        If the value is outside the valid range.
     """
+    # Check for a true Python int first (booleans are ints in Python,
+    # so exclude them explicitly).
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value >= 1:
+            return value
+        raise ValueError(
+            f"val_check_interval as int must be >= 1, got {value!r}"
+        )
+
+    # For everything else, coerce to float.
     try:
         as_float = float(value)
     except (TypeError, ValueError) as err:
@@ -59,19 +73,19 @@ def _parse_val_check_interval(value) -> Union[int, float]:
             f"got {value!r}"
         ) from err
 
-    # If the string / numeric value is an integer-like (e.g. 50000, "50000")
-    # keep it as int so Lightning treats it as a step count.
-    if as_float == int(as_float) and as_float >= 1:
-        return int(as_float)
-
-    # Float path: must be in (0, 1]
+    # Float path: valid range is (0.0, 1.0]
     if 0.0 < as_float <= 1.0:
         return as_float
+
+    # Integer-valued strings (e.g. "50000") arrive here as float — coerce back.
+    if as_float == int(as_float) and as_float >= 1:
+        return int(as_float)
 
     raise ValueError(
         f"val_check_interval must be an int >= 1 or a float in (0, 1], "
         f"got {value!r}"
     )
+
 
 
 class Config:

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -27,6 +27,53 @@ _config_deprecated = dict(
 )
 
 
+def _parse_val_check_interval(value) -> Union[int, float]:
+    """Parse val_check_interval as either a float (0, 1] or a positive int.
+
+    PyTorch Lightning accepts:
+    - float in (0.0, 1.0]: fraction of epoch between validations
+    - int >= 1: number of training batches between validations
+
+    Parameters
+    ----------
+    value : int or float
+        The raw config value.
+
+    Returns
+    -------
+    Union[int, float]
+        The validated value.
+
+    Raises
+    ------
+    TypeError
+        If the value cannot be interpreted as a valid interval.
+    ValueError
+        If a float is outside (0, 1] or an int is less than 1.
+    """
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError) as err:
+        raise TypeError(
+            f"val_check_interval must be an int >= 1 or a float in (0, 1], "
+            f"got {value!r}"
+        ) from err
+
+    # If the string / numeric value is an integer-like (e.g. 50000, "50000")
+    # keep it as int so Lightning treats it as a step count.
+    if as_float == int(as_float) and as_float >= 1:
+        return int(as_float)
+
+    # Float path: must be in (0, 1]
+    if 0.0 < as_float <= 1.0:
+        return as_float
+
+    raise ValueError(
+        f"val_check_interval must be an int >= 1 or a float in (0, 1], "
+        f"got {value!r}"
+    )
+
+
 class Config:
     """
     The Casanovo configuration options.
@@ -71,7 +118,7 @@ class Config:
         log_metrics=bool,
         log_every_n_steps=int,
         lance_dir=str,
-        val_check_interval=int,
+        val_check_interval=_parse_val_check_interval,  # int >= 1 or float in (0, 1]
         min_peaks=int,
         max_peaks=int,
         min_mz=float,


### PR DESCRIPTION
Closes #627

## What

Adds `_parse_val_check_interval()` — a dedicated validator that accepts PyTorch Lightning's full range for `val_check_interval`:

- **`float` in `(0.0, 1.0]`** — fraction of an epoch between validations
- **`int >= 1`** — number of training batches between validations

Previously the `_config_types` dict mapped `val_check_interval` to `int`, so passing `0.25` or `1.0` would be silently coerced or raise a confusing error.

## Changes

- `casanovo/config.py`: replace `val_check_interval=int` with `val_check_interval=_parse_val_check_interval`
- New module-level function `_parse_val_check_interval` with clear docstring and `ValueError` for out-of-range values
- Default value in `config.yaml` (`50_000`) continues to work as an int

## Example

```yaml
# validate every quarter of an epoch
val_check_interval: 0.25

# validate every 10 000 steps (existing behaviour)
val_check_interval: 10000
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of the validation check interval configuration parameter to properly handle different input types and provide clearer error messages when invalid values are supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->