### PR TITLE
fix: use utf-8 for config and mztab text files

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -108,13 +108,13 @@ class Config:
     def __init__(self, config_file: Optional[str] = None):
         """Initialize a Config object."""
         self.file = str(config_file) if config_file is not None else "default"
-        with self._default_config.open() as f_in:
+        with self._default_config.open(encoding="utf-8") as f_in:
             self._params = yaml.safe_load(f_in)
 
         if config_file is None:
             self._user_config = {}
         else:
-            with Path(config_file).open() as f_in:
+            with Path(config_file).open(encoding="utf-8") as f_in:
                 self._user_config = yaml.safe_load(f_in)
                 # Remap deprecated config entries.
                 for old, new in _config_deprecated.items():

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -148,7 +148,7 @@ class MztabWriter:
         """
         Export the spectrum identifications to the mzTab file.
         """
-        with open(self.filename, "w", newline="") as f:
+        with open(self.filename, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f, delimiter="\t", lineterminator=os.linesep)
             # Write metadata.
             for row in self.metadata:


### PR DESCRIPTION
## What changed

- Load the packaged default config with explicit UTF-8 decoding.
- Load user-provided config files with explicit UTF-8 decoding.
- Write mzTab text output with explicit UTF-8 encoding while preserving the existing newline handling.

## Why

These files are text data that can contain non-ASCII content, especially user config values or spectrum metadata. Relying on the process default encoding can fail on systems whose locale is not UTF-8.

## Before / after

Before, config reads and mzTab writes used the platform default encoding. After, they consistently use UTF-8 across platforms.

## Verification

- `python -m py_compile casanovo/config.py casanovo/data/ms_io.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved configuration file loading to work consistently across different operating systems and system locales, ensuring configuration settings are always read correctly regardless of the user's system environment.
  * Enhanced output file generation by standardizing file encoding, ensuring that exported mzTab data is written consistently across all platforms and system configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Noble-Lab/casanovo/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->