### PR TITLE
Modified config loading to load based on model selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Modified config loading to load based on model selectors (e.g., `orbitrap` and `timstof` 
+are currently supported) in sequencing mode
+
 ### Removed
 
 - Removed the override that forced `accelerator: "auto"` to `"cpu"` on Apple Silicon devices.

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -769,9 +769,6 @@ def _resolve_setup_config(
     resolved_model : Path | None
         Path to the resolved model weights, or None if training from
         scratch with random starting weights.
-    is_train : bool
-        Whether this is a training run (affects the wording of the
-        fallback warning).
 
     Returns
     -------
@@ -802,7 +799,10 @@ def _resolve_setup_config(
     elif Path(config).is_file():
         config = Config(config)
     else:
-        logger.warning("Config was: %s, which is not None or a Path", config)
+        logger.warning(
+            "Config '%s' is not a valid file path; using default config.",
+            config,
+        )
         config = Config(None)
 
     return config

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -681,9 +681,6 @@ def setup_model(
         Initialized Casanovo config, local path to model weights if any
         (may be `None` if training using random starting weights).
     """
-    config = Config(config)
-    seed_everything(seed=config["random_seed"], workers=True)
-
     cache_dir = Path(appdirs.user_cache_dir("casanovo", False, opinion=False))
     resolved_model: Optional[Path] = None
 
@@ -737,6 +734,9 @@ def setup_model(
                 "the model weights"
             ) from None
 
+    config = _resolve_setup_config(config, resolved_model)
+    seed_everything(seed=config["random_seed"], workers=True)
+
     logger.info("Casanovo version %s", str(__version__))
     logger.debug("model = %s", resolved_model)
     logger.debug("config = %s", config.file)
@@ -746,6 +746,66 @@ def setup_model(
         logger.debug("%s = %s", str(key), str(value))
 
     return config, resolved_model
+
+
+def _resolve_setup_config(
+    config: Optional[str],
+    resolved_model: Optional[Path],
+) -> "Config":
+    """
+    Resolve the Config object to use for this run.
+
+    Priority:
+      1. Explicit `config` path, if it points to a real file.
+      2. Auto-resolved from `resolved_model`'s canonical model id, if
+         the weights filename can be identified.
+      3. Default config, with a warning explaining why no more
+         specific config could be determined.
+
+    Parameters
+    ----------
+    config : str | None
+        User-supplied config file path, or None if not specified.
+    resolved_model : Path | None
+        Path to the resolved model weights, or None if training from
+        scratch with random starting weights.
+    is_train : bool
+        Whether this is a training run (affects the wording of the
+        fallback warning).
+
+    Returns
+    -------
+    Config
+        The resolved Config object.
+    """
+    if config is None:
+        if resolved_model is not None:
+            parsed = _parse_ckpt(resolved_model.name)
+            if parsed is not None:
+                canonical_id = parsed[0]
+            else:
+                canonical_id = None
+                logger.warning(
+                    "Could not determine model type from weights file '%s'. "
+                    "Using default config. If this is incorrect, specify a "
+                    "config file explicitly with '--config'.",
+                    resolved_model.name,
+                )
+        else:
+            canonical_id = None
+            logger.warning(
+                "No model weights specified (training from scratch). "
+                "Using default config. If this is incorrect, specify a "
+                "config file explicitly with '--config'."
+            )
+        config = Config(canonical_id)
+    elif Path(config).is_file():
+        config = Config(config)
+    else:
+        logger.warning("Config was: %s, which is not None or a Path", config)
+        config = Config(None)
+
+    return config
 
 
 def _get_model_weights(

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -47,7 +47,17 @@ class Config:
     ```
     """
 
-    _default_config = Path(__file__).parent / "config.yaml"
+    _config_dir = Path(__file__).parent
+    _default_config = _config_dir / "config.yaml"
+
+    _canonical_configs = {
+        "orbitrap": _default_config,
+        **{
+            path.stem.removeprefix("config_"): path
+            for path in _config_dir.glob("config_*.yaml")
+        },
+    }
+
     _config_types = dict(
         precursor_mass_tol=float,
         isotope_error_range=lambda min_max: (int(min_max[0]), int(min_max[1])),
@@ -114,6 +124,9 @@ class Config:
         if config_file is None:
             self._user_config = {}
         else:
+            if not Path(config_file).is_file():
+                config_file = self._resolve_config(config_file)
+
             with Path(config_file).open() as f_in:
                 self._user_config = yaml.safe_load(f_in)
                 # Remap deprecated config entries.
@@ -209,3 +222,18 @@ class Config:
             The output file.
         """
         shutil.copyfile(cls._default_config, output)
+
+    def _resolve_config(self, config_selector: str) -> Path:
+        if config_selector is None:
+            return self._default_config
+
+        base_config = self._canonical_configs.get(config_selector)
+        if base_config is None:
+            logger.warning(
+                "No bundled config found for model '%s'; using default "
+                "config.",
+                config_selector,
+            )
+            return self._default_config
+
+        return base_config

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -224,9 +224,6 @@ class Config:
         shutil.copyfile(cls._default_config, output)
 
     def _resolve_config(self, config_selector: str) -> Path:
-        if config_selector is None:
-            return self._default_config
-
         base_config = self._canonical_configs.get(config_selector)
         if base_config is None:
             logger.warning(

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -123,6 +123,7 @@ top_match: 5
 ```
 
 Each candidate will appear as a separate row in the mzTab output, distinguished by the `PSM_ID` field.
+When predicting spectra using models other than the default Orbitrap, only the `--model` flag needs to be changed (see Model Weights under File Formats) and the correct config file will load automatically.
 
 ### Evaluate *De Novo* Sequencing Performance
 

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -6,6 +6,15 @@ import yaml
 from casanovo.config import Config
 
 
+def test_config_resolution(caplog):
+    config = Config(None)
+    assert config._resolve_config("test") == config._default_config
+    assert "No bundled config found" in caplog.text
+
+    key = next(iter(config._canonical_configs))
+    assert config._resolve_config(key) == config._canonical_configs[key]
+
+
 def test_default():
     """Test that loading the default works"""
     config = Config()

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -47,7 +47,10 @@ from casanovo.denovo.model import (
 def test_casanovo_resolve_config_from_model(tmp_path, caplog):
     result = casanovo._resolve_setup_config("test", None)
     assert result["max_peaks"] == Config(result._default_config)["max_peaks"]
-    assert "Config was: test, which is not None or a Path" in caplog.text
+    assert (
+        "Config 'test' is not a valid file path; using default config."
+        in caplog.text
+    )
 
     fake_ckpt = tmp_path / "casanovo_orbitrap_v1-0-0.ckpt"
     fake_ckpt.touch()

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -44,10 +44,21 @@ from casanovo.denovo.model import (
 )
 
 
-def test_casanovo_resolve_config(caplog):
+def test_casanovo_resolve_config_from_model(tmp_path, caplog):
     result = casanovo._resolve_setup_config("test", None)
     assert result["max_peaks"] == Config(result._default_config)["max_peaks"]
     assert "Config was: test, which is not None or a Path" in caplog.text
+
+    fake_ckpt = tmp_path / "casanovo_orbitrap_v1-0-0.ckpt"
+    fake_ckpt.touch()
+    result = casanovo._resolve_setup_config(None, fake_ckpt)
+    assert result["max_peaks"] == Config(None)["max_peaks"]
+
+    fake_ckpt2 = tmp_path / "casanovo_unknownmodel_v1-0-0.ckpt"
+    fake_ckpt2.touch()
+    result2 = casanovo._resolve_setup_config(None, fake_ckpt2)
+    assert result2["max_peaks"] == Config(None)["max_peaks"]
+    assert "No bundled config found" in caplog.text
 
 
 def test_forward_reverse():

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -44,6 +44,12 @@ from casanovo.denovo.model import (
 )
 
 
+def test_casanovo_resolve_config(caplog):
+    result = casanovo._resolve_setup_config("test", None)
+    assert result["max_peaks"] == Config(result._default_config)["max_peaks"]
+    assert "Config was: test, which is not None or a Path" in caplog.text
+
+
 def test_forward_reverse():
     """Test forward and reverse peptide predictions"""
     score_A = [0.42, 1.0, 0.0, 0.0, 0.0]


### PR DESCRIPTION
Changes made:
- Loads config based on the model for sequencing mode 
- Added documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically selects the correct sequencing configuration based on the chosen model (including Orbitrap and timsTOF) or the model weights provided.
  - Supports configuration lookup by model name/selector, including automatic loading when running non-default models.
- **Bug Fixes**
  - Improved configuration resolution and startup behavior, including more reliable fallback to the default configuration with clear warnings when no match is found.
- **Documentation**
  - Updated getting-started instructions to clarify that only the `--model` flag needs changing for non-default models.
- **Tests**
  - Added unit tests covering configuration resolution and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->