### PR TITLE
Remove CPU accelerator override for Apple Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 
-- Removed the override that forced `accelerator: "auto"` to `"cpu"` on Apple Silicon
-  devices. PyTorch Lightning's `"auto"` mode correctly selects MPS on arm64 macOS,
-  giving approximately 2.3× faster inference compared to CPU.
+- Removed the override that forced `accelerator: "auto"` to `"cpu"` on Apple Silicon devices.
 
 ## [5.2.0] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the override that forced `accelerator: "auto"` to `"cpu"` on Apple Silicon
+  devices. PyTorch Lightning's `"auto"` mode correctly selects MPS on arm64 macOS,
+  giving approximately 2.3× faster inference compared to CPU.
+
 ## [5.2.0] - 2026-06-02
 
 ### Added

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -153,15 +153,6 @@ class Config:
 
         self._params["n_workers"] = utils.n_workers()
 
-        if self._params["accelerator"] == "auto" and utils.is_apple_silicon():
-            self._params["accelerator"] = "cpu"
-            logger.warning(
-                "accelerator='auto' will be overwritten to 'cpu' on Apple Silicon"
-                " devices due to incompatibility with MPS accelerators.\n"
-                "Note: If you want to use a different accelerator (other than MPS),"
-                " please specify it explicitly in the config file."
-            )
-
     def __getitem__(self, param: str) -> Union[int, bool, str, Tuple, Dict]:
         """Retrieve a parameter."""
         return self._params[param]

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -259,15 +259,3 @@ def check_dir_file_exists(
                 f"File matching wildcard pattern {pattern} already exist in "
                 f"{dir} and can not be overwritten."
             )
-
-
-def is_apple_silicon() -> bool:
-    """
-    Check whether the current device is Apple Silicon.
-
-    Returns
-    -------
-    bool
-        Whether the current device is Apple Silicon.
-    """
-    return platform.system() == "Darwin" and platform.machine() == "arm64"

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,19 +1,14 @@
 """Test configuration loading"""
 
-import logging
-
 import pytest
 import yaml
 
 from casanovo.config import Config
 
 
-def test_default(monkeypatch):
+def test_default():
     """Test that loading the default works"""
-    with monkeypatch.context() as ctx:
-        ctx.setattr("platform.machine", lambda: "x86-64")
-        config = Config()
-
+    config = Config()
     assert config.random_seed == 454
     assert config["random_seed"] == 454
     assert config.accelerator == "auto"
@@ -75,39 +70,3 @@ def test_deprecated(tmp_path, tiny_config):
 
     with pytest.warns(DeprecationWarning):
         Config(filename)
-
-
-def test_override_mps(monkeypatch, tiny_config, tmp_path, caplog):
-    filename = str(tmp_path / "config_auto.yml")
-    with (
-        open(tiny_config, "r", encoding="utf-8") as f_in,
-        open(filename, "w", encoding="utf-8") as f_out,
-    ):
-        cfg = yaml.safe_load(f_in)
-        cfg["accelerator"] = "auto"
-        yaml.safe_dump(cfg, f_out)
-
-    with monkeypatch.context() as ctx, caplog.at_level(logging.WARNING):
-        # Overwrite on Apple Silicon
-        ctx.setattr("platform.system", lambda: "Darwin")
-        ctx.setattr("platform.machine", lambda: "arm64")
-        cfg = Config(filename)
-
-        assert cfg["accelerator"] == "cpu"
-        assert cfg.accelerator == "cpu"
-        assert any(
-            "overwritten to 'cpu' on Apple Silicon" in rec.getMessage()
-            for rec in caplog.records
-        )
-
-        # Don't overwrite on x86-64
-        caplog.clear()
-        ctx.setattr("platform.machine", lambda: "x86-64")
-        cfg = Config(filename)
-
-        assert cfg["accelerator"] == "auto"
-        assert cfg.accelerator == "auto"
-        assert not any(
-            "overwritten to 'cpu' on Apple Silicon" in rec.getMessage()
-            for rec in caplog.records
-        )


### PR DESCRIPTION
## Summary

Casanovo currently overrides `accelerator: "auto"` to `"cpu"` on Apple Silicon (added in #522). This PR removes that override because it is no longer needed: PyTorch Lightning's `"auto"` mode already selects MPS on arm64 macOS by itself.

**Changes:**
- Delete the 8-line override block in `casanovo/config.py`
- Delete the now-dead `is_apple_silicon()` utility function in `casanovo/utils.py`
- Remove the `test_override_mps` test and simplify `test_default` (which had been monkeypatched to work around the override on Apple Silicon CI)
- Add a CHANGELOG entry

## Testing

Tested on Apple M2 Max, macOS 25.5.0, PyTorch 2.12.1, Casanovo 5.2.0:

| Accelerator | Wall time | Spectra sequenced |
|-------------|-----------|-------------------|
| CPU (old default) | 14 min 41 s | 13,489 |
| MPS (new default) | **6 min 24 s** | 13,489 |

Outputs compared directly: 13,489/13,489 sequences identical, score differences within float32 precision (max 2×10⁻⁵). **MPS is ~2.3× faster with no change to correctness.**

One non-fatal PyTorch warning is emitted at startup — `aten::_nested_tensor_from_mask_left_aligned` falls back to CPU inside `nn.MultiheadAttention` when using `key_padding_mask`. PyTorch handles this silently. Despite the fallback, performance is still 2.3× better than CPU-only.

Note: Lightning's `_AcceleratorConnector(accelerator="auto")` returns `MPSAccelerator` on arm64 macOS when MPS is available, confirmed with PyTorch 2.12.1.

## Test plan

- [x] `pytest tests/unit_tests/test_config.py -v` — all 3 tests pass
- [x] End-to-end `casanovo sequence` run on Apple Silicon with default config confirms `accelerator = mps` in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected accelerator behavior on Apple Silicon: automatic accelerator detection now properly selects MPS on arm64 macOS, instead of forcing CPU.
* **Tests**
  * Simplified configuration tests and removed the Apple Silicon override-specific test case to match the new behavior.
* **Documentation**
  * Updated the Unreleased changelog entry to reflect the removal of the previous accelerator override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->