### PR TITLE
fix(config): allow fractional val_check_interval

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -172,11 +172,15 @@ class Config:
                 " please specify it explicitly in the config file."
             )
 
-    def __getitem__(self, param: str) -> Union[int, float, bool, str, Tuple, Dict]:
+    def __getitem__(
+        self, param: str
+    ) -> Union[int, float, bool, str, Tuple, Dict]:
         """Retrieve a parameter."""
         return self._params[param]
 
-    def __getattr__(self, param: str) -> Union[int, float, bool, str, Tuple, Dict]:
+    def __getattr__(
+        self, param: str
+    ) -> Union[int, float, bool, str, Tuple, Dict]:
         """Retrieve a parameter."""
         return self._params[param]
 

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -26,6 +26,16 @@ _config_deprecated = dict(
 )
 
 
+def _int_or_float(value: int | float | str) -> int | float:
+    """Parse an integer batch count or a float epoch fraction."""
+    if isinstance(value, float):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return float(value)
+
+
 class Config:
     """
     The Casanovo configuration options.
@@ -70,7 +80,7 @@ class Config:
         log_metrics=bool,
         log_every_n_steps=int,
         lance_dir=str,
-        val_check_interval=int,
+        val_check_interval=_int_or_float,
         min_peaks=int,
         max_peaks=int,
         min_mz=float,
@@ -162,11 +172,11 @@ class Config:
                 " please specify it explicitly in the config file."
             )
 
-    def __getitem__(self, param: str) -> Union[int, bool, str, Tuple, Dict]:
+    def __getitem__(self, param: str) -> Union[int, float, bool, str, Tuple, Dict]:
         """Retrieve a parameter."""
         return self._params[param]
 
-    def __getattr__(self, param: str) -> Union[int, bool, str, Tuple, Dict]:
+    def __getattr__(self, param: str) -> Union[int, float, bool, str, Tuple, Dict]:
         """Retrieve a parameter."""
         return self._params[param]
 

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -29,11 +29,18 @@ _config_deprecated = dict(
 def _int_or_float(value: int | float | str) -> int | float:
     """Parse an integer batch count or a float epoch fraction."""
     if isinstance(value, float):
-        return value
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return float(value)
+        parsed = value
+    else:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            parsed = float(value)
+
+    if not 0 <= parsed <= 1:
+        raise ValueError(
+            "Float val_check_interval values must be within [0, 1]"
+        )
+    return parsed
 
 
 class Config:

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -88,8 +88,9 @@ log_metrics: false
 log_every_n_steps: 50
 # Path to save Lance instances.
 lance_dir:
-# Model validation and checkpointing frequency in training steps.
-val_check_interval: 50_000
+# Model validation and checkpointing frequency. Use an integer for a fixed
+# number of training steps or a float in [0, 1] for a fraction of an epoch.
+val_check_interval: 1.0
 
 # SPECTRUM PROCESSING OPTIONS
 # Minimum number of peaks for a spectrum to be considered valid.

--- a/casanovo/config_timstof.yaml
+++ b/casanovo/config_timstof.yaml
@@ -88,8 +88,9 @@ log_metrics: false
 log_every_n_steps: 50
 # Path to save Lance instances.
 lance_dir:
-# Model validation and checkpointing frequency in training steps.
-val_check_interval: 50_000
+# Model validation and checkpointing frequency. Use an integer for a fixed
+# number of training steps or a float in [0, 1] for a fraction of an epoch.
+val_check_interval: 1.0
 
 # SPECTRUM PROCESSING OPTIONS
 # Minimum number of peaks for a spectrum to be considered valid.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -135,10 +135,9 @@ After the training job is finished, the validation snapshot that achieved the lo
 Additionally, a snapshot of the model weights at the end of each **training** epoch will be saved to the output directory as `epoch=<epoch>-step=<step>.ckpt`.
 Snapshots from previous training epochs will be overwritten with the latest training snapshot at the end of each training epoch.
 
-By default, Casanovo runs model validation every 50,000 training steps.
-Note that the number of samples that are processed during a single training step depends on the batch size.
-Therefore, the default training batch size of 32 corresponds to saving a model snapshot after every 1.6 million training samples.
+By default, Casanovo runs model validation once per training epoch (`val_check_interval: 1.0`).
 You can optionally modify the validation run frequency in the [config file](https://github.com/Noble-Lab/casanovo/blob/main/casanovo/config.yaml) (parameter `val_check_interval`), depending on your dataset size.
+Use a float between 0 and 1 to validate at a fraction of each epoch, or use an integer to validate after a fixed number of training steps.
 Note that running model validation very frequently will result in slower training time because Casanovo will evaluate its performance on the validation data for every validation check.
 
 ### Even though I added new post-translational modifications to the configuration file, Casanovo didn't identify those peptides.

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -75,6 +75,23 @@ def test_val_check_interval_accepts_int_or_float(tmp_path, tiny_config):
     assert config.val_check_interval == 100
 
 
+@pytest.mark.parametrize("val_check_interval", [-0.1, 1.5])
+def test_val_check_interval_rejects_out_of_range_float(
+    tmp_path, tiny_config, val_check_interval
+):
+    filename = str(tmp_path / "config_val_check_interval.yml")
+    with (
+        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(filename, "w", encoding="utf-8") as f_out,
+    ):
+        cfg = yaml.safe_load(f_in)
+        cfg["val_check_interval"] = val_check_interval
+        yaml.safe_dump(cfg, f_out)
+
+    with pytest.raises(TypeError, match="val_check_interval"):
+        Config(filename)
+
+
 def test_deprecated(tmp_path, tiny_config):
     filename = str(tmp_path / "config_deprecated.yml")
     with (

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -50,6 +50,31 @@ def test_override(tmp_path, tiny_config):
         Config(filename)
 
 
+def test_val_check_interval_accepts_int_or_float(tmp_path, tiny_config):
+    filename = str(tmp_path / "config_val_check_interval.yml")
+    with (
+        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(filename, "w", encoding="utf-8") as f_out,
+    ):
+        cfg = yaml.safe_load(f_in)
+        cfg["val_check_interval"] = 0.5
+        yaml.safe_dump(cfg, f_out)
+
+    config = Config(filename)
+    assert config.val_check_interval == 0.5
+
+    with (
+        open(tiny_config, "r", encoding="utf-8") as f_in,
+        open(filename, "w", encoding="utf-8") as f_out,
+    ):
+        cfg = yaml.safe_load(f_in)
+        cfg["val_check_interval"] = 100
+        yaml.safe_dump(cfg, f_out)
+
+    config = Config(filename)
+    assert config.val_check_interval == 100
+
+
 def test_deprecated(tmp_path, tiny_config):
     filename = str(tmp_path / "config_deprecated.yml")
     with (


### PR DESCRIPTION
## Problem

Closes #627.

Casanovo currently parses `val_check_interval` with `int`, even though PyTorch Lightning accepts either an integer batch/step interval or a float epoch fraction. A YAML value such as `0.5` can therefore be coerced incorrectly instead of being passed through as a fractional validation interval.

## Before / after

Before, `val_check_interval` was always parsed as an integer and the default config documented a fixed 50,000-step interval.

After, `val_check_interval` preserves both supported forms:

- `100` stays an integer fixed step interval
- `0.5` stays a float fractional epoch interval

The default config now uses `1.0`, matching the issue request for once-per-epoch validation by default, and the FAQ/config comments document both forms.

## Verification

Ran locally:

```bash
python -m pytest tests\unit_tests\test_config.py -q
python -m py_compile casanovo\config.py tests\unit_tests\test_config.py
git diff --check
```

Focused config tests passed: `5 passed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation/checkpoint timing (`val_check_interval`) now accepts an integer (steps) or a fractional value (fraction of an epoch).
  * Default training configs were updated to validate once per epoch (`val_check_interval: 1.0`).
* **Documentation**
  * Updated FAQ to reflect epoch-based validation by default and how to configure step- vs fraction-based timing.
* **Bug Fixes**
  * Validation timing config values are now parsed and preserved correctly when provided as integers or floats.
* **Tests**
  * Added coverage to verify `val_check_interval` handling for both numeric types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->