### PR TITLE
fix(io): write mzTab output with explicit utf-8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Write the mzTab output file with an explicit `utf-8` encoding so non-ASCII content is not corrupted on platforms whose default encoding is not UTF-8 (e.g. Windows cp1252).
+
 ## [5.1.2] - 2025-12-11
 
 ### Changed

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -148,7 +148,7 @@ class MztabWriter:
         """
         Export the spectrum identifications to the mzTab file.
         """
-        with open(self.filename, "w", newline="") as f:
+        with open(self.filename, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f, delimiter="\t", lineterminator=os.linesep)
             # Write metadata.
             for row in self.metadata:


### PR DESCRIPTION
### What

`MztabWriter.save()` in `casanovo/data/ms_io.py` opens the mzTab output file in text mode without specifying an encoding:

```python
with open(self.filename, "w", newline="") as f:
    writer = csv.writer(f, delimiter="	", lineterminator=os.linesep)
```

Without `encoding=`, Python uses the platform default (`locale.getpreferredencoding()`), which is **cp1252** on Windows rather than UTF-8.

### Why it matters

The [mzTab specification](https://github.com/HUPO-PSI/mzTab) mandates UTF-8. Any non-ASCII content in metadata or PSM rows (e.g. accession strings, file URIs with accented path components) would be written using the wrong codec on a non-UTF-8 platform, producing a non-compliant file or raising `UnicodeEncodeError`.

### Fix

```python
# Before
with open(self.filename, "w", newline="") as f:
# After
with open(self.filename, "w", newline="", encoding="utf-8") as f:
```

`newline=""` is preserved (correct for the `csv` module). Added a `### Fixed` entry to the `[Unreleased]` section of CHANGELOG.md per the project convention.

### Verification

The file still parses, the diff is limited to the single `open()` call plus the changelog note, and `utf-8` is a strict superset of ASCII so existing ASCII-only outputs are byte-for-byte unchanged. Happy to adjust if you prefer a different approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * mzTab output files now use explicit UTF-8 encoding, preventing non-ASCII character corruption on Windows and other platforms with non-UTF-8 default system encoding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Noble-Lab/casanovo/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->