### PR TITLE
Upgrade minimum Depthcharge version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "appdirs",
     "lightning>=2.6",
     "click",
-    "depthcharge-ms>=0.4.9,<0.5.0",
+    "depthcharge-ms>=0.4.10,<0.5.0",
     "natsort",
     "numpy<2.0",
     "pandas",
@@ -62,7 +62,7 @@ dev = [
     "black>=26.3.0",
     "ppx",
     "psims",
-    "pyteomics>=4.7,<5.0",
+    "pyteomics",
     "pytest",
 ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `depthcharge-ms` dependency to minimum version 0.4.10
  * Removed version constraints on `pyteomics` dependency for greater flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->