### PR TITLE
Fix integration test compatibility with pandas 3.0

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -280,7 +280,7 @@ def test_train_and_run(
         None,
         "27-Carbamidomethyl (C):UNIMOD:4",
     ]
-    for actual, expected in zip(mods, expected_mods):
+    for actual, expected in zip(mods, expected_mods, strict=True):
         if expected is None:
             assert pd.isna(actual)
         else:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,7 @@ import functools
 import subprocess
 from pathlib import Path
 
+import pandas as pd
 import pyteomics.mztab
 import pytest
 import yaml
@@ -269,8 +270,8 @@ def test_train_and_run(
         "FSGSGSGTDFTLTISSLQPEDFAVYYCQQDYNLP",
     ]
 
-    mods = psms["modifications"].to_list()
-    assert mods == [
+    mods = psms["modifications"]
+    expected_mods = [
         None,
         "5-Carbamidomethyl (C):UNIMOD:4",
         None,
@@ -279,6 +280,11 @@ def test_train_and_run(
         None,
         "27-Carbamidomethyl (C):UNIMOD:4",
     ]
+    for actual, expected in zip(mods, expected_mods):
+        if expected is None:
+            assert pd.isna(actual)
+        else:
+            assert actual == expected
 
     # Validate the mzTab output file.
     validate_args = [


### PR DESCRIPTION
Fixes #634.

Pandas 3.0 changed the default string dtype from object to str (PyArrow-backed), which converts None to NaN in mixed string/null DataFrame columns. This caused test_train_and_run to fail when asserting mzTab modification values against None.

Use pd.isna() for null checks instead of direct None equality, matching the existing pattern in test_unit.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test validation for database prediction results: strict per-entry checks and NA-aware handling of missing modifications to reduce false positives.

---

**Note:** This release contains no user-facing changes. Updates are internal improvements to test coverage and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->