### PR TITLE
fix: skip fresh cached URL weight checks

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -47,6 +47,8 @@ click.rich_click.USE_MARKDOWN = True
 click.rich_click.STYLE_HELPTEXT = ""
 click.rich_click.SHOW_ARGUMENTS = True
 
+_URL_WEIGHTS_CACHE_TTL_SECONDS = 24 * 60 * 60
+
 
 class _SharedFileIOParams(click.RichCommand):
     """File IO options shared between most Casanovo commands"""
@@ -950,6 +952,12 @@ def _get_weights_from_url(
 
     if cache_file_path.is_file() and not force_download:
         cache_time = cache_file_path.stat()
+        if time.time() - cache_time.st_mtime < _URL_WEIGHTS_CACHE_TTL_SECONDS:
+            logger.info(
+                "Model weights %s retrieved from local cache", file_url
+            )
+            return cache_file_path
+
         url_last_modified = 0
 
         try:

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -444,8 +444,10 @@ class MockResponseHead:
         self.last_modified = None
         self.is_ok = True
         self.fail = False
+        self.request_counter = 0
 
     def __call__(self, url):
+        self.request_counter += 1
         if self.fail:
             raise requests.ConnectionError
 
@@ -785,6 +787,7 @@ def test_get_weights_from_url(monkeypatch):
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 1
+        assert mock_head.request_counter == 0
 
         # Test force downloading the file
         result_path = casanovo._get_weights_from_url(
@@ -797,20 +800,29 @@ def test_get_weights_from_url(monkeypatch):
         # file last modified
         # NOTE: Assuming test takes < 1 year to run
         curr_utc = datetime.datetime.now().astimezone(datetime.timezone.utc)
+        stale_time = (
+            datetime.datetime.now().timestamp()
+            - casanovo._URL_WEIGHTS_CACHE_TTL_SECONDS
+            - 1
+        )
+        os.utime(cache_file_path, (stale_time, stale_time))
         mock_head.last_modified = (
             curr_utc + datetime.timedelta(days=365.0)
         ).strftime("%a, %d %b %Y %H:%M:%S GMT")
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 3
+        assert mock_head.request_counter == 1
 
         # Test file is not redownloaded if its newer than upstream file
+        os.utime(cache_file_path, (stale_time, stale_time))
         mock_head.last_modified = (
             curr_utc - datetime.timedelta(days=365.0)
         ).strftime("%a, %d %b %Y %H:%M:%S GMT")
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 3
+        assert mock_head.request_counter == 2
 
         # Test that error is raised if file get response is not OK
         mock_get.is_ok = False
@@ -823,6 +835,7 @@ def test_get_weights_from_url(monkeypatch):
 
         # Test that cached file is used if head requests yields non-ok status
         # code, even if upstream file is newer
+        os.utime(cache_file_path, (stale_time, stale_time))
         mock_head.is_ok = False
         mock_head.last_modified = (
             curr_utc + datetime.timedelta(days=365.0)
@@ -830,13 +843,16 @@ def test_get_weights_from_url(monkeypatch):
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 4
+        assert mock_head.request_counter == 3
         mock_head.is_ok = True
 
         # Test that cached file is used if head request fails
+        os.utime(cache_file_path, (stale_time, stale_time))
         mock_head.fail = True
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 4
+        assert mock_head.request_counter == 4
         mock_head.fail = False
 
         # Test invalid URL


### PR DESCRIPTION
## Problem

Closes #616.

`_get_weights_from_url()` made a `HEAD` request every time a URL-backed model file already existed in the cache. That meant repeat invocations still depended on network latency and remote availability even when the local cache had just been populated.

## Before / after

Before:
- First run downloaded and cached the URL model weights.
- A second immediate run reused the cached file, but still performed a remote `HEAD` request first.

After:
- Cached URL weights newer than the 24-hour TTL are returned immediately without a remote `HEAD` request.
- Stale cached files still use the existing `HEAD` / `Last-Modified` freshness check before deciding whether to re-download.
- `force_download=True` still bypasses the cache.

## Verification

- `python -m pytest tests/unit_tests/test_unit.py -k get_weights_from_url`
- `python -m ruff check --extend-ignore E402 casanovo/casanovo.py tests/unit_tests/test_unit.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized weight file caching to validate locally cached copies against a time-based validity window, eliminating unnecessary remote verification requests for recently cached weight files and improving load performance.

* **Tests**
  * Enhanced unit tests to verify cache validation logic and confirm that remote verification requests are only made when the cached file is no longer within the acceptable time window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->