### PR TITLE
feat(io): propagate retention time from input spectra to mzTab output

### DIFF
--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -3,6 +3,7 @@
 import collections
 import csv
 import logging
+import math
 import operator
 import os
 import re
@@ -293,9 +294,11 @@ class MztabWriter:
                     # FIXME: Modifications should be specified as
                     #  controlled vocabulary terms.
                     psm.modifications,  # modifications
-                    # FIXME: Can we get the retention time from the data
-                    #  loader?
-                    "null",  # retention_time
+                    (
+                        "null"
+                        if math.isnan(psm.retention_time)
+                        else psm.retention_time
+                    ),  # retention_time
                     psm.charge,  # charge
                     psm.exp_mz,  # exp_mass_to_charge
                     psm.calc_mz,  # calc_mass_to_charge

--- a/casanovo/data/psm.py
+++ b/casanovo/data/psm.py
@@ -35,6 +35,9 @@ class PepSpecMatch:
         sequence, where len(aa_scores) == len(sequence).
     protein : str
         Protein associated with the peptide sequence (for db mode).
+    retention_time : float
+        The retention time of the parent MS1 spectrum in seconds, NaN if
+        unknown.
     """
 
     sequence: str
@@ -45,6 +48,7 @@ class PepSpecMatch:
     exp_mz: float
     aa_scores: Iterable[float]
     protein: str = "null"
+    retention_time: float = float("nan")
 
     # Private properties to handle proteoform caching
     _proteoform_sequence: Optional[str] = dataclasses.field(

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -5,7 +5,7 @@ import logging
 import math
 import os
 import pathlib
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import lightning.pytorch as pl
 import numpy as np
@@ -295,7 +295,11 @@ class DeNovoDataModule(pl.LightningDataModule):
         torch.utils.data.Dataset
             A PyTorch Dataset for the given peak files.
         """
-        custom_fields = [self.custom_field_anno] if annotated else []
+        custom_fields = [
+            CustomField("retention_time", _get_retention_time, pa.float32())
+        ]
+        if annotated:
+            custom_fields.append(self.custom_field_anno)
         lance_path = pathlib.Path(f"{self.lance_dir}/{mode}.lance")
 
         parse_params = dict(
@@ -402,6 +406,41 @@ class DeNovoDataModule(pl.LightningDataModule):
     def db_dataloader(self) -> torch.utils.data.DataLoader:
         """Get a special dataloader for DB search."""
         return self._make_loader(self.test_dataset)
+
+
+def _get_retention_time(spectrum: dict[str, Any]) -> float:
+    """
+    Extract the retention time from a spectrum dict and return it in seconds.
+
+    Handles mzML, mzXML, and MGF formats. Returns NaN if unavailable.
+
+    Parameters
+    ----------
+    spectrum : dict
+        A spectrum dictionary as returned by pyteomics.
+
+    Returns
+    -------
+    float
+        The retention time in seconds, or NaN if unavailable.
+    """
+    # mzML / mzXML top-level keys
+    for key in ("scan start time", "retention time", "retentionTime"):
+        if key in spectrum:
+            return float(spectrum[key])
+
+    # mzML nested scanList
+    scan = spectrum.get("scanList", {}).get("scan", [{}])[0]
+    if "scan start time" in scan:
+        return float(scan["scan start time"])
+
+    # MGF params block
+    params = spectrum.get("params", {})
+    for key in ("rtinseconds", "rtinsec"):
+        if key in params:
+            return float(params[key])
+
+    return float("nan")
 
 
 def _discard_low_quality(

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -430,9 +430,9 @@ def _get_retention_time(spectrum: dict[str, Any]) -> float:
             return float(spectrum[key])
 
     # mzML nested scanList
-    scan = spectrum.get("scanList", {}).get("scan", [{}])[0]
-    if "scan start time" in scan:
-        return float(scan["scan start time"])
+    scans = spectrum.get("scanList", {}).get("scan") or []
+    if scans and "scan start time" in scans[0]:
+        return float(scans[0]["scan start time"])
 
     # MGF params block
     params = spectrum.get("params", {})

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -956,12 +956,14 @@ class Spec2Pep(pl.LightningModule):
             scan,
             precursor_charge,
             precursor_mz,
+            retention_time,
             spectrum_preds,
         ) in zip(
             batch["peak_file"],
             batch["scan_id"],
             batch["precursor_charge"],
             batch["precursor_mz"],
+            batch["retention_time"],
             self.forward(batch),
         ):
             for peptide_score, aa_scores, peptide in spectrum_preds:
@@ -974,6 +976,7 @@ class Spec2Pep(pl.LightningModule):
                         calc_mz=np.nan,
                         exp_mz=precursor_mz.item(),
                         aa_scores=aa_scores,
+                        retention_time=retention_time.item(),
                     )
                 )
 
@@ -1227,6 +1230,7 @@ class DbSpec2Pep(Spec2Pep):
                     scan,
                     precursor_charge,
                     precursor_mz,
+                    retention_time,
                     peptide,
                     peptide_score,
                     curr_aa_scores,
@@ -1235,6 +1239,7 @@ class DbSpec2Pep(Spec2Pep):
                     psm_batch["scan_id"],
                     psm_batch["precursor_charge"],
                     psm_batch["precursor_mz"],
+                    psm_batch["retention_time"],
                     psm_batch["original_seq_str"],
                     peptide_scores,
                     aa_scores_all,
@@ -1254,6 +1259,7 @@ class DbSpec2Pep(Spec2Pep):
                             calc_mz=np.nan,
                             exp_mz=precursor_mz.item(),
                             aa_scores=curr_aa_scores,
+                            retention_time=retention_time.item(),
                         )
                     )
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -950,6 +950,11 @@ class Spec2Pep(pl.LightningModule):
         predictions: List[psm.PepSpecMatch]
             Predicted PSMs for the given batch of spectra.
         """
+        n = len(batch["peak_file"])
+        retention_times = batch.get(
+            "retention_time",
+            torch.full((n,), float("nan")),
+        )
         predictions = []
         for (
             filename,
@@ -963,7 +968,7 @@ class Spec2Pep(pl.LightningModule):
             batch["scan_id"],
             batch["precursor_charge"],
             batch["precursor_mz"],
-            batch["retention_time"],
+            retention_times,
             self.forward(batch),
         ):
             for peptide_score, aa_scores, peptide in spectrum_preds:
@@ -976,7 +981,7 @@ class Spec2Pep(pl.LightningModule):
                         calc_mz=np.nan,
                         exp_mz=precursor_mz.item(),
                         aa_scores=aa_scores,
-                        retention_time=retention_time.item(),
+                        retention_time=float(retention_time),
                     )
                 )
 
@@ -1209,6 +1214,13 @@ class DbSpec2Pep(Spec2Pep):
         """
         predictions = collections.defaultdict(list)
 
+        if "retention_time" not in batch:
+            n = batch["precursor_charge"].shape[0]
+            batch = {
+                **batch,
+                "retention_time": torch.full((n,), float("nan")),
+            }
+
         with torch.inference_mode():
             # Pre-compute encoder outputs for the entire batch.
             mzs, intensities, precursors_all, _ = self._process_batch(batch)
@@ -1259,7 +1271,7 @@ class DbSpec2Pep(Spec2Pep):
                             calc_mz=np.nan,
                             exp_mz=precursor_mz.item(),
                             aa_scores=curr_aa_scores,
-                            retention_time=retention_time.item(),
+                            retention_time=float(retention_time),
                         )
                     )
 

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -6,6 +6,7 @@ import hashlib
 import heapq
 import io
 import logging
+import math
 import os
 import pathlib
 import platform
@@ -34,7 +35,7 @@ from casanovo import casanovo, denovo, utils
 from casanovo.casanovo import _SharedFileIOParams
 from casanovo.config import Config
 from casanovo.data import db_utils, ms_io, psm
-from casanovo.denovo.dataloaders import DeNovoDataModule
+from casanovo.denovo.dataloaders import DeNovoDataModule, _get_retention_time
 from casanovo.denovo.evaluate import aa_match, aa_match_batch, aa_match_metrics
 from casanovo.denovo.model import (
     DbSpec2Pep,
@@ -1613,6 +1614,7 @@ def test_db_stop_token(tiny_config):
         "scan_id": [1, 2],
         "mz_array": torch.zeros((2, 10)),
         "intensity_array": torch.zeros((2, 10)),
+        "retention_time": torch.tensor([float("nan"), float("nan")]),
     }
 
     for predction in db_model.predict_step(mock_batch):
@@ -1648,6 +1650,7 @@ def test_isoleucine_match(tiny_config):
         "intensity_array": torch.zeros((2, 10)),
         "peak_file": ["one.mgf", "two.mgf"],
         "scan_id": [1, 2],
+        "retention_time": torch.tensor([float("nan"), float("nan")]),
     }
 
     matches = db_model.predict_step(batch)
@@ -1964,6 +1967,7 @@ def test_n_term_scores_db(tiny_config, monkeypatch):
             "scan_id": [1, 2],
             "precursor_charge": ["+1", "+1"],
             "precursor_mz": torch.tensor([42.0, 42.0]),
+            "retention_time": torch.tensor([float("nan"), float("nan")]),
             "original_seq_str": ["[Acetyl]-P", "PP"],
         }
     ]
@@ -3176,3 +3180,29 @@ def test_train_cli_tracking_peak_path(tmp_path, mgf_small, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     assert str(mgf_small) in captured.get("tracking", ())
+
+
+@pytest.mark.parametrize(
+    "spectrum, expected",
+    [
+        # Flat mzML / mzXML style
+        ({"scan start time": 123.4}, 123.4),
+        ({"retention time": 456.7}, 456.7),
+        ({"retentionTime": 789.0}, 789.0),
+        # Nested mzML style
+        ({"scanList": {"scan": [{"scan start time": 321.0}]}}, 321.0),
+        # MGF style
+        ({"params": {"rtinseconds": 654.0}}, 654.0),
+        ({"params": {"rtinsec": 987.0}}, 987.0),
+        # Missing all keys
+        ({}, math.nan),
+        ({"scanList": {"scan": [{}]}}, math.nan),
+        ({"params": {}}, math.nan),
+    ],
+)
+def test_get_retention_time(spectrum, expected):
+    result = _get_retention_time(spectrum)
+    if math.isnan(expected):
+        assert math.isnan(result)
+    else:
+        assert result == pytest.approx(expected)

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -284,6 +284,43 @@ def test_mztab_save(tiny_config, tmp_path):
     assert file.is_file()
 
 
+def test_mztab_retention_time(tiny_config, tmp_path):
+    """Known RT is written numerically; unknown RT becomes null in mzTab."""
+    file = tmp_path / "rt_test.mztab"
+    writer = ms_io.MztabWriter(str(file))
+    writer.set_metadata(Config(tiny_config))
+    writer.set_ms_run(["test.mgf"])
+    writer.psms = [
+        psm.PepSpecMatch(
+            sequence="AAAA",
+            spectrum_id=("test.mgf", "0"),
+            peptide_score=1.0,
+            charge=2,
+            calc_mz=100.0,
+            exp_mz=100.0,
+            aa_scores=[0.5] * 4,
+            retention_time=42.5,
+        ),
+        psm.PepSpecMatch(
+            sequence="PPPP",
+            spectrum_id=("test.mgf", "1"),
+            peptide_score=0.9,
+            charge=2,
+            calc_mz=200.0,
+            exp_mz=200.0,
+            aa_scores=[0.8] * 4,
+            retention_time=float("nan"),
+        ),
+    ]
+    writer.save()
+
+    mztab = pyteomics.mztab.MzTab(str(file))
+    rows = mztab.spectrum_match_table
+    assert float(rows.loc[1, "retention_time"]) == pytest.approx(42.5)
+    rt2 = rows.loc[2, "retention_time"]
+    assert rt2 is None or (isinstance(rt2, float) and math.isnan(rt2))
+
+
 def test_version():
     """Check that the version is not None."""
     assert casanovo.__version__ is not None


### PR DESCRIPTION
## Summary

Closes #427.

- Added `_get_retention_time()` helper in `dataloaders.py` that extracts retention time (in seconds) from mzML, mzXML, and MGF spectrum dicts, returning NaN when the field is absent.
- The helper is registered as a `CustomField` on every dataset (both annotated and unannotated), so `retention_time` is always present in batches.
- Added `retention_time: float = float("nan")` field to `PepSpecMatch`.
- Both `Spec2Pep.predict_step` and `DbSpec2Pep.predict_step` now extract `retention_time` from the batch and pass it to `PepSpecMatch`.
- `MztabWriter.save()` now writes `psm.retention_time` to the `retention_time` mzTab column instead of the hardcoded `"null"` placeholder.

## Test plan

- [ ] Run `pytest tests/unit_tests/test_unit.py` — 9 new `test_get_retention_time` cases cover all supported formats (flat mzML/mzXML, nested mzML scanList, MGF params, and missing-key fallback to NaN); no previously-passing tests regress.
- [ ] Run Casanovo on an mzML or MGF file with known retention times and confirm the `retention_time` column in the output mzTab is populated correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Retention time from MS spectra is now captured, propagated into PSM outputs, and included in mzTab exports.

* **Bug Fixes**
  * Improved mzTab export behavior so unknown retention time values are written as `null` instead of being emitted incorrectly.

* **Tests**
  * Added unit tests to validate retention-time extraction across common spectrum metadata formats and to verify mzTab retention-time output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->