### PR TITLE
ci: fix ReadTheDocs build (ubuntu-20.04 image retired)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "mambaforge-4.10"
 


### PR DESCRIPTION
ReadTheDocs retired the `ubuntu-20.04` build image, so `latest` builds now fail config validation in ~2s before checkout and nothing publishes (including the new `getting_started_gui` page from #658). This bumps `build.os` to `ubuntu-22.04`. Last successful `latest` build was 2026-06-03 on the same config, before RTD removed the image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation build environment to a newer Ubuntu version for Read the Docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->