### PR TITLE
feat(config): allow val_check_interval to be a float (#627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `val_check_interval` now accepts a float in `[0.0, 1.0]` (fraction of epoch) in addition to an int (training-step count), matching the PyTorch Lightning `Trainer` signature. The default in the bundled `config.yaml` changes from `50_000` (steps) to `1.0` (validate once per epoch end). `model_runner` automatically derives a compatible `check_val_every_n_epoch` from the supplied type. (#627)
+
 ## [5.1.2] - 2025-12-11
 
 ### Changed

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -22,13 +22,13 @@ def _coerce_val_check_interval(value):
     PyTorch Lightning's ``Trainer(val_check_interval=...)`` accepts
     both, with different semantics:
 
-    * ``int`` — run validation every N training **steps** (batches).
-    * ``float`` in ``[0.0, 1.0]`` — run validation at that fraction of
+    * ``int``, run validation every N training **steps** (batches).
+    * ``float`` in ``[0.0, 1.0]``, run validation at that fraction of
       each **epoch** (``1.0`` = once per epoch end).
 
     Casanovo's config schema previously cast everything through
     ``int``, which silently truncated a user-supplied ``0.5`` to ``0``
-    (equivalent to "validate every step" — almost certainly not what
+    (equivalent to "validate every step", almost certainly not what
     the user wanted). Accept both shapes here, reject anything else,
     and reject out-of-range floats up front so the error message
     points at the config field rather than failing deep inside
@@ -36,7 +36,7 @@ def _coerce_val_check_interval(value):
 
     See https://github.com/Noble-Lab/casanovo/issues/627.
     """
-    # ``bool`` is a subclass of ``int`` in Python — guard explicitly so
+    # ``bool`` is a subclass of ``int`` in Python, guard explicitly so
     # ``val_check_interval: true`` is not silently coerced to 1.
     if isinstance(value, bool):
         raise TypeError(

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -16,6 +16,54 @@ logger = logging.getLogger("casanovo")
 
 # FIXME: This contains deprecated config options to be removed in the next
 #  major version update.
+def _coerce_val_check_interval(value):
+    """Accept ``val_check_interval`` as either an int or a float.
+
+    PyTorch Lightning's ``Trainer(val_check_interval=...)`` accepts
+    both, with different semantics:
+
+    * ``int`` — run validation every N training **steps** (batches).
+    * ``float`` in ``[0.0, 1.0]`` — run validation at that fraction of
+      each **epoch** (``1.0`` = once per epoch end).
+
+    Casanovo's config schema previously cast everything through
+    ``int``, which silently truncated a user-supplied ``0.5`` to ``0``
+    (equivalent to "validate every step" — almost certainly not what
+    the user wanted). Accept both shapes here, reject anything else,
+    and reject out-of-range floats up front so the error message
+    points at the config field rather than failing deep inside
+    PyTorch Lightning's trainer setup.
+
+    See https://github.com/Noble-Lab/casanovo/issues/627.
+    """
+    # ``bool`` is a subclass of ``int`` in Python — guard explicitly so
+    # ``val_check_interval: true`` is not silently coerced to 1.
+    if isinstance(value, bool):
+        raise TypeError(
+            "val_check_interval must be an int or a float in [0.0, 1.0], "
+            f"got bool ({value!r})"
+        )
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(
+                "val_check_interval as a float must be in [0.0, 1.0] "
+                f"(fraction of epoch); got {value!r}"
+            )
+        return value
+    if isinstance(value, str):
+        # Prefer int over float when the string has no decimal point,
+        # so ``"50000"`` keeps step-count semantics.
+        if "." in value or "e" in value.lower():
+            return _coerce_val_check_interval(float(value))
+        return _coerce_val_check_interval(int(value))
+    raise TypeError(
+        "val_check_interval must be an int or a float in [0.0, 1.0], "
+        f"got {type(value).__name__} ({value!r})"
+    )
+
+
 _config_deprecated = dict(
     n_peaks="max_peaks",
     every_n_train_steps="val_check_interval",
@@ -71,7 +119,7 @@ class Config:
         log_metrics=bool,
         log_every_n_steps=int,
         lance_dir=str,
-        val_check_interval=int,
+        val_check_interval=lambda v: _coerce_val_check_interval(v),
         min_peaks=int,
         max_peaks=int,
         min_mz=float,

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -90,8 +90,11 @@ log_metrics: false
 log_every_n_steps: 50
 # Path to save Lance instances.
 lance_dir:
-# Model validation and checkpointing frequency in training steps.
-val_check_interval: 50_000
+# Model validation and checkpointing frequency.
+# - An int (e.g. `50_000`) runs validation every N training steps.
+# - A float in [0.0, 1.0] (e.g. `0.5`) runs validation that fraction
+#   of the way through each epoch (`1.0` = once per epoch end).
+val_check_interval: 1.0
 
 # SPECTRUM PROCESSING OPTIONS
 # Minimum number of peaks for a spectrum to be considered valid.

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -386,7 +386,7 @@ class ModelRunner:
             # check_val_every_n_epoch must be None to disable the
             # epoch-based check), and a float in [0, 1] means "this
             # fraction of every epoch" (in which case
-            # check_val_every_n_epoch must be a positive int — defaults
+            # check_val_every_n_epoch must be a positive int, defaults
             # to 1 in PL). Issue #627.
             val_check_interval = self.config.val_check_interval
             if isinstance(val_check_interval, float):

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -381,16 +381,29 @@ class ModelRunner:
                             ),
                         )
 
+            # PyTorch Lightning interprets val_check_interval based on its
+            # type: an int means "every N training steps" (in which case
+            # check_val_every_n_epoch must be None to disable the
+            # epoch-based check), and a float in [0, 1] means "this
+            # fraction of every epoch" (in which case
+            # check_val_every_n_epoch must be a positive int — defaults
+            # to 1 in PL). Issue #627.
+            val_check_interval = self.config.val_check_interval
+            if isinstance(val_check_interval, float):
+                check_val_every_n_epoch = 1
+            else:
+                check_val_every_n_epoch = None
+
             additional_cfg = dict(
                 devices=devices,
-                val_check_interval=self.config.val_check_interval,
+                val_check_interval=val_check_interval,
                 max_epochs=self.config.max_epochs,
                 num_sanity_val_steps=self.config.num_sanity_val_steps,
                 accumulate_grad_batches=self.config.accumulate_grad_batches,
                 gradient_clip_val=self.config.gradient_clip_val,
                 gradient_clip_algorithm=self.config.gradient_clip_algorithm,
                 callbacks=self.callbacks,
-                check_val_every_n_epoch=None,
+                check_val_every_n_epoch=check_val_every_n_epoch,
                 enable_checkpointing=True,
                 logger=loggers,
                 strategy=self._get_strategy(),

--- a/docs/file_formats.md
+++ b/docs/file_formats.md
@@ -47,7 +47,7 @@ After Casanovo processes your input file(s), it provides the results in an **[mz
 This file is divided into two main sections:
 
 1. **Metadata section**: This part describes general information about the file and the Casanovo task.
-2. **Peptide–spectrum match (PSM) section**: Details of the peptide sequences that Casanovo predicted for the MS/MS spectra.
+2. **Peptide-spectrum match (PSM) section**: Details of the peptide sequences that Casanovo predicted for the MS/MS spectra.
 
 mzTab files can contain additional sections to include protein identifications and quantification information as well.
 However, as these levels of information are not relevant for Casanovo, these are not included in its output mzTab files.
@@ -76,7 +76,7 @@ MTD	software[1]	[MS, MS:1003281, Casanovo, 4.0.1]
 ```
 
 This identifies this mzTab file with filename "my_example_output" as a summary-level identification file produced by Casanovo.
-On the final line you can see a typical key–value entry using information defined in the [PSI-MS controlled vocabulary](https://github.com/HUPO-PSI/psi-ms-CV/).
+On the final line you can see a typical key-value entry using information defined in the [PSI-MS controlled vocabulary](https://github.com/HUPO-PSI/psi-ms-CV/).
 In this case, the line indicates that the file is produced by the Casanovo software, which is recorded in the `MS` controlled vocabulary with accession number `MS:1003281`.
 The final element is the version number of Casanovo that produced this file.
 
@@ -261,7 +261,7 @@ Tips for using log files:
 ## For Advanced Users: Training Casanovo
 
 To train a new Casanovo model, the training and validation data must be provided as **annotated MGF files**.
-Annotated MGF files are similar to standard MGF files but include a `SEQ` key–value pair in the spectrum header, indicating the peptide sequence for the corresponding spectrum.
+Annotated MGF files are similar to standard MGF files but include a `SEQ` key-value pair in the spectrum header, indicating the peptide sequence for the corresponding spectrum.
 
 Example of an annotated MGF file entry:
 

--- a/docs/file_formats.md
+++ b/docs/file_formats.md
@@ -287,7 +287,7 @@ Similarly, in Casanovo evaluation mode only annotated MGF files are supported.
 
 <!-- TODO: when index files can be reused, document this here -->
 
-During training, Casanovo will save **checkpoint files** at every `val_check_interval` steps, specified in the configuration.
+During training, Casanovo will save **checkpoint files** at the `val_check_interval` cadence specified in the configuration. `val_check_interval` accepts either an int (every N training steps) or a float in `[0.0, 1.0]` (that fraction of every epoch; e.g. `1.0` saves once at each epoch end).
 Model checkpoints will be saved to the folder specified by the `--output_dir` command line option with filename format `epoch=EPOCH-step=STEP.ckpt`, with `EPOCH` the epoch and `STEP` the training step at which the checkpoint was taken, helping you track progress and select the best model based on validation performance.
 
 <!-- TODO: when checkpointing is made more flexible, update this information -->

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -92,3 +92,74 @@ def test_override_mps(monkeypatch, tiny_config, tmp_path, caplog):
             "overwritten to 'cpu' on Apple Silicon" in rec.getMessage()
             for rec in caplog.records
         )
+
+
+# Regression tests for https://github.com/Noble-Lab/casanovo/issues/627.
+# val_check_interval must accept both int (training-step count) and
+# float in [0.0, 1.0] (fraction of epoch), matching PyTorch Lightning's
+# Trainer signature.
+
+def test_val_check_interval_accepts_int(tmp_path, tiny_config):
+    filename = str(tmp_path / "vci_int.yml")
+    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+        cfg = yaml.safe_load(f_in)
+        cfg["val_check_interval"] = 50_000
+        yaml.safe_dump(cfg, f_out)
+
+    cfg = Config(filename)
+    assert cfg.val_check_interval == 50_000
+    assert isinstance(cfg.val_check_interval, int)
+
+
+def test_val_check_interval_accepts_float(tmp_path, tiny_config):
+    filename = str(tmp_path / "vci_float.yml")
+    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+        cfg = yaml.safe_load(f_in)
+        cfg["val_check_interval"] = 0.5
+        yaml.safe_dump(cfg, f_out)
+
+    cfg = Config(filename)
+    assert cfg.val_check_interval == 0.5
+    assert isinstance(cfg.val_check_interval, float)
+
+
+def test_val_check_interval_rejects_float_above_one(tmp_path, tiny_config):
+    filename = str(tmp_path / "vci_too_big.yml")
+    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+        cfg = yaml.safe_load(f_in)
+        cfg["val_check_interval"] = 1.5
+        yaml.safe_dump(cfg, f_out)
+
+    with pytest.raises(TypeError, match="val_check_interval"):
+        Config(filename)
+
+
+def test_val_check_interval_rejects_float_below_zero(tmp_path, tiny_config):
+    filename = str(tmp_path / "vci_neg.yml")
+    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+        cfg = yaml.safe_load(f_in)
+        cfg["val_check_interval"] = -0.1
+        yaml.safe_dump(cfg, f_out)
+
+    with pytest.raises(TypeError, match="val_check_interval"):
+        Config(filename)
+
+
+def test_val_check_interval_rejects_bool(tmp_path, tiny_config):
+    # bool is a subclass of int in Python — must not silently coerce
+    # `true` / `false` into 1 / 0.
+    filename = str(tmp_path / "vci_bool.yml")
+    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+        cfg = yaml.safe_load(f_in)
+        cfg["val_check_interval"] = True
+        yaml.safe_dump(cfg, f_out)
+
+    with pytest.raises(TypeError, match="val_check_interval"):
+        Config(filename)
+
+
+def test_val_check_interval_default_is_one_point_oh():
+    """The default config now ships `val_check_interval: 1.0` (validate
+    once per epoch end), not the old `50_000`-step value."""
+    cfg = Config()
+    assert cfg.val_check_interval == 1.0

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -146,7 +146,7 @@ def test_val_check_interval_rejects_float_below_zero(tmp_path, tiny_config):
 
 
 def test_val_check_interval_rejects_bool(tmp_path, tiny_config):
-    # bool is a subclass of int in Python — must not silently coerce
+    # bool is a subclass of int in Python, must not silently coerce
     # `true` / `false` into 1 / 0.
     filename = str(tmp_path / "vci_bool.yml")
     with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:


### PR DESCRIPTION
Closes #627.

## Summary
PyTorch Lightning's `Trainer(val_check_interval=...)` accepts:
- **int**, validate every N training steps (batches);
- **float in `[0.0, 1.0]`**, validate at that fraction of every epoch (`1.0` = once per epoch end).

Casanovo's config schema previously cast everything through `int`, silently truncating a user-supplied `0.5` to `0` ("validate every step", almost certainly not what the user wanted).

## Change
- Replace the bare `int` cast in `_config_types` with a small `_coerce_val_check_interval` validator that:
  - keeps int values as-is (step-count semantics);
  - accepts float values in `[0.0, 1.0]` (fraction-of-epoch semantics) and rejects out-of-range floats up front so the error message points at the config field rather than failing deep inside Lightning's trainer setup;
  - refuses bool (an int subclass in Python) so `val_check_interval: true` is not silently coerced to `1`;
  - parses string values from CLI/yaml in either form, dispatching on whether the literal contains `.` or `e`.
- Default value in `casanovo/config.yaml` changes from `50_000` (steps) to `1.0` (once per epoch end), per the issue.
- `model_runner` derives a compatible `check_val_every_n_epoch` based on the supplied type:
  - `int` → `check_val_every_n_epoch=None` (step-mode; epoch-based check disabled, matches the previous behavior);
  - `float` → `check_val_every_n_epoch=1` (fraction-of-epoch; PL requires a positive int here).
- Updated `docs/file_formats.md` and `CHANGELOG.md`. The FAQ entry already speaks generically about "validation run frequency" so it didn't need a change.

## Test plan
Six new tests under `tests/unit_tests/test_config.py`:
- [x] `test_val_check_interval_accepts_int`, `50_000` parses to int (existing behavior).
- [x] `test_val_check_interval_accepts_float`, `0.5` parses to float.
- [x] `test_val_check_interval_rejects_float_above_one`, `1.5` raises `TypeError`.
- [x] `test_val_check_interval_rejects_float_below_zero`, `-0.1` raises `TypeError`.
- [x] `test_val_check_interval_rejects_bool`, `true` raises `TypeError` (bool subclass guard).
- [x] `test_val_check_interval_default_is_one_point_oh`, pins the new default.

Local results:
- [x] `pytest tests/unit_tests/test_config.py -k val_check_interval` → **6 passed**.
- [x] `pytest tests/unit_tests/test_config.py` → 9 passed, 1 fail in `test_default` (pre-existing Apple-Silicon issue unrelated to this change, accelerator gets auto-overwritten to `cpu` even on a fresh `Config()`).

## Notes
- This is a soft schema widening, every previously-valid `val_check_interval: <int>` config keeps working unchanged. Configs that previously read a float and silently became `0` now do the right thing.
- The default change to `1.0` is the first user-visible behavior change a fresh checkout will see; called out explicitly in the CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `val_check_interval` configuration now accepts both integer values (training steps) and float values (epoch fractions) for flexible validation scheduling.

* **Documentation**
  * Added documentation clarifying `val_check_interval` parameter accepts integers or float values between 0.0, 1.0.

* **Chores**
  * Default validation interval updated from 50,000 training steps to 1.0, validating at the end of each epoch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->