### PR TITLE
Fine-tune from checkpoint with extended residue vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `--load_all_states` flag to load all model states when resuming training.
 - A TSV file with all candidate peptides can be exported during database searching with the `--export` flag.
 - Track instrument-assigned scan numbers from MGF `SCANS`, `SCAN`, and `SCAN ID` header fields in a new `opt_global_cv_MS:1003057_scan_number` mzTab column.
+- Support fine-tuning a pretrained checkpoint with an extended residue vocabulary via the `new_token_init` config option.
 - Per-file validation loss logging via `valid_CELoss/<stem>` keys.
 - New `--tracking_peak_path/-t` CLI option for monitoring catastrophic forgetting on additional validation files without affecting checkpoint selection.
 

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -102,6 +102,7 @@ class Config:
         replace_isoleucine_with_leucine=bool,
         massivekb_tokenizer=bool,
         residues=dict,
+        new_token_init=dict,
     )
 
     def __init__(self, config_file: Optional[str] = None):

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -208,6 +208,8 @@ residues:
 
 # When fine-tuning from a checkpoint with a smaller vocabulary, map each new
 # token to an existing token whose weights should be used for initialization.
-# Example:  "K[Acetyl]": "K"
-# Leave empty ({}) when training from scratch or when vocabs already match.
+# Example:
+#   new_token_init:
+#     "K[Acetyl]": "K"
+# Leave empty when training from scratch or when vocabs already match.
 new_token_init: {}

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -205,3 +205,9 @@ residues:
   "[Ammonia-loss]-": -17.026549           # Ammonia loss
   "[+25.980265]-": 25.980265              # Carbamylation and ammonia loss
   #"[Carbamyl][Ammonia-loss]-": 25.980265  # Carbamylation and ammonia loss
+
+# When fine-tuning from a checkpoint with a smaller vocabulary, map each new
+# token to an existing token whose weights should be used for initialization.
+# Example:  "K[+46.032751]": "K"
+# Leave empty ({}) when training from scratch or when vocabs already match.
+new_token_init: {}

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -208,6 +208,6 @@ residues:
 
 # When fine-tuning from a checkpoint with a smaller vocabulary, map each new
 # token to an existing token whose weights should be used for initialization.
-# Example:  "K[+46.032751]": "K"
+# Example:  "K[Acetyl]": "K"
 # Leave empty ({}) when training from scratch or when vocabs already match.
 new_token_init: {}

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -206,8 +206,8 @@ residues:
   "[+25.980265]-": 25.980265              # Carbamylation and ammonia loss
   #"[Carbamyl][Ammonia-loss]-": 25.980265  # Carbamylation and ammonia loss
 
-# When fine-tuning from a checkpoint with a smaller vocabulary, map each new
-# token to an existing token whose weights should be used for initialization.
+# When fine-tuning with a vocabulary that extends the checkpoint's, map each
+# new token to an existing token whose weights should be used for initialization.
 # Example:
 #   new_token_init:
 #     "K[Acetyl]": "K"

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -451,107 +451,6 @@ class ModelRunner:
             stop_token="$",
         )
 
-    def _remap_decoder_vocab(
-        self,
-        ckpt_tokenizer: Optional[PeptideTokenizer],
-        new_tokenizer: PeptideTokenizer,
-    ) -> None:
-        """Remap the decoder embedding and output layers to a new vocabulary.
-
-        Called after loading a checkpoint whose tokenizer vocabulary differs
-        from the config tokenizer (e.g. when fine-tuning with additional PTM
-        tokens). Rows for tokens present in both vocabularies are copied by
-        name; rows for new tokens are initialized from ``config.new_token_init``
-        (a dict mapping new token -> existing token to copy from). After this
-        call the decoder layers and ``model.vocab_size`` reflect the new vocab.
-
-        Parameters
-        ----------
-        ckpt_tokenizer : PeptideTokenizer or None
-            The tokenizer stored in the checkpoint. If None the function
-            returns immediately.
-        new_tokenizer : PeptideTokenizer
-            The tokenizer built from the current config file.
-        """
-        if ckpt_tokenizer is None:
-            return
-        ckpt_vocab = ckpt_tokenizer.index
-        new_vocab = new_tokenizer.index
-        if set(ckpt_vocab) == set(new_vocab):
-            return
-
-        new_tokens = set(new_vocab) - set(ckpt_vocab)
-        removed_tokens = set(ckpt_vocab) - set(new_vocab)
-        if removed_tokens:
-            logger.warning(
-                "Checkpoint tokens absent from new config (dropped): %s",
-                sorted(removed_tokens),
-            )
-
-        new_token_init: dict = self.config.new_token_init or {}
-        missing_init = new_tokens - set(new_token_init)
-        if missing_init:
-            raise ValueError(
-                f"New tokens {sorted(missing_init)} have no initialization "
-                "source. Add entries to the 'new_token_init' config field, "
-                'e.g.  "K[+46.032751]": "K"'
-            )
-
-        logger.info(
-            "Remapping decoder vocabulary: %d -> %d tokens",
-            len(ckpt_vocab) + 1,
-            len(new_vocab) + 1,
-        )
-
-        def _remap_rows(old: torch.Tensor) -> torch.Tensor:
-            """Return a new tensor with rows remapped by token name."""
-            new_n = len(new_vocab) + 1
-            out = torch.zeros(
-                new_n, *old.shape[1:], dtype=old.dtype, device=old.device
-            )
-            out[0] = old[0]
-            for tok, new_idx in new_vocab.items():
-                if tok in ckpt_vocab:
-                    out[new_idx] = old[ckpt_vocab[tok]]
-                else:
-                    init_src = new_token_init[tok]
-                    if init_src not in ckpt_vocab:
-                        raise ValueError(
-                            f"Init source {init_src!r} for new token "
-                            f"{tok!r} is not in checkpoint vocabulary"
-                        )
-                    out[new_idx] = old[ckpt_vocab[init_src]]
-            return out
-
-        new_n_tokens = len(new_vocab) + 1
-        decoder = self.model.decoder
-
-        old_emb = decoder.token_encoder.weight.data
-        new_emb = _remap_rows(old_emb)
-        decoder.token_encoder = torch.nn.Embedding(
-            new_n_tokens,
-            old_emb.shape[1],
-            padding_idx=decoder.token_encoder.padding_idx,
-        ).to(old_emb.device)
-        decoder.token_encoder.weight.data.copy_(new_emb)
-
-        old_w = decoder.final.weight.data
-        old_b = (
-            decoder.final.bias.data.clone()
-            if decoder.final.bias is not None
-            else None
-        )
-        new_w = _remap_rows(old_w)
-        decoder.final = torch.nn.Linear(
-            old_w.shape[1], new_n_tokens, bias=old_b is not None
-        ).to(old_w.device)
-        decoder.final.weight.data.copy_(new_w)
-        if old_b is not None:
-            decoder.final.bias.data.copy_(_remap_rows(old_b))
-
-        self.model.vocab_size = new_n_tokens
-        self.model.hparams["tokenizer"] = new_tokenizer
-
     def initialize_model(self, train: bool, db_search: bool = False) -> None:
         """Initialize the Casanovo model.
 
@@ -863,6 +762,124 @@ class ModelRunner:
                 "config's `residues` and token ordering match those used "
                 "during training."
             )
+
+    def _remap_decoder_vocab(
+        self,
+        ckpt_tokenizer: Optional[PeptideTokenizer],
+        new_tokenizer: PeptideTokenizer,
+    ) -> None:
+        """Remap the decoder embedding and output layers to a new vocabulary.
+
+        Called after loading a checkpoint whose tokenizer vocabulary differs
+        from the config tokenizer (e.g. when fine-tuning with additional PTM
+        tokens). Rows for tokens present in both vocabularies are copied by
+        name; rows for new tokens are initialized from ``config.new_token_init``
+        (a dict mapping new token -> existing token to copy from). After this
+        call the decoder layers and ``model.vocab_size`` reflect the new vocab.
+
+        Parameters
+        ----------
+        ckpt_tokenizer : PeptideTokenizer or None
+            The tokenizer stored in the checkpoint. If None the function
+            returns immediately.
+        new_tokenizer : PeptideTokenizer
+            The tokenizer built from the current config file.
+        """
+        if ckpt_tokenizer is None:
+            return
+        # Build index dicts: token -> integer position in the embedding table.
+        ckpt_vocab = ckpt_tokenizer.index
+        new_vocab = new_tokenizer.index
+        if set(ckpt_vocab) == set(new_vocab):
+            return
+
+        # Identify which tokens are added or removed relative to the checkpoint.
+        new_tokens = set(new_vocab) - set(ckpt_vocab)
+        removed_tokens = set(ckpt_vocab) - set(new_vocab)
+        if removed_tokens:
+            logger.warning(
+                "Checkpoint tokens absent from new config (dropped): %s",
+                sorted(removed_tokens),
+            )
+
+        # Every new token must have an initialization source in the config.
+        new_token_init: dict = self.config.new_token_init or {}
+        missing_init = new_tokens - set(new_token_init)
+        if missing_init:
+            raise ValueError(
+                f"New tokens {sorted(missing_init)} have no initialization "
+                "source. Add entries to the 'new_token_init' config field, "
+                'e.g.  "K[+46.032751]": "K"'
+            )
+
+        logger.info(
+            "Remapping decoder vocabulary: %d -> %d tokens",
+            len(ckpt_vocab) + 1,
+            len(new_vocab) + 1,
+        )
+
+        def _remap_rows(old: torch.Tensor) -> torch.Tensor:
+            """Return a new tensor with rows remapped by token name.
+
+            Row 0 (padding) is preserved as-is. Every other row is either
+            copied from the matching checkpoint position (known token) or
+            copied from the initialization-source token (new token).
+            """
+            new_n = len(new_vocab) + 1
+            out = torch.zeros(
+                new_n, *old.shape[1:], dtype=old.dtype, device=old.device
+            )
+            # Row 0 is the padding embedding; keep it unchanged.
+            out[0] = old[0]
+            for tok, new_idx in new_vocab.items():
+                if tok in ckpt_vocab:
+                    out[new_idx] = old[ckpt_vocab[tok]]
+                else:
+                    # New token: copy weights from the configured source token.
+                    init_src = new_token_init[tok]
+                    if init_src not in ckpt_vocab:
+                        raise ValueError(
+                            f"Init source {init_src!r} for new token "
+                            f"{tok!r} is not in checkpoint vocabulary"
+                        )
+                    out[new_idx] = old[ckpt_vocab[init_src]]
+            return out
+
+        new_n_tokens = len(new_vocab) + 1
+        decoder = self.model.decoder
+
+        # Replace the input embedding table (token -> vector).
+        old_emb = decoder.token_encoder.weight.data
+        new_emb = _remap_rows(old_emb)
+        decoder.token_encoder = torch.nn.Embedding(
+            new_n_tokens,
+            old_emb.shape[1],
+            padding_idx=decoder.token_encoder.padding_idx,
+        ).to(old_emb.device)
+        decoder.token_encoder.weight.data.copy_(new_emb)
+
+        # Replace the output projection (vector -> logit per token).
+        # Capture bias BEFORE replacing the layer to avoid reading
+        # the new (zero-initialized) bias instead of the checkpoint bias.
+        old_w = decoder.final.weight.data
+        old_b = (
+            decoder.final.bias.data.clone()
+            if decoder.final.bias is not None
+            else None
+        )
+        new_w = _remap_rows(old_w)
+        decoder.final = torch.nn.Linear(
+            old_w.shape[1], new_n_tokens, bias=old_b is not None
+        ).to(old_w.device)
+        decoder.final.weight.data.copy_(new_w)
+        if old_b is not None:
+            decoder.final.bias.data.copy_(_remap_rows(old_b))
+
+        # Keep vocab_size and the checkpoint's hyperparameter record in sync
+        # with the new layers so downstream comparisons and checkpoint saves
+        # see the updated vocabulary.
+        self.model.vocab_size = new_n_tokens
+        self.model.hparams["tokenizer"] = new_tokenizer
 
 
 def _get_peak_filenames(

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -790,12 +790,14 @@ class ModelRunner:
         # Build index dicts: token -> integer position in the embedding table.
         ckpt_vocab = ckpt_tokenizer.index
         new_vocab = new_tokenizer.index
-        if set(ckpt_vocab) == set(new_vocab):
+        ckpt_set = set(ckpt_vocab)
+        new_set = set(new_vocab)
+        if ckpt_set == new_set:
             return
 
         # Identify which tokens are added or removed relative to the checkpoint.
-        new_tokens = set(new_vocab) - set(ckpt_vocab)
-        removed_tokens = set(ckpt_vocab) - set(new_vocab)
+        new_tokens = new_set - ckpt_set
+        removed_tokens = ckpt_set - new_set
         if removed_tokens:
             logger.warning(
                 "Checkpoint tokens absent from new config (dropped): %s",

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -451,6 +451,107 @@ class ModelRunner:
             stop_token="$",
         )
 
+    def _remap_decoder_vocab(
+        self,
+        ckpt_tokenizer: Optional[PeptideTokenizer],
+        new_tokenizer: PeptideTokenizer,
+    ) -> None:
+        """Remap the decoder embedding and output layers to a new vocabulary.
+
+        Called after loading a checkpoint whose tokenizer vocabulary differs
+        from the config tokenizer (e.g. when fine-tuning with additional PTM
+        tokens). Rows for tokens present in both vocabularies are copied by
+        name; rows for new tokens are initialized from ``config.new_token_init``
+        (a dict mapping new token -> existing token to copy from). After this
+        call the decoder layers and ``model.vocab_size`` reflect the new vocab.
+
+        Parameters
+        ----------
+        ckpt_tokenizer : PeptideTokenizer or None
+            The tokenizer stored in the checkpoint. If None the function
+            returns immediately.
+        new_tokenizer : PeptideTokenizer
+            The tokenizer built from the current config file.
+        """
+        if ckpt_tokenizer is None:
+            return
+        ckpt_vocab = ckpt_tokenizer.index
+        new_vocab = new_tokenizer.index
+        if set(ckpt_vocab) == set(new_vocab):
+            return
+
+        new_tokens = set(new_vocab) - set(ckpt_vocab)
+        removed_tokens = set(ckpt_vocab) - set(new_vocab)
+        if removed_tokens:
+            logger.warning(
+                "Checkpoint tokens absent from new config (dropped): %s",
+                sorted(removed_tokens),
+            )
+
+        new_token_init: dict = self.config.new_token_init or {}
+        missing_init = new_tokens - set(new_token_init)
+        if missing_init:
+            raise ValueError(
+                f"New tokens {sorted(missing_init)} have no initialization "
+                "source. Add entries to the 'new_token_init' config field, "
+                'e.g.  "K[+46.032751]": "K"'
+            )
+
+        logger.info(
+            "Remapping decoder vocabulary: %d -> %d tokens",
+            len(ckpt_vocab) + 1,
+            len(new_vocab) + 1,
+        )
+
+        def _remap_rows(old: torch.Tensor) -> torch.Tensor:
+            """Return a new tensor with rows remapped by token name."""
+            new_n = len(new_vocab) + 1
+            out = torch.zeros(
+                new_n, *old.shape[1:], dtype=old.dtype, device=old.device
+            )
+            out[0] = old[0]
+            for tok, new_idx in new_vocab.items():
+                if tok in ckpt_vocab:
+                    out[new_idx] = old[ckpt_vocab[tok]]
+                else:
+                    init_src = new_token_init[tok]
+                    if init_src not in ckpt_vocab:
+                        raise ValueError(
+                            f"Init source {init_src!r} for new token "
+                            f"{tok!r} is not in checkpoint vocabulary"
+                        )
+                    out[new_idx] = old[ckpt_vocab[init_src]]
+            return out
+
+        new_n_tokens = len(new_vocab) + 1
+        decoder = self.model.decoder
+
+        old_emb = decoder.token_encoder.weight.data
+        new_emb = _remap_rows(old_emb)
+        decoder.token_encoder = torch.nn.Embedding(
+            new_n_tokens,
+            old_emb.shape[1],
+            padding_idx=decoder.token_encoder.padding_idx,
+        ).to(old_emb.device)
+        decoder.token_encoder.weight.data.copy_(new_emb)
+
+        old_w = decoder.final.weight.data
+        old_b = (
+            decoder.final.bias.data.clone()
+            if decoder.final.bias is not None
+            else None
+        )
+        new_w = _remap_rows(old_w)
+        decoder.final = torch.nn.Linear(
+            old_w.shape[1], new_n_tokens, bias=old_b is not None
+        ).to(old_w.device)
+        decoder.final.weight.data.copy_(new_w)
+        if old_b is not None:
+            decoder.final.bias.data.copy_(_remap_rows(old_b))
+
+        self.model.vocab_size = new_n_tokens
+        self.model.hparams["tokenizer"] = new_tokenizer
+
     def initialize_model(self, train: bool, db_search: bool = False) -> None:
         """Initialize the Casanovo model.
 
@@ -542,7 +643,9 @@ class ModelRunner:
             )
             # Use tokenizer initialized from config file instead of loaded
             # from checkpoint file.
+            ckpt_tokenizer = self.model.hparams.get("tokenizer")
             self.model.tokenizer = tokenizer
+            self._remap_decoder_vocab(ckpt_tokenizer, tokenizer)
 
             architecture_params = set(model_params.keys()) - set(
                 loaded_model_params.keys()
@@ -571,7 +674,9 @@ class ModelRunner:
                     weights_only=False,
                     **model_params,
                 )
+                ckpt_tokenizer = self.model.hparams.get("tokenizer")
                 self.model.tokenizer = tokenizer
+                self._remap_decoder_vocab(ckpt_tokenizer, tokenizer)
 
             except RuntimeError:
                 raise RuntimeError(

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -809,7 +809,7 @@ class ModelRunner:
             raise ValueError(
                 f"New tokens {sorted(missing_init)} have no initialization "
                 "source. Add entries to the 'new_token_init' config field, "
-                'e.g.  "K[+46.032751]": "K"'
+                'e.g.  "K[Acetyl]": "K"'
             )
 
         logger.info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,6 +362,7 @@ def _get_config_file(file_path, file_name, additional_cfg=None):
             "[Ammonia-loss]-": -17.026549,
             "[+25.980265]-": 25.980265,
         },
+        "new_token_init": {},
     }
 
     if additional_cfg is not None:

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -744,3 +744,196 @@ def test_train_with_tracking_peak_path(tmp_path, mgf_small, tiny_config):
         # Per-file key must appear in logged metrics history.
         track_key = f"valid/{Path(mgf_track).stem}"
         assert any(track_key in metrics for metrics in runner.model._history)
+
+
+def test_remap_decoder_vocab_no_change(tmp_path, mgf_small, tiny_config):
+    """Identical vocabs: weights unchanged and layers not rebuilt."""
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+
+        old_emb = runner.model.decoder.token_encoder
+        old_final = runner.model.decoder.final
+        old_emb_data = old_emb.weight.data.clone()
+        old_final_data = old_final.weight.data.clone()
+
+        runner._remap_decoder_vocab(runner.tokenizer, runner.tokenizer)
+
+        assert runner.model.decoder.token_encoder is old_emb
+        assert runner.model.decoder.final is old_final
+        assert torch.equal(old_emb.weight.data, old_emb_data)
+        assert torch.equal(old_final.weight.data, old_final_data)
+
+
+def test_remap_decoder_vocab_extends(tmp_path, mgf_small, tiny_config):
+    """Extending vocab copies shared rows and inits new token from source."""
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+        runner.trainer.save_checkpoint(tmp_path / "base.ckpt")
+
+    new_residues = dict(config.residues)
+    new_residues["K[Acetyl]"] = 128.094963 + 42.010565
+
+    ext_config = Config(tiny_config)
+    ext_config.residues = new_residues
+    ext_config.new_token_init = {"K[Acetyl]": "K"}
+    ext_config.n_layers = 1
+
+    runner = ModelRunner(
+        config=ext_config, model_filename=str(tmp_path / "base.ckpt")
+    )
+    runner.initialize_tokenizer()
+
+    from depthcharge.tokenizers import PeptideTokenizer
+
+    ckpt_tokenizer = PeptideTokenizer(
+        residues=config.residues,
+        replace_isoleucine_with_leucine=config.replace_isoleucine_with_leucine,
+        reverse=True,
+        start_token=None,
+        stop_token="$",
+    )
+    old_k_idx = ckpt_tokenizer.index["K"]
+    runner.initialize_model(train=True)
+
+    new_tokenizer = runner.tokenizer
+    new_k_mod_idx = new_tokenizer.index["K[Acetyl]"]
+    new_k_idx = new_tokenizer.index["K"]
+    new_n = len(new_tokenizer) + 1
+
+    assert runner.model.vocab_size == new_n
+    assert runner.model.hparams["tokenizer"] is new_tokenizer
+
+    emb_w = runner.model.decoder.token_encoder.weight.data
+    final_w = runner.model.decoder.final.weight.data
+    assert torch.equal(emb_w[new_k_mod_idx], emb_w[new_k_idx])
+    assert torch.equal(final_w[new_k_mod_idx], final_w[new_k_idx])
+
+
+def test_remap_decoder_vocab_missing_init_raises(
+    tmp_path, mgf_small, tiny_config
+):
+    """Extending vocab with no new_token_init entry raises ValueError."""
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+        runner.trainer.save_checkpoint(tmp_path / "base.ckpt")
+
+    new_residues = dict(config.residues)
+    new_residues["K[Acetyl]"] = 128.094963 + 42.010565
+
+    ext_config = Config(tiny_config)
+    ext_config.residues = new_residues
+    ext_config.new_token_init = {}
+    ext_config.n_layers = 1
+
+    runner = ModelRunner(
+        config=ext_config, model_filename=str(tmp_path / "base.ckpt")
+    )
+    runner.initialize_tokenizer()
+    with pytest.raises(ValueError, match="no initialization source"):
+        runner.initialize_model(train=True)
+
+
+def test_remap_decoder_vocab_bad_init_source_raises(
+    tmp_path, mgf_small, tiny_config
+):
+    """Init source not in checkpoint vocab raises ValueError."""
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+        runner.trainer.save_checkpoint(tmp_path / "base.ckpt")
+
+    new_residues = dict(config.residues)
+    new_residues["K[Acetyl]"] = 128.094963 + 42.010565
+
+    ext_config = Config(tiny_config)
+    ext_config.residues = new_residues
+    ext_config.new_token_init = {"K[Acetyl]": "NONEXISTENT"}
+    ext_config.n_layers = 1
+
+    runner = ModelRunner(
+        config=ext_config, model_filename=str(tmp_path / "base.ckpt")
+    )
+    runner.initialize_tokenizer()
+    with pytest.raises(ValueError, match="not in checkpoint vocabulary"):
+        runner.initialize_model(train=True)
+
+
+def test_remap_decoder_vocab_drops_token_warns(
+    tmp_path, mgf_small, tiny_config, caplog
+):
+    """Checkpoint token absent from new vocab logs a warning."""
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+        runner.trainer.save_checkpoint(tmp_path / "base.ckpt")
+
+    reduced_residues = {
+        k: v for k, v in config.residues.items() if k != "M[Oxidation]"
+    }
+
+    red_config = Config(tiny_config)
+    red_config.residues = reduced_residues
+    red_config.n_layers = 1
+
+    runner = ModelRunner(
+        config=red_config, model_filename=str(tmp_path / "base.ckpt")
+    )
+    runner.initialize_tokenizer()
+    with caplog.at_level("WARNING"):
+        runner.initialize_model(train=True)
+
+    assert any("dropped" in rec.message.lower() for rec in caplog.records)
+
+
+def test_initialize_model_with_new_token_init_passes_validate(
+    tmp_path, mgf_small, tiny_config
+):
+    """End-to-end: load checkpoint with extended vocab passes validation."""
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+    ckpt = tmp_path / "base.ckpt"
+
+    with ModelRunner(config=config, output_dir=tmp_path) as runner:
+        runner.train([mgf_small], [mgf_small])
+        runner.trainer.save_checkpoint(ckpt)
+
+    orig_n = runner.model.vocab_size
+
+    new_residues = dict(config.residues)
+    new_residues["K[Acetyl]"] = 128.094963 + 42.010565
+
+    ext_config = Config(tiny_config)
+    ext_config.residues = new_residues
+    ext_config.new_token_init = {"K[Acetyl]": "K"}
+    ext_config.n_layers = 1
+
+    runner = ModelRunner(config=ext_config, model_filename=str(ckpt))
+    runner.initialize_tokenizer()
+    with unittest.mock.patch.object(
+        ModelRunner,
+        "_validate_vocab_compatibility",
+        wraps=runner._validate_vocab_compatibility,
+    ) as mock_validate:
+        runner.initialize_model(train=True)
+        mock_validate.assert_called_once()
+
+    assert runner.model.vocab_size == orig_n + 1


### PR DESCRIPTION
**Summary**

Allow fine-tuning with a larger residue vocabulary. Primary use case: fine-tuning with new PTMs.

Adds `_remap_decoder_vocab` to `ModelRunner` so that a pretrained checkpoint can be fine-tuned with a larger residue vocabulary.

When a checkpoint is loaded whose tokenizer vocabulary is a strict subset of the config vocabulary, the method resizes the decoder's input embedding (token_encoder) and output projection (final) by name-matching existing rows and copying the configured donor-token weights for new rows. Tokens in the checkpoint that are absent from the new config are dropped with a warning. The operation is a no-op when vocabularies already match.

**New config option**
```
# Example: add K[Acetyl] token and initialize with weights from K
new_token_init:
    "K[Acetyl]": "K"
```

Every token present in residues but absent from the checkpoint must have an entry here, omitting one raises a ValueError at load time.

**Changes**

- casanovo/denovo/model_runner.py: _remap_decoder_vocab (new private method, called from both load_from_checkpoint code paths in initialize_model)
- casanovo/config.py: register new_token_init as a typed config field (dict)
- casanovo/config.yaml: add new_token_init: {} with usage comment
- tests/unit_tests/test_runner.py: 6 new tests covering: identity no-op, successful remap, dropped-token warning, missing-init error, bad-source error, and that _validate_vocab_compatibility passes cleanly after remapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for fine-tuning pretrained checkpoints when the residue vocabulary is extended, with a new config option to control how weights for newly added tokens are initialized.

* **Documentation**
  * Added and documented the new configuration key for token initialization behavior.

* **Tests**
  * Added unit and integration tests covering vocabulary remapping, initialization sources, and related validation and warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Noble-Lab/casanovo/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->