### PR TITLE
fix(io): add explicit encoding='utf-8' to text-mode file I/O

### DIFF
--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -230,7 +230,7 @@ class MztabWriter:
         """
         Export the spectrum identifications to the mzTab file.
         """
-        with open(self.filename, "w", newline="") as f:
+        with open(self.filename, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f, delimiter="\t", lineterminator=os.linesep)
             # Write metadata.
             for row in self.metadata:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def mgf_small(tmp_path):
 @pytest.fixture
 def tiny_fasta_file(tmp_path):
     fasta_file = tmp_path / "tiny_fasta.fasta"
-    with fasta_file.open("w+") as fasta_ref:
+    with fasta_file.open("w+", encoding="utf-8") as fasta_ref:
         fasta_ref.write(
             (
                 ">foo\nMEAPAQLLFLLLLWLPDTTREIVMTQSPPTLSLSPGERVTLSCRASQSVSSSYLTWYQ"
@@ -97,7 +97,7 @@ def _create_mgf(
         )
         for i, p in enumerate(peptides)
     ]
-    with mgf_file.open("w+") as mgf_ref:
+    with mgf_file.open("w+", encoding="utf-8") as mgf_ref:
         mgf_ref.write("\n".join(entries))
 
     return mgf_file
@@ -368,7 +368,7 @@ def _get_config_file(file_path, file_name, additional_cfg=None):
         cfg.update(additional_cfg)
 
     cfg_file = file_path / file_name
-    with cfg_file.open("w+") as out_file:
+    with cfg_file.open("w+", encoding="utf-8") as out_file:
         yaml.dump(cfg, out_file)
 
     return cfg_file

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -51,7 +51,7 @@ def test_train_and_run(
     assert best_model.exists()
 
     # Resume training from previous checkpoint.
-    with tiny_config.open("r") as f:
+    with tiny_config.open("r", encoding="utf-8") as f:
         config_data = yaml.safe_load(f)
     original_max_epochs = config_data.get("max_epochs")
 
@@ -61,7 +61,7 @@ def test_train_and_run(
             config_data["max_epochs"] = original_max_epochs + 10
         else:
             config_data["max_epochs"] = 10
-        with tiny_config.open("w") as f:
+        with tiny_config.open("w", encoding="utf-8") as f:
             yaml.safe_dump(config_data, f, sort_keys=False)
 
         train_args = [
@@ -88,7 +88,7 @@ def test_train_and_run(
         else:
             config_data["max_epochs"] = original_max_epochs
 
-        with tiny_config.open("w") as f:
+        with tiny_config.open("w", encoding="utf-8") as f:
             yaml.safe_dump(config_data, f, sort_keys=False)
 
     # Run Casanovo in de novo prediction mode.
@@ -220,10 +220,10 @@ def test_train_and_run(
     output_db_file = (tmp_path / output_rootname).with_suffix(".tsv")
 
     # Keep tokenizer settings compatible with the trained checkpoint.
-    with tiny_config_db.open("r") as f:
+    with tiny_config_db.open("r", encoding="utf-8") as f:
         db_config_data = yaml.safe_load(f)
     db_config_data["replace_isoleucine_with_leucine"] = True
-    with tiny_config_db.open("w") as f:
+    with tiny_config_db.open("w", encoding="utf-8") as f:
         yaml.safe_dump(db_config_data, f, sort_keys=False)
 
     search_args = [
@@ -327,7 +327,7 @@ def test_auxilliary_cli(tmp_path, mgf_small, monkeypatch):
     with pytest.raises(FileExistsError):
         run(["configure", "-o", "test.yaml"])
 
-    with open("casanovo.yaml") as f_in, open("small.yaml", "w") as f_out:
+    with open("casanovo.yaml", encoding="utf-8") as f_in, open("small.yaml", "w", encoding="utf-8") as f_out:
         config = yaml.safe_load(f_in)
         config["max_epochs"] = 1
         config["n_layers"] = 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -327,7 +327,10 @@ def test_auxilliary_cli(tmp_path, mgf_small, monkeypatch):
     with pytest.raises(FileExistsError):
         run(["configure", "-o", "test.yaml"])
 
-    with open("casanovo.yaml", encoding="utf-8") as f_in, open("small.yaml", "w", encoding="utf-8") as f_out:
+    with (
+        open("casanovo.yaml", encoding="utf-8") as f_in,
+        open("small.yaml", "w", encoding="utf-8") as f_out,
+    ):
         config = yaml.safe_load(f_in)
         config["max_epochs"] = 1
         config["n_layers"] = 1

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -23,7 +23,10 @@ def test_default(monkeypatch):
 def test_override(tmp_path, tiny_config):
     # Test expected config option is missing.
     filename = str(tmp_path / "config_missing.yml")
-    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
+    with (
+        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(filename, "w", encoding="utf-8") as f_out,
+    ):
         cfg = yaml.safe_load(f_in)
         # Remove config option.
         del cfg["random_seed"]
@@ -34,7 +37,10 @@ def test_override(tmp_path, tiny_config):
 
     # Test invalid config option is present.
     filename = str(tmp_path / "config_invalid.yml")
-    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
+    with (
+        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(filename, "w", encoding="utf-8") as f_out,
+    ):
         cfg = yaml.safe_load(f_in)
         # Insert invalid config option.
         cfg["random_seed_"] = 354
@@ -46,7 +52,10 @@ def test_override(tmp_path, tiny_config):
 
 def test_deprecated(tmp_path, tiny_config):
     filename = str(tmp_path / "config_deprecated.yml")
-    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
+    with (
+        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(filename, "w", encoding="utf-8") as f_out,
+    ):
         cfg = yaml.safe_load(f_in)
         # Insert remapped deprecated config option.
         cfg["max_iters"] = 1
@@ -55,7 +64,10 @@ def test_deprecated(tmp_path, tiny_config):
     with pytest.warns(DeprecationWarning):
         Config(filename)
 
-    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
+    with (
+        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(filename, "w", encoding="utf-8") as f_out,
+    ):
         cfg = yaml.safe_load(f_in)
         # Insert non-remapped deprecated config option.
         cfg["save_top_k"] = 5
@@ -67,7 +79,10 @@ def test_deprecated(tmp_path, tiny_config):
 
 def test_override_mps(monkeypatch, tiny_config, tmp_path, caplog):
     filename = str(tmp_path / "config_auto.yml")
-    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
+    with (
+        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(filename, "w", encoding="utf-8") as f_out,
+    ):
         cfg = yaml.safe_load(f_in)
         cfg["accelerator"] = "auto"
         yaml.safe_dump(cfg, f_out)

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -23,7 +23,7 @@ def test_default(monkeypatch):
 def test_override(tmp_path, tiny_config):
     # Test expected config option is missing.
     filename = str(tmp_path / "config_missing.yml")
-    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
         cfg = yaml.safe_load(f_in)
         # Remove config option.
         del cfg["random_seed"]
@@ -34,7 +34,7 @@ def test_override(tmp_path, tiny_config):
 
     # Test invalid config option is present.
     filename = str(tmp_path / "config_invalid.yml")
-    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
         cfg = yaml.safe_load(f_in)
         # Insert invalid config option.
         cfg["random_seed_"] = 354
@@ -46,7 +46,7 @@ def test_override(tmp_path, tiny_config):
 
 def test_deprecated(tmp_path, tiny_config):
     filename = str(tmp_path / "config_deprecated.yml")
-    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
         cfg = yaml.safe_load(f_in)
         # Insert remapped deprecated config option.
         cfg["max_iters"] = 1
@@ -55,7 +55,7 @@ def test_deprecated(tmp_path, tiny_config):
     with pytest.warns(DeprecationWarning):
         Config(filename)
 
-    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
         cfg = yaml.safe_load(f_in)
         # Insert non-remapped deprecated config option.
         cfg["save_top_k"] = 5
@@ -67,7 +67,7 @@ def test_deprecated(tmp_path, tiny_config):
 
 def test_override_mps(monkeypatch, tiny_config, tmp_path, caplog):
     filename = str(tmp_path / "config_auto.yml")
-    with open(tiny_config, "r") as f_in, open(filename, "w") as f_out:
+    with open(tiny_config, "r", encoding="utf-8") as f_in, open(filename, "w", encoding="utf-8") as f_out:
         cfg = yaml.safe_load(f_in)
         cfg["accelerator"] = "auto"
         yaml.safe_dump(cfg, f_out)


### PR DESCRIPTION
## Summary

Add explicit `encoding='utf-8'` to all text-mode `open()` calls across the codebase to prevent platform-dependent encoding issues.

## Problem

On Windows systems where the default locale is not UTF-8, `open()` without an explicit encoding parameter uses the system's default encoding (e.g., `cp1252`). This can cause `UnicodeEncodeError` when writing non-ASCII characters (such as modification names or peptide metadata) to mzTab output files.

## Changes

### Source code
- **`casanovo/data/ms_io.py`** - `MztabWriter.save()`: added `encoding='utf-8'` to the output file `open()` call

### Test files (addresses CodeRabbit review)
- **`tests/conftest.py`** - added `encoding='utf-8'` to FASTA, MGF, and YAML config fixture writes
- **`tests/unit_tests/test_config.py`** - added `encoding='utf-8'` to all config file read/write `open()` calls
- **`tests/test_integration.py`** - added `encoding='utf-8'` to all config and YAML file `open()` calls

## Verification

- Grep confirms no remaining text-mode `open()` calls without explicit encoding
- All changes are additive (no behavior change on UTF-8 default systems)
- This is a retarget of #639 to the `dev` branch per maintainer guidance

## Before/After

**Before:**
```python
with open(self.filename, 'w', newline='') as f:
```  

**After:**
```python
with open(self.filename, 'w', newline='', encoding='utf-8') as f:
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured exports and configuration files are read and written using UTF-8 encoding, improving cross-platform text handling and reliability (including in tests and integrations).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Noble-Lab/casanovo/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->