### PR TITLE
Per-file validation loss logging and --tracking_peak_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `--load_all_states` flag to load all model states when resuming training.
 - A TSV file with all candidate peptides can be exported during database searching with the `--export` flag.
 - Track instrument-assigned scan numbers from MGF `SCANS`, `SCAN`, and `SCAN ID` header fields in a new `opt_global_cv_MS:1003057_scan_number` mzTab column.
+- Per-file validation loss logging via `valid_CELoss/<stem>` keys.
+- New `--tracking_peak_path/-t` CLI option for monitoring catastrophic forgetting on additional validation files without affecting checkpoint selection.
 
 ### Changed
 

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -300,7 +300,21 @@ def db_search(
     "--validation_peak_path",
     help="""
     An annotated MGF file for validation, like from MassIVE-KB. Use this
-    option multiple times to specify multiple files.
+    option multiple times to specify multiple files. Loss from these files
+    contributes to the aggregate valid_CELoss used for checkpoint selection.
+    """,
+    required=False,
+    multiple=True,
+    type=click.Path(exists=True, dir_okay=True),
+)
+@click.option(
+    "-t",
+    "--tracking_peak_path",
+    help="""
+    An annotated MGF file used to monitor validation loss during training
+    without influencing checkpoint selection (useful for detecting
+    catastrophic forgetting). Use this option multiple times to specify
+    multiple files.
     """,
     required=False,
     multiple=True,
@@ -319,6 +333,7 @@ def db_search(
 def train(
     train_peak_path: Tuple[str],
     validation_peak_path: Optional[Tuple[str]],
+    tracking_peak_path: Optional[Tuple[str]],
     model: Optional[str],
     config: Optional[str],
     output_dir: Optional[str],
@@ -365,10 +380,16 @@ def train(
         for peak_file in validation_peak_path:
             logger.info("  %s", peak_file)
 
+        if tracking_peak_path:
+            logger.info("Using the following tracking-only validation files:")
+            for peak_file in tracking_peak_path:
+                logger.info("  %s", peak_file)
+
         runner.train(
             train_peak_path,
             validation_peak_path,
             model if load_all_states else None,
+            tracking_peak_path,
         )
 
         utils.log_run_report(start_time=start_time, end_time=time.time())

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -35,9 +35,14 @@ class DeNovoDataModule(pl.LightningDataModule):
     train_paths : Sequence[str], optional
         Spectrum Lance path(s) for model training.
     valid_paths : Sequence[str], optional
-        Spectrum Lance path(s) for validation.
+        Spectrum Lance path(s) for validation. Each file gets its own
+        DataLoader and contributes to the aggregate ``valid_CELoss``.
     test_paths : Sequence[str], optional
         Spectrum Lance path(s) for evaluation or inference.
+    tracking_paths : Sequence[str], optional
+        Additional annotated spectrum files logged per-file for monitoring
+        only (e.g. detecting catastrophic forgetting); excluded from the
+        aggregate ``valid_CELoss`` used for checkpoint selection.
     train_batch_size : int
         The batch size to use for training.
     eval_batch_size : int
@@ -79,6 +84,7 @@ class DeNovoDataModule(pl.LightningDataModule):
         train_paths: Optional[Sequence[str]] = None,
         valid_paths: Optional[Sequence[str]] = None,
         test_paths: Optional[Sequence[str]] = None,
+        tracking_paths: Optional[Sequence[str]] = None,
         train_batch_size: int = 128,
         eval_batch_size: int = 1028,
         min_peaks: Optional[int] = 20,
@@ -100,6 +106,7 @@ class DeNovoDataModule(pl.LightningDataModule):
         self.train_paths = train_paths
         self.valid_paths = valid_paths
         self.test_paths = test_paths
+        self.tracking_paths = tracking_paths or []
 
         self.train_batch_size = train_batch_size
         self.eval_batch_size = eval_batch_size
@@ -128,7 +135,13 @@ class DeNovoDataModule(pl.LightningDataModule):
             "seq", lambda x: x["params"]["seq"], pa.string()
         )
         self.train_dataset = None
-        self.valid_dataset = None
+        # Per-file validation datasets: main (monitored) + tracking (log-only).
+        self.valid_datasets: list = []
+        self.tracking_datasets: list = []
+        # val_stems[i] is the filename stem for the i-th val dataloader.
+        # Dataloaders 0..n_main_loaders-1 are main; the rest are tracking.
+        self.val_stems: list = []
+        self.n_main_loaders: int = 0
         self.test_dataset = None
         self.protein_database = None
 
@@ -157,17 +170,37 @@ class DeNovoDataModule(pl.LightningDataModule):
                     "Training dataset contains %d spectra.",
                     self._get_n_spectra(self.train_dataset),
                 )
-            if self.valid_paths is not None:
-                self.valid_dataset = self._make_dataset(
-                    self.valid_paths,
-                    annotated=True,
-                    mode="valid",
-                    shuffle=False,
+            # Build one dataset per validation file so each gets its own
+            # DataLoader and its loss can be logged separately.
+            self.valid_datasets = []
+            for i, path in enumerate(self.valid_paths or []):
+                self.valid_datasets.append(
+                    self._make_dataset(
+                        [path],
+                        annotated=True,
+                        mode=f"valid_{i}",
+                        shuffle=False,
+                    )
                 )
-                logger.info(
-                    "Validation dataset contains %d spectra.",
-                    self._get_n_spectra(self.valid_dataset),
+            self.tracking_datasets = []
+            for i, path in enumerate(self.tracking_paths or []):
+                self.tracking_datasets.append(
+                    self._make_dataset(
+                        [path],
+                        annotated=True,
+                        mode=f"tracking_{i}",
+                        shuffle=False,
+                    )
                 )
+            self.n_main_loaders = len(self.valid_datasets)
+            self.val_stems = [
+                pathlib.Path(p).stem for p in (self.valid_paths or [])
+            ] + [pathlib.Path(p).stem for p in (self.tracking_paths or [])]
+            if self.valid_datasets:
+                total = sum(
+                    self._get_n_spectra(ds) for ds in self.valid_datasets
+                )
+                logger.info("Validation dataset contains %d spectra.", total)
         if stage in (None, "test"):
             if self.test_paths is not None:
                 self.test_dataset = self._make_dataset(
@@ -300,9 +333,12 @@ class DeNovoDataModule(pl.LightningDataModule):
         """Get the training DataLoader."""
         return self._make_loader(self.train_dataset, shuffle=self.shuffle)
 
-    def val_dataloader(self) -> torch.utils.data.DataLoader:
-        """Get the validation DataLoader."""
-        return self._make_loader(self.valid_dataset)
+    def val_dataloader(self) -> list:
+        """Get validation DataLoaders — one per file, main first then tracking."""
+        return [
+            self._make_loader(ds)
+            for ds in self.valid_datasets + self.tracking_datasets
+        ]
 
     def test_dataloader(self) -> torch.utils.data.DataLoader:
         """Get the test DataLoader."""

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -123,9 +123,9 @@ class DeNovoDataModule(pl.LightningDataModule):
         self.lance_dir = lance_dir
 
         self.train_paths = train_paths
-        self.valid_paths = valid_paths
+        self.valid_paths = list(valid_paths or [])
         self.test_paths = test_paths
-        self.tracking_paths = tracking_paths or []
+        self.tracking_paths = list(tracking_paths or [])
 
         self.train_batch_size = train_batch_size
         self.eval_batch_size = eval_batch_size
@@ -213,7 +213,7 @@ class DeNovoDataModule(pl.LightningDataModule):
                 )
             self.n_main_loaders = len(self.valid_datasets)
             self.val_stems = _unique_stems(
-                (self.valid_paths or []) + (self.tracking_paths or [])
+                [*self.valid_paths, *self.tracking_paths]
             )
             if self.valid_datasets:
                 total = sum(

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -24,6 +24,21 @@ from torch.utils.data.datapipes.iter.combinatorics import ShufflerIterDataPipe
 logger = logging.getLogger("casanovo")
 
 
+def _unique_stems(paths: list) -> list:
+    """Return stems from *paths*, disambiguating duplicates with a suffix."""
+    counts: dict = {}
+    stems = []
+    for p in paths:
+        stem = pathlib.Path(p).stem
+        if stem in counts:
+            counts[stem] += 1
+            stems.append(f"{stem}_{counts[stem]}")
+        else:
+            counts[stem] = 0
+            stems.append(stem)
+    return stems
+
+
 class DeNovoDataModule(pl.LightningDataModule):
     """
     Data loader to prepare MS/MS spectra for a Spec2Pep predictor.
@@ -193,9 +208,9 @@ class DeNovoDataModule(pl.LightningDataModule):
                     )
                 )
             self.n_main_loaders = len(self.valid_datasets)
-            self.val_stems = [
-                pathlib.Path(p).stem for p in (self.valid_paths or [])
-            ] + [pathlib.Path(p).stem for p in (self.tracking_paths or [])]
+            self.val_stems = _unique_stems(
+                (self.valid_paths or []) + (self.tracking_paths or [])
+            )
             if self.valid_datasets:
                 total = sum(
                     self._get_n_spectra(ds) for ds in self.valid_datasets

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -25,7 +25,25 @@ logger = logging.getLogger("casanovo")
 
 
 def _unique_stems(paths: list) -> list:
-    """Return stems from *paths*, disambiguating duplicates with a suffix."""
+    """Return unique file stems for a list of paths.
+
+    Extract the file stem from each path. When the same stem appears
+    more than once, subsequent occurrences are disambiguated with a
+    ``_1``, ``_2``, ... suffix. The suffix probe skips names that are
+    already in use (e.g. an organic ``data_1`` file will not collide
+    with a duplicate ``data``).
+
+    Parameters
+    ----------
+    paths : list
+        File paths (strings or Path objects) to extract stems from.
+
+    Returns
+    -------
+    list of str
+        Stems in the same order as *paths*, with duplicates
+        disambiguated.
+    """
     used: set = set()
     stems = []
     for p in paths:
@@ -192,7 +210,7 @@ class DeNovoDataModule(pl.LightningDataModule):
             # Build one dataset per validation file so each gets its own
             # DataLoader and its loss can be logged separately.
             self.valid_datasets = []
-            for i, path in enumerate(self.valid_paths or []):
+            for i, path in enumerate(self.valid_paths):
                 self.valid_datasets.append(
                     self._make_dataset(
                         [path],
@@ -202,7 +220,7 @@ class DeNovoDataModule(pl.LightningDataModule):
                     )
                 )
             self.tracking_datasets = []
-            for i, path in enumerate(self.tracking_paths or []):
+            for i, path in enumerate(self.tracking_paths):
                 self.tracking_datasets.append(
                     self._make_dataset(
                         [path],
@@ -353,7 +371,19 @@ class DeNovoDataModule(pl.LightningDataModule):
         return self._make_loader(self.train_dataset, shuffle=self.shuffle)
 
     def val_dataloader(self) -> list:
-        """Get validation DataLoaders — one per file, main first then tracking."""
+        """Get validation DataLoaders.
+
+        Returns one DataLoader per validation file, ordered with main
+        files first (indices ``0..n_main_loaders-1``) followed by
+        tracking-only files. Lightning dispatches each loader's
+        batches with a ``dataloader_idx`` that maps 1-to-1 to the
+        entries in ``val_stems``.
+
+        Returns
+        -------
+        list of torch.utils.data.DataLoader
+            One loader per validation and tracking file.
+        """
         return [
             self._make_loader(ds)
             for ds in self.valid_datasets + self.tracking_datasets

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -26,16 +26,20 @@ logger = logging.getLogger("casanovo")
 
 def _unique_stems(paths: list) -> list:
     """Return stems from *paths*, disambiguating duplicates with a suffix."""
-    counts: dict = {}
+    used: set = set()
     stems = []
     for p in paths:
         stem = pathlib.Path(p).stem
-        if stem in counts:
-            counts[stem] += 1
-            stems.append(f"{stem}_{counts[stem]}")
-        else:
-            counts[stem] = 0
+        if stem not in used:
+            used.add(stem)
             stems.append(stem)
+        else:
+            i = 1
+            while f"{stem}_{i}" in used:
+                i += 1
+            unique = f"{stem}_{i}"
+            used.add(unique)
+            stems.append(unique)
     return stems
 
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -163,6 +163,9 @@ class Spec2Pep(pl.LightningModule):
         self.calculate_precision = calculate_precision
         self.n_log = n_log
         self._history = []
+        # Per-file validation metadata; set by ModelRunner.train() before fit.
+        self.val_stems: list = []
+        self.n_main_loaders: int = 0
 
         # Output writer during predicting.
         self.out_writer = out_writer
@@ -839,7 +842,10 @@ class Spec2Pep(pl.LightningModule):
         return loss
 
     def validation_step(
-        self, batch: Dict[str, torch.Tensor], *args
+        self,
+        batch: Dict[str, torch.Tensor],
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> torch.Tensor:
         """
         A single validation step.
@@ -848,24 +854,54 @@ class Spec2Pep(pl.LightningModule):
         ----------
         batch : Dict[str, torch.Tensor]
             A batch from the SpectrumDataset, which contains keys:
-            A batch from the SpectrumDataset, which contains keys:
             ``mz_array``, ``intensity_array``, ``precursor_mz``, and
             ``precursor_charge``, each pointing to tensors with the
             corresponding data. The ``seq`` key is optional and
             contains the peptide sequences for training.
+        batch_idx : int
+            Index of the current batch within its dataloader.
+        dataloader_idx : int
+            Index of the dataloader this batch comes from. Dataloaders
+            0..n_main_loaders-1 are "main" validation files that contribute
+            to the aggregate ``valid_CELoss`` used for checkpoint selection.
+            Higher indices are "tracking" files logged per-file only.
 
         Returns
         -------
         torch.Tensor
             The loss of the validation step.
         """
-        # Record the loss.
-        loss = self.training_step(batch, mode="valid")
-        if not self.calculate_precision:
+        pred, truth = self._forward_step(batch)
+        pred = pred[:, :-1, :].reshape(-1, self.vocab_size)
+        loss = self.val_celoss(pred, truth.flatten())
+
+        batch_size = pred.shape[0]
+        log_kwargs = dict(
+            add_dataloader_idx=False,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch_size,
+        )
+
+        # Determine per-file stem and main/tracking classification.
+        n_main = self.n_main_loaders if self.n_main_loaders > 0 else 1
+        is_main = dataloader_idx < n_main
+
+        if self.val_stems and dataloader_idx < len(self.val_stems):
+            stem = self.val_stems[dataloader_idx]
+            self.log(f"valid_CELoss/{stem}", loss.detach(), **log_kwargs)
+
+        if is_main:
+            # Contributes to the aggregate ``valid_CELoss`` monitored by
+            # ModelCheckpoint for best-checkpoint selection.
+            self.log("valid_CELoss", loss.detach(), **log_kwargs)
+
+        if not self.calculate_precision or not is_main:
             return loss
 
         # Calculate and log amino acid and peptide match evaluation
-        # metrics from the predicted peptides.
+        # metrics from the predicted peptides (main files only).
         peptides_true = self.tokenizer.detokenize(batch["seq"])
         peptides_pred = [
             pred
@@ -879,7 +915,12 @@ class Spec2Pep(pl.LightningModule):
         )
 
         batch_size = len(peptides_true)
-        log_args = dict(on_step=False, on_epoch=True, sync_dist=True)
+        log_args = dict(
+            add_dataloader_idx=False,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+        )
         self.log(
             "pep_precision", pep_precision, **log_args, batch_size=batch_size
         )
@@ -956,18 +997,27 @@ class Spec2Pep(pl.LightningModule):
         Log the validation metrics at the end of each epoch.
         """
         callback_metrics = self.trainer.callback_metrics
-        metrics = {
-            "step": self.trainer.global_step,
-            "valid": callback_metrics["valid_CELoss"].detach().item(),
-        }
+        metrics = {"step": self.trainer.global_step}
+
+        if "valid_CELoss" in callback_metrics:
+            metrics["valid"] = callback_metrics["valid_CELoss"].detach().item()
+
+        for stem in self.val_stems:
+            key = f"valid_CELoss/{stem}"
+            if key in callback_metrics:
+                metrics[f"valid/{stem}"] = (
+                    callback_metrics[key].detach().item()
+                )
 
         if self.calculate_precision:
-            metrics["valid_aa_precision"] = (
-                callback_metrics["aa_precision"].detach().item()
-            )
-            metrics["valid_pep_precision"] = (
-                callback_metrics["pep_precision"].detach().item()
-            )
+            if "aa_precision" in callback_metrics:
+                metrics["valid_aa_precision"] = (
+                    callback_metrics["aa_precision"].detach().item()
+                )
+            if "pep_precision" in callback_metrics:
+                metrics["valid_pep_precision"] = (
+                    callback_metrics["pep_precision"].detach().item()
+                )
         self._history.append(metrics)
         self._log_history()
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -803,7 +803,6 @@ class Spec2Pep(pl.LightningModule):
         self,
         batch: Dict[str, torch.Tensor],
         *args,
-        mode: str = "train",
     ) -> torch.Tensor:
         """
         A single training step.
@@ -816,8 +815,6 @@ class Spec2Pep(pl.LightningModule):
             ``precursor_charge``, each pointing to tensors with the
             corresponding data. The ``seq`` key is optional and
             contains the peptide sequences for training.
-        mode : str
-            Logging key to describe the current stage.
 
         Returns
         -------
@@ -826,13 +823,9 @@ class Spec2Pep(pl.LightningModule):
         """
         pred, truth = self._forward_step(batch)
         pred = pred[:, :-1, :].reshape(-1, self.vocab_size)
-
-        if mode == "train":
-            loss = self.celoss(pred, truth.flatten())
-        else:
-            loss = self.val_celoss(pred, truth.flatten())
+        loss = self.celoss(pred, truth.flatten())
         self.log(
-            f"{mode}_CELoss",
+            "train_CELoss",
             loss.detach(),
             on_step=False,
             on_epoch=True,

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -175,6 +175,7 @@ class ModelRunner:
         train_peak_path: Iterable[str],
         valid_peak_path: Iterable[str],
         ckpt_path: Optional[str] = None,
+        tracking_peak_path: Iterable[str] = (),
     ) -> None:
         """
         Train the Casanovo model.
@@ -184,11 +185,18 @@ class ModelRunner:
         train_peak_path : iterable of str
             The path to the MS data files for training.
         valid_peak_path : iterable of str
-            The path to the MS data files for validation.
+            The path to the MS data files for validation. These files
+            contribute to the aggregate ``valid_CELoss`` used for
+            checkpoint selection.
         ckpt_path : str, optional
             Path to a checkpoint file to resume training from. When provided,
             training will resume from the saved optimizer state, learning rate
             scheduler, and epoch. If None, training starts fresh (default).
+        tracking_peak_path : iterable of str, optional
+            Additional MS data files whose loss is logged per-file for
+            monitoring purposes (e.g. detecting catastrophic forgetting)
+            but is excluded from the aggregate used for checkpoint
+            selection.
         """
         self.initialize_trainer(train=True)
         self.initialize_tokenizer()
@@ -196,8 +204,21 @@ class ModelRunner:
 
         train_paths = self._get_input_paths(train_peak_path, True, "train")
         valid_paths = self._get_input_paths(valid_peak_path, True, "valid")
-        self.initialize_data_module(train_paths, valid_paths)
+        tracking_paths = (
+            self._get_input_paths(tracking_peak_path, True, "tracking")
+            if tracking_peak_path
+            else []
+        )
+        self.initialize_data_module(
+            train_paths, valid_paths, tracking_paths=tracking_paths
+        )
         self.loaders.setup()
+
+        # Store per-file validation metadata on the model so validation_step
+        # can log per-file losses. trainer.datamodule is None when dataloaders
+        # are passed directly to trainer.fit(), so we attach metadata here.
+        self.model.val_stems = self.loaders.val_stems
+        self.model.n_main_loaders = self.loaders.n_main_loaders
 
         if ckpt_path is None:
             self.trainer.fit(
@@ -565,6 +586,7 @@ class ModelRunner:
         train_paths: Sequence[str] | None = None,
         valid_paths: Sequence[str] | None = None,
         test_paths: Sequence[str] | None = None,
+        tracking_paths: Sequence[str] | None = None,
     ) -> None:
         """Initialize the data module.
 
@@ -573,9 +595,13 @@ class ModelRunner:
         train_paths : str, optional
             Spectrum paths for model training.
         valid_paths : str, optional
-            Spectrum paths for validation.
+            Spectrum paths for validation (contribute to aggregate
+            ``valid_CELoss`` used for checkpoint selection).
         test_paths : str, optional
             Spectrum paths for evaluation or inference.
+        tracking_paths : str, optional
+            Additional validation paths logged per-file for monitoring
+            only; excluded from the aggregate ``valid_CELoss``.
         """
         try:
             n_devices = self.trainer.num_devices
@@ -602,6 +628,7 @@ class ModelRunner:
             train_paths=train_paths,
             valid_paths=valid_paths,
             test_paths=test_paths,
+            tracking_paths=tracking_paths,
             train_batch_size=train_batch_size,
             eval_batch_size=eval_batch_size,
             min_peaks=self.config.min_peaks,

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -706,3 +706,41 @@ def test_initialize_model_calls_validate_vocab_compatibility(
     ) as mock_validate:
         runner.initialize_model(train=True)
         mock_validate.assert_called_once()
+
+
+def test_train_no_tracking_peak_path_backward_compat(
+    tmp_path, mgf_small, tiny_config
+):
+    """train() with no tracking_peak_path sets n_main_loaders == len(valid_paths)."""
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    with ModelRunner(
+        config, output_dir=tmp_path, output_rootname="compat"
+    ) as runner:
+        runner.train([mgf_small], [mgf_small])
+        assert runner.model.n_main_loaders == 1
+        assert runner.model.val_stems == [Path(mgf_small).stem]
+
+
+def test_train_with_tracking_peak_path(tmp_path, mgf_small, tiny_config):
+    """train() with tracking_peak_path logs per-file metrics for tracking files."""
+    config = Config(tiny_config)
+    config.max_epochs = 1
+    config.n_layers = 1
+
+    mgf_track = tmp_path / "track.mgf"
+    shutil.copy(mgf_small, mgf_track)
+
+    with ModelRunner(
+        config, output_dir=tmp_path, output_rootname="track"
+    ) as runner:
+        runner.train([mgf_small], [mgf_small], tracking_peak_path=[mgf_track])
+        # main loader is mgf_small (index 0); tracking is mgf_track (index 1)
+        assert runner.model.n_main_loaders == 1
+        assert runner.model.val_stems[0] == Path(mgf_small).stem
+        assert runner.model.val_stems[1] == Path(mgf_track).stem
+        # Per-file key must appear in logged metrics history.
+        track_key = f"valid/{Path(mgf_track).stem}"
+        assert any(track_key in metrics for metrics in runner.model._history)

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -1949,11 +1949,8 @@ def test_spectrum_id_mgf(mgf_small, tmp_path):
     )
     data_module.setup()
 
-    for dataset in [
-        data_module.train_dataset,
-        data_module.valid_dataset,
-        data_module.test_dataset,
-    ]:
+    # train/test combine both files into one dataset (4 spectra total).
+    for dataset in [data_module.train_dataset, data_module.test_dataset]:
         for i, (filename, scan_id) in enumerate(
             [
                 (mgf_small, "0"),
@@ -1964,6 +1961,15 @@ def test_spectrum_id_mgf(mgf_small, tmp_path):
         ):
             assert dataset[i]["peak_file"][0] == filename.name
             assert dataset[i]["scan_id"][0] == f"index={scan_id}"
+
+    # Validation is now per-file; each dataset has 2 spectra from its file.
+    assert len(data_module.valid_datasets) == 2
+    for i, filename in enumerate([mgf_small, mgf_small2]):
+        vds = data_module.valid_datasets[i]
+        assert vds[0]["peak_file"][0] == filename.name
+        assert vds[0]["scan_id"][0] == "index=0"
+        assert vds[1]["peak_file"][0] == filename.name
+        assert vds[1]["scan_id"][0] == "index=1"
 
 
 def test_log_training_set_size(mgf_small, tmp_path, caplog):
@@ -2060,7 +2066,8 @@ def test_train_val_step_functions():
     val_batch = copy.deepcopy(train_batch)
 
     train_step_loss = model.training_step(train_batch)
-    val_step_loss = model.validation_step(val_batch)
+    with unittest.mock.patch.object(model, "log"):
+        val_step_loss = model.validation_step(val_batch, 0)
 
     # Check if valid loss value returned
     assert train_step_loss > 0
@@ -2952,3 +2959,93 @@ def test_mixed_mgf_mzml_scan_number_column(mzml_small, tmp_path):
     # mzML row must be null.
     mzml_row = psms[psms["spectra_ref"].str.contains("scan=17")].iloc[0]
     assert pd.isna(mzml_row["opt_global_cv_MS:1003057_scan_number"])
+
+
+def test_data_module_per_file_validation(mgf_small, tmp_path):
+    """DeNovoDataModule creates one dataset per validation/tracking file."""
+    mgf_small2 = tmp_path / "mgf_small2.mgf"
+    shutil.copy(mgf_small, mgf_small2)
+    data_module = DeNovoDataModule(
+        lance_dir=tmp_path.name,
+        valid_paths=[mgf_small, mgf_small2],
+        tracking_paths=[mgf_small],
+        min_peaks=0,
+        shuffle=False,
+    )
+    data_module.setup()
+
+    assert len(data_module.valid_datasets) == 2
+    assert len(data_module.tracking_datasets) == 1
+    assert data_module.n_main_loaders == 2
+    assert data_module.val_stems == [
+        mgf_small.stem,
+        mgf_small2.stem,
+        mgf_small.stem,
+    ]
+    loaders = data_module.val_dataloader()
+    assert len(loaders) == 3
+
+
+def test_validation_step_logs_per_file():
+    """validation_step logs per-file CELoss; aggregate only for main loaders."""
+    tokenizer = depthcharge.tokenizers.peptides.MskbPeptideTokenizer()
+    model = Spec2Pep(
+        n_beams=1,
+        residues="massivekb",
+        min_peptide_len=4,
+        tokenizer=tokenizer,
+    )
+    model.val_stems = ["a", "b"]
+    model.n_main_loaders = 1
+
+    batch = {
+        "mz_array": torch.zeros(1, 5),
+        "intensity_array": torch.zeros(1, 5),
+        "precursor_mz": torch.tensor(235.63410),
+        "precursor_charge": torch.tensor(2),
+        "seq": tokenizer.tokenize(["PEPK"]),
+    }
+
+    # dataloader_idx=0 is a main loader: logs per-file AND aggregate.
+    with unittest.mock.patch.object(model, "log") as mock_log:
+        model.validation_step(batch, 0, dataloader_idx=0)
+    logged = {c.args[0]: c.kwargs for c in mock_log.call_args_list}
+    assert "valid_CELoss/a" in logged
+    assert "valid_CELoss" in logged
+    assert logged["valid_CELoss/a"]["add_dataloader_idx"] is False
+    assert logged["valid_CELoss"]["add_dataloader_idx"] is False
+
+    # dataloader_idx=1 is a tracking loader: logs per-file only.
+    with unittest.mock.patch.object(model, "log") as mock_log:
+        model.validation_step(batch, 0, dataloader_idx=1)
+    logged = {c.args[0]: c.kwargs for c in mock_log.call_args_list}
+    assert "valid_CELoss/b" in logged
+    assert "valid_CELoss" not in logged
+
+
+def test_train_cli_tracking_peak_path(tmp_path, mgf_small, monkeypatch):
+    """-t/--tracking_peak_path CLI option is forwarded to ModelRunner.train()."""
+    from casanovo.denovo.model_runner import ModelRunner as _ModelRunner
+
+    captured = {}
+
+    def fake_train(self, train_pp, valid_pp, ckpt=None, tracking_pp=()):
+        captured["tracking"] = tracking_pp
+
+    monkeypatch.setattr(_ModelRunner, "train", fake_train)
+    monkeypatch.setattr(casanovo, "_is_valid_model", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        casanovo, "_setup_output", lambda *a, **kw: (tmp_path, "out")
+    )
+    monkeypatch.setattr(
+        casanovo, "setup_model", lambda *a, **kw: (Config(), None)
+    )
+    monkeypatch.setattr(utils, "log_system_info", lambda: None)
+    monkeypatch.setattr(utils, "log_run_report", lambda **kw: None)
+
+    result = click.testing.CliRunner().invoke(
+        casanovo.main,
+        ["train", "-t", str(mgf_small), str(mgf_small)],
+    )
+    assert result.exit_code == 0, result.output
+    assert str(mgf_small) in captured.get("tracking", ())

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2980,7 +2980,7 @@ def test_data_module_per_file_validation(mgf_small, tmp_path):
     assert data_module.val_stems == [
         mgf_small.stem,
         mgf_small2.stem,
-        mgf_small.stem,
+        f"{mgf_small.stem}_1",
     ]
     loaders = data_module.val_dataloader()
     assert len(loaders) == 3


### PR DESCRIPTION
**Summary**

Two related changes to the validation pipeline during training.

1. **Per-file validation loss**: each file passed via -p/--validation_peak_path now gets its own DataLoader and logs valid_CELoss/<stem> independently, in addition to the existing aggregate valid_CELoss that drives checkpoint selection. This makes it easy to spot per-dataset regression in TensorBoard/CSV logs without affecting the checkpoint criterion.
2. **Tracking-only validation files**: a new -t/--tracking_peak_path option accepts additional annotated files that are logged per-file (valid_CELoss/<stem>) but excluded from the aggregate valid_CELoss. The intended use case is monitoring catastrophic forgetting on a held-out dataset during fine-tuning, where including it in the aggregate would bias best-checkpoint selection.

**Changes**

- casanovo/denovo/dataloaders.py: DeNovoDataModule accepts tracking_paths; setup() builds one AnnotatedSpectrumDataset per validation/tracking file; val_dataloader() returns a list (main files first, tracking files after); exposes val_stems, n_main_loaders
- casanovo/denovo/model.py: validation_step gains a dataloader_idx parameter; logs valid_CELoss/<stem> for every loader and valid_CELoss only for main loaders (dataloader_idx < n_main_loaders); all self.log calls use add_dataloader_idx=False to prevent Lightning from appending /dataloader_idx_N suffixes that would break ModelCheckpoint(monitor="valid_CELoss"); on_validation_epoch_end records per-file keys in _history
- casanovo/denovo/model_runner.py: train() accepts tracking_peak_path; sets model.val_stems and model.n_main_loaders before trainer.fit(); initialize_data_module() forwards tracking_paths
- casanovo/casanovo.py: -t/--tracking_peak_path CLI option
- tests/unit_tests/test_unit.py: test_train_val_step_functions fixed (now passes batch_idx); 3 new tests: per-file dataset wiring (val_stems, n_main_loaders, loader count), validation_step log-key assertions with mocked self.log, CLI -t argument parsing
- tests/unit_tests/test_runner.py: 2 new runner tests: backward-compat (no tracking path), per-file key in _history when tracking path is supplied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repeatable CLI option (-t / --tracking_peak_path) to monitor validation on extra files without affecting checkpoint selection.
  * Per-file validation loss logging (metrics recorded per-file using distinct stems) and support for separate "tracking-only" validation files.

* **Tests**
  * Added unit tests for tracking validation behavior, per-file logging, dataloader ordering, and CLI forwarding of the new option.

* **Documentation**
  * CHANGELOG updated with the new entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Noble-Lab/casanovo/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->