### PR TITLE
fix: bound model weights download requests

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -954,9 +954,7 @@ def _get_weights_from_url(
         url_last_modified = 0
 
         try:
-            file_response = requests.head(
-                file_url, timeout=REQUEST_TIMEOUT
-            )
+            file_response = requests.head(file_url, timeout=REQUEST_TIMEOUT)
             if file_response.ok:
                 if "Last-Modified" in file_response.headers:
                     url_last_modified = datetime.datetime.strptime(

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -43,6 +43,7 @@ from .config import Config
 from .denovo import ModelRunner
 
 logger = logging.getLogger("casanovo")
+REQUEST_TIMEOUT = 30
 click.rich_click.USE_MARKDOWN = True
 click.rich_click.STYLE_HELPTEXT = ""
 click.rich_click.SHOW_ARGUMENTS = True
@@ -953,7 +954,9 @@ def _get_weights_from_url(
         url_last_modified = 0
 
         try:
-            file_response = requests.head(file_url)
+            file_response = requests.head(
+                file_url, timeout=REQUEST_TIMEOUT
+            )
             if file_response.ok:
                 if "Last-Modified" in file_response.headers:
                     url_last_modified = datetime.datetime.strptime(
@@ -1005,7 +1008,12 @@ def _download_weights(file_url: str, download_path: Path) -> None:
     """
     download_file_dir = download_path.parent
     os.makedirs(download_file_dir, exist_ok=True)
-    response = requests.get(file_url, stream=True, allow_redirects=True)
+    response = requests.get(
+        file_url,
+        stream=True,
+        allow_redirects=True,
+        timeout=REQUEST_TIMEOUT,
+    )
     response.raise_for_status()
     file_size = int(response.headers.get("Content-Length", 0))
     desc = "(Unknown total file size)" if file_size == 0 else ""

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -425,13 +425,21 @@ class MockResponseGet:
     def __init__(self):
         self.request_counter = 0
         self.is_ok = True
+        self.timeout = None
 
     def raise_for_status(self):
         if not self.is_ok:
             raise requests.HTTPError
 
-    def __call__(self, url, stream=True, allow_redirects=True):
+    def __call__(
+        self,
+        url,
+        stream=True,
+        allow_redirects=True,
+        timeout=None,
+    ):
         self.request_counter += 1
+        self.timeout = timeout
         response = unittest.mock.MagicMock()
         response.raise_for_status = self.raise_for_status
         response.headers = {"Content-Length": str(len(self.file_content))}
@@ -444,8 +452,10 @@ class MockResponseHead:
         self.last_modified = None
         self.is_ok = True
         self.fail = False
+        self.timeout = None
 
-    def __call__(self, url):
+    def __call__(self, url, timeout=None):
+        self.timeout = timeout
         if self.fail:
             raise requests.ConnectionError
 
@@ -780,11 +790,13 @@ def test_get_weights_from_url(monkeypatch):
         assert cache_file_path.is_file()
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 1
+        assert mock_get.timeout == casanovo.REQUEST_TIMEOUT
 
         # Test that cached file is used
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 1
+        assert mock_head.timeout == casanovo.REQUEST_TIMEOUT
 
         # Test force downloading the file
         result_path = casanovo._get_weights_from_url(


### PR DESCRIPTION
## Problem

URL-based model weight resolution uses `requests.head()` for cache freshness checks and `requests.get()` for streaming downloads without a timeout. If the remote server accepts the connection but stalls, Casanovo can wait indefinitely while resolving weights.

## Before / After

Before, both the HEAD freshness check and the streaming download could block forever on a slow or unresponsive server.

After, both requests use the same 30 second timeout constant, so network stalls fail in a bounded way and the existing cache fallback behavior for HEAD failures still applies.

## Verification

- `python -m py_compile casanovo\casanovo.py tests\unit_tests\test_unit.py`
- Attempted `python -m pytest tests/unit_tests/test_unit.py::test_get_weights_from_url`, but the local environment is missing `psims` from `tests/conftest.py`, so pytest could not start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model weight download reliability by adding time limits to remote requests used for downloading and cache checking. This prevents indefinite hangs during weight retrieval and cache validation, making model loading more robust and responsive for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->