### PR TITLE
Read MGF scan index files with explicit UTF-8 encoding

### DIFF
--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -45,7 +45,7 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
     """
     index, current_scan, in_ions = 0, None, False
     try:
-        with open(mgf_path, errors="replace") as fh:
+        with open(mgf_path, encoding="utf-8", errors="replace") as fh:
             for line in fh:
                 upper = line.strip().upper()
                 if upper == _MGF_BEGIN:


### PR DESCRIPTION
## Problem

`_build_mgf_scan_index()` opens MGF files as text with `errors="replace"`, but it does not specify an encoding. That leaves the scan-index helper dependent on the platform default encoding, while the rest of the project generally uses explicit UTF-8 for text file reads/writes.

## Before

MGF scan-index parsing used the process/platform default text encoding.

## After

MGF scan-index parsing now opens files with `encoding="utf-8"` while preserving `errors="replace"` for malformed bytes.

## Verification

Ran the focused tests for the touched MGF scan-index path:

```bash
python -m pytest tests/unit_tests/test_unit.py -k "mgf_scan_index or mgf_scan_alias"
```

Result: 3 passed, 115 deselected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in MGF file encoding handling to ensure reliable character interpretation across all file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->