### PR TITLE
fix(model_runner): only warn about config/checkpoint alphabet mismatch when a checkpoint is loaded (#629)

### DIFF
--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -407,15 +407,6 @@ class ModelRunner:
         else:
             tokenizer_clss = PeptideTokenizer
 
-        missing_aa = list(
-            set(self.config.residues) - set(tokenizer_clss.residues)
-        )
-        if missing_aa:
-            logger.warning(
-                "Configured residue(s) not in model alphabet: %s",
-                ", ".join(missing_aa),
-            )
-
         self.tokenizer = tokenizer_clss(
             residues=self.config.residues,
             replace_isoleucine_with_leucine=self.config.replace_isoleucine_with_leucine,
@@ -498,6 +489,27 @@ class ModelRunner:
                 raise ValueError("A model file must be provided")
         # Else a model file is provided (to continue training or for
         # inference).
+
+        # The class-level `tokenizer_clss.residues` is the *default* alphabet
+        # (the 20 standard amino acids). It is only meaningful as a comparison
+        # baseline when a pre-trained checkpoint is being loaded and the
+        # checkpoint's tokenizer will replace the config's. When training
+        # from scratch the config vocabulary IS the alphabet, so the warning
+        # is meaningless and was firing spuriously for any config containing
+        # a modification token (issue #629). The check now lives here, where
+        # a checkpoint is actually being loaded.
+        if self.config.massivekb_tokenizer:
+            tokenizer_clss = MskbPeptideTokenizer
+        else:
+            tokenizer_clss = PeptideTokenizer
+        missing_aa = list(
+            set(self.config.residues) - set(tokenizer_clss.residues)
+        )
+        if missing_aa:
+            logger.warning(
+                "Configured residue(s) not in model alphabet: %s",
+                ", ".join(missing_aa),
+            )
 
         if not Path(self.model_filename).exists():
             logger.error(

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -535,7 +535,7 @@ def test_log_metrics(monkeypatch, tiny_config):
 
 def test_initialize_tokenizer_does_not_warn_about_alphabet(caplog):
     """initialize_tokenizer must not warn about residues missing from the
-    class-level default alphabet — when training from scratch the config
+    class-level default alphabet, when training from scratch the config
     vocabulary IS the alphabet, so the warning is meaningless. The check
     now lives in initialize_model where a checkpoint is actually being
     loaded. Regression test for #629.
@@ -577,6 +577,6 @@ def test_initialize_model_train_from_scratch_no_alphabet_warning(
         "Configured residue(s) not in model alphabet" in msg
         for msg in caplog.messages
     ), (
-        "training from scratch must not emit the alphabet warning — "
+        "training from scratch must not emit the alphabet warning, "
         "there is no prior model alphabet to mismatch against"
     )

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -533,7 +533,13 @@ def test_log_metrics(monkeypatch, tiny_config):
             assert aa_recall == pytest.approx(100 * (2 / 3))
 
 
-def test_initialize_tokenizer(caplog):
+def test_initialize_tokenizer_does_not_warn_about_alphabet(caplog):
+    """initialize_tokenizer must not warn about residues missing from the
+    class-level default alphabet — when training from scratch the config
+    vocabulary IS the alphabet, so the warning is meaningless. The check
+    now lives in initialize_model where a checkpoint is actually being
+    loaded. Regression test for #629.
+    """
     mock_config = unittest.mock.MagicMock()
     mock_config.residues = {"foo": 100}
 
@@ -542,7 +548,35 @@ def test_initialize_tokenizer(caplog):
     with caplog.at_level("WARNING"):
         runner.initialize_tokenizer()
 
-    assert any(
-        "Configured residue(s) not in model alphabet: foo" in msg
+    assert not any(
+        "Configured residue(s) not in model alphabet" in msg
         for msg in caplog.messages
+    ), "the alphabet warning must not fire from initialize_tokenizer"
+
+
+def test_initialize_model_train_from_scratch_no_alphabet_warning(
+    tmp_path, caplog
+):
+    """initialize_model with model_filename=None and train=True must NOT
+    emit the 'Configured residue(s) not in model alphabet' warning, since
+    no checkpoint is being loaded and the config IS the alphabet (#629).
+    """
+    config = Config()
+    config.model_save_folder_path = tmp_path
+    # Add a modification token that's absent from the default alphabet.
+    config.residues = dict(config.residues)
+    config.residues["[Acetyl]-"] = 42.010565
+
+    runner = ModelRunner(config=config)
+    runner.initialize_tokenizer()
+
+    with caplog.at_level("WARNING"):
+        runner.initialize_model(train=True)
+
+    assert not any(
+        "Configured residue(s) not in model alphabet" in msg
+        for msg in caplog.messages
+    ), (
+        "training from scratch must not emit the alphabet warning — "
+        "there is no prior model alphabet to mismatch against"
     )


### PR DESCRIPTION
Closes #629.

## What

`ModelRunner.initialize_tokenizer` compared `config.residues`
against `tokenizer_clss.residues` (the **class-level default
alphabet**, 20 standard amino acids) and warned about any
modification token in the config that wasn't in that default. The
warning fired unconditionally because:

- The 20-AA default never contains modifications like
  `C[Carbamidomethyl]` or `[Acetyl]-`.
- `initialize_tokenizer` runs from every entry point (`train`,
  `sequence`, `db_search`) regardless of whether a checkpoint will
  ultimately be loaded.

When training from scratch (`model_filename is None`) the warning
is meaningless: there is no prior model alphabet to mismatch
against, the config vocabulary *is* the alphabet. The warning was
intended to catch genuine config/checkpoint mismatches at
inference / fine-tuning time, but it was placed before
`initialize_model` ran the `model_filename is None` check.

## Fix

Move the check into `initialize_model`, after the
`model_filename is None` early-return for `train=True`. It now only
runs when a checkpoint is actually being loaded (the case where
the checkpoint's tokenizer replaces the config's, and a
config-only modification is genuinely lost).
`initialize_tokenizer` becomes a pure setup routine.

## Tests

- Renamed `test_initialize_tokenizer` to
  `test_initialize_tokenizer_does_not_warn_about_alphabet` and
  flipped the assertion: the warning must NOT fire from this
  function any more.
- New
  `test_initialize_model_train_from_scratch_no_alphabet_warning`:
  uses a realistic `Config` with `[Acetyl]-` added to
  `config.residues`; the train-from-scratch path must not emit the
  warning.

I verified locally that both new assertions FAIL against a stashed
version of the fix (proving they catch the regression) and PASS
with the fix in this PR. The unrelated existing
`test_initialize_model` still passes.

## Notes

This restores the "no spurious warning when training from scratch"
property #549 originally established. #578 re-introduced the
warning in the right *spirit* (legit when a checkpoint is loaded
that doesn't know about your modifications) but in the wrong
*location*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Reduced spurious alphabet-mismatch warnings that previously appeared when training models from scratch, improving the training experience.

* **Tests**
  * Updated unit tests to ensure no erroneous alphabet-mismatch warnings are triggered during initialization and training-from-scratch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->