### PR TITLE
fix(model_runner): only warn on residue mismatch when loading a checkpoint (#629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Suppressed the spurious `Configured residue(s) not in model alphabet` warning when training a model from scratch with a custom residue vocabulary. The warning now fires only when a checkpoint is being loaded, where an alphabet mismatch is meaningful (#629).
+
 ## [5.1.2] - 2025-12-11
 
 ### Changed

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -502,7 +502,7 @@ class ModelRunner:
 
         # A checkpoint is about to be loaded, so a mismatch between the
         # config's residue alphabet and the checkpoint's tokenizer
-        # alphabet is now meaningful — the checkpoint's tokenizer will
+        # alphabet is now meaningful, the checkpoint's tokenizer will
         # be used and any config-only residues will silently be ignored.
         # ``initialize_tokenizer`` cached the class-level alphabet so we
         # can compare without re-reading the tokenizer module here.

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -407,14 +407,15 @@ class ModelRunner:
         else:
             tokenizer_clss = PeptideTokenizer
 
-        missing_aa = list(
-            set(self.config.residues) - set(tokenizer_clss.residues)
-        )
-        if missing_aa:
-            logger.warning(
-                "Configured residue(s) not in model alphabet: %s",
-                ", ".join(missing_aa),
-            )
+        # NOTE: the "Configured residue(s) not in model alphabet"
+        # warning previously lived here, but firing it from this
+        # method is incorrect: at this point we don't yet know whether
+        # a checkpoint will be loaded. When training from scratch the
+        # config residues *are* the alphabet, so the warning was
+        # unconditionally spurious for any config with modifications
+        # (issue #629). The warning has moved to ``initialize_model``,
+        # which is where the load-vs-train decision is made.
+        self._tokenizer_class_residues = set(tokenizer_clss.residues)
 
         self.tokenizer = tokenizer_clss(
             residues=self.config.residues,
@@ -498,6 +499,23 @@ class ModelRunner:
                 raise ValueError("A model file must be provided")
         # Else a model file is provided (to continue training or for
         # inference).
+
+        # A checkpoint is about to be loaded, so a mismatch between the
+        # config's residue alphabet and the checkpoint's tokenizer
+        # alphabet is now meaningful — the checkpoint's tokenizer will
+        # be used and any config-only residues will silently be ignored.
+        # ``initialize_tokenizer`` cached the class-level alphabet so we
+        # can compare without re-reading the tokenizer module here.
+        tokenizer_residues = getattr(
+            self, "_tokenizer_class_residues", None
+        )
+        if tokenizer_residues is not None:
+            missing_aa = list(set(self.config.residues) - tokenizer_residues)
+            if missing_aa:
+                logger.warning(
+                    "Configured residue(s) not in model alphabet: %s",
+                    ", ".join(missing_aa),
+                )
 
         if not Path(self.model_filename).exists():
             logger.error(

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -565,7 +565,7 @@ def test_initialize_model_train_from_scratch_does_not_warn(tmp_path, caplog):
     """Regression test for #629.
 
     When training from scratch (``model_filename is None``) the config
-    residues *are* the alphabet — there is no prior alphabet to
+    residues *are* the alphabet, there is no prior alphabet to
     mismatch against. The warning must stay silent.
     """
     config = Config()
@@ -597,7 +597,7 @@ def test_initialize_model_warns_when_loading_checkpoint(
 
     The warning *should* fire when a checkpoint is being loaded and
     the config introduces residues that the checkpoint's tokenizer
-    does not know about — that is the case the warning was originally
+    does not know about, that is the case the warning was originally
     intended to surface.
     """
     config = Config()

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -533,16 +533,99 @@ def test_log_metrics(monkeypatch, tiny_config):
             assert aa_recall == pytest.approx(100 * (2 / 3))
 
 
-def test_initialize_tokenizer(caplog):
+def test_initialize_tokenizer_does_not_warn_about_missing_residues(caplog):
+    """Regression test for #629.
+
+    The "Configured residue(s) not in model alphabet" warning previously
+    fired from ``initialize_tokenizer``. Because that method runs before
+    the load-vs-train decision, the warning was unconditionally spurious
+    for any config with modifications when training a model from
+    scratch. The warning has moved to ``initialize_model``, where the
+    decision is actually made.
+    """
     mock_config = unittest.mock.MagicMock()
     mock_config.residues = {"foo": 100}
+    mock_config.massivekb_tokenizer = False
 
     runner = ModelRunner(config=mock_config)
 
     with caplog.at_level("WARNING"):
         runner.initialize_tokenizer()
 
-    assert any(
-        "Configured residue(s) not in model alphabet: foo" in msg
+    assert not any(
+        "Configured residue(s) not in model alphabet" in msg
         for msg in caplog.messages
+    ), (
+        "initialize_tokenizer must no longer emit the alphabet-mismatch "
+        f"warning; got: {caplog.messages!r}"
+    )
+
+
+def test_initialize_model_train_from_scratch_does_not_warn(tmp_path, caplog):
+    """Regression test for #629.
+
+    When training from scratch (``model_filename is None``) the config
+    residues *are* the alphabet — there is no prior alphabet to
+    mismatch against. The warning must stay silent.
+    """
+    config = Config()
+    config.model_save_folder_path = tmp_path
+    # Add a custom modification so the *old* code path would have
+    # warned. Use the same residues + a clearly synthetic addition so
+    # the rest of model construction still works.
+    config.residues = {**config.residues, "X[Synthetic]": 100.0}
+
+    runner = ModelRunner(config=config)
+    runner.initialize_tokenizer()
+
+    with caplog.at_level("WARNING"):
+        runner.initialize_model(train=True)
+
+    assert not any(
+        "Configured residue(s) not in model alphabet" in msg
+        for msg in caplog.messages
+    ), (
+        "training from scratch must not emit the alphabet-mismatch "
+        f"warning; got: {caplog.messages!r}"
+    )
+
+
+def test_initialize_model_warns_when_loading_checkpoint(
+    tmp_path, mgf_small, caplog
+):
+    """Regression test for #629.
+
+    The warning *should* fire when a checkpoint is being loaded and
+    the config introduces residues that the checkpoint's tokenizer
+    does not know about — that is the case the warning was originally
+    intended to surface.
+    """
+    config = Config()
+    config.model_save_folder_path = tmp_path
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    # Train a tiny model with the *default* alphabet so the saved
+    # checkpoint's tokenizer does not include any custom residues.
+    ckpt = tmp_path / "existing.ckpt"
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+        runner.trainer.save_checkpoint(ckpt)
+
+    # Now load the checkpoint with a config that adds a residue not in
+    # the default alphabet. The warning is expected.
+    config.residues = {**config.residues, "X[Synthetic]": 100.0}
+    runner = ModelRunner(config=config, model_filename=str(ckpt))
+    runner.initialize_tokenizer()
+
+    with caplog.at_level("WARNING"):
+        runner.initialize_model(train=False)
+
+    assert any(
+        "Configured residue(s) not in model alphabet" in msg
+        and "X[Synthetic]" in msg
+        for msg in caplog.messages
+    ), (
+        "loading a checkpoint with a residue not in the model alphabet "
+        f"must emit the warning; got: {caplog.messages!r}"
     )


### PR DESCRIPTION
Closes #629.

## Reproduction (from the issue)
With a `config.yaml` that adds modification residues:
```yaml
residues:
  G: 57.021464
  # ...
  C[Carbamidomethyl]: 160.030649
  '[Acetyl]-': 42.010565
```
Then:
```
casanovo train --config config.yaml --output_dir model --output_root run train.mgf --validation_peak_path val.mgf
```
emits:
```
WARNING: Configured residue(s) not in model alphabet: C[Carbamidomethyl], [Acetyl]-
```
even though no `--model` was passed and there is no prior alphabet to mismatch against.

## Root cause
`ModelRunner.initialize_tokenizer` compared `config.residues` against `PeptideTokenizer.residues` (the class-level default alphabet of 20 standard amino acids) and warned on every difference. The method runs *before* `initialize_model`, which is where the load-vs-train decision is made (`model_filename is None`). So at the time the warning fired, it was unknown whether a checkpoint would even be loaded, the warning was unconditional for any config with a modification token.

PR #549 (v5.1.1) had removed an earlier version of this warning entirely. PR #578 reintroduced it but placed the check in the wrong location, leading to this issue.

## Fix
Move the check into `initialize_model`, after the `model_filename is None` branch returns. The warning now fires only when a checkpoint is actually being loaded, the case the warning was originally written for, where the checkpoint's tokenizer will be used and any config-only residues will silently be ignored (the existing `Mismatching tokenizer parameter` warning then follows).

`initialize_tokenizer` stashes the class-level alphabet on `self._tokenizer_class_residues` so `initialize_model` can compare without re-reading the tokenizer module. `getattr(..., None)` keeps callers that bypass `initialize_tokenizer` (synthetic test paths) working unchanged.

## Test plan
Three regression tests in `tests/unit_tests/test_runner.py`:
- [x] `test_initialize_tokenizer_does_not_warn_about_missing_residues`, pins that the warning has *moved out* of `initialize_tokenizer`.
- [x] `test_initialize_model_train_from_scratch_does_not_warn`, exact reproduction from the issue: training from scratch with a config that adds a custom residue is now silent.
- [x] `test_initialize_model_warns_when_loading_checkpoint`, confirms the legitimate case (loading a checkpoint with extra config residues) still emits the warning, including the offending name (`X[Synthetic]`).

Local results:
- [x] All three new tests pass.
- [x] Existing `test_initialize_model` still passes (covers train-from-scratch, inference with `model_filename`, missing-checkpoint error path).

## Changelog
Added an entry under `[Unreleased] / Fixed` in `CHANGELOG.md`.

## Notes
- This restores the behavior PR #549 (v5.1.1) intended, silent on train-from-scratch, while keeping the genuine alphabet-mismatch warning that PR #578 introduced for the load-checkpoint case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed spurious "configured residue(s) not in model alphabet" warnings during training from scratch with custom residue vocabularies; the warning is now emitted only when loading a checkpoint.

* **Tests**
  * Added and adjusted unit tests to verify the new warning behavior.

* **Documentation**
  * Updated changelog to reflect the warning behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->