### PR TITLE
Use UTF-8 for text file reads

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -108,13 +108,13 @@ class Config:
     def __init__(self, config_file: Optional[str] = None):
         """Initialize a Config object."""
         self.file = str(config_file) if config_file is not None else "default"
-        with self._default_config.open() as f_in:
+        with self._default_config.open(encoding="utf-8") as f_in:
             self._params = yaml.safe_load(f_in)
 
         if config_file is None:
             self._user_config = {}
         else:
-            with Path(config_file).open() as f_in:
+            with Path(config_file).open(encoding="utf-8") as f_in:
                 self._user_config = yaml.safe_load(f_in)
                 # Remap deprecated config entries.
                 for old, new in _config_deprecated.items():

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -45,7 +45,7 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
     """
     index, current_scan, in_ions = 0, None, False
     try:
-        with open(mgf_path, errors="replace") as fh:
+        with open(mgf_path, encoding="utf-8", errors="replace") as fh:
             for line in fh:
                 upper = line.strip().upper()
                 if upper == _MGF_BEGIN:

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -375,7 +375,8 @@ def test_evaluate_failure_cases(
     mgf_path = Path(mgf_small)
     improperly_annotated_file = mgf_path.parent / "improperly_annotated.mgf"
     improperly_annotated_file.write_text(
-        mgf_path.read_text().replace("SEQ=", "PEPTIDE=")
+        mgf_path.read_text(encoding="utf-8").replace("SEQ=", "PEPTIDE="),
+        encoding="utf-8",
     )
 
     file_map = {


### PR DESCRIPTION
## Problem
A few text file operations rely on the platform default encoding when reading YAML config files, scanning MGF headers, or rewriting an MGF fixture in tests. That can make behavior vary across environments with non-UTF-8 defaults.

## Before / after
Before, these reads/writes used the process default text encoding.

After, the config loader, MGF scan-index reader, and related test fixture rewrite explicitly use UTF-8. The MGF reader keeps `errors="replace"` unchanged.

## Verification
- `python -m compileall casanovo\\config.py casanovo\\data\\ms_io.py tests\\unit_tests\\test_runner.py`
- `pytest tests/unit_tests/test_config.py tests/unit_tests/test_unit.py::test_mgf_scan_index_built_correctly tests/unit_tests/test_unit.py::test_mgf_without_scans_gives_empty_index tests/unit_tests/test_unit.py::test_mgf_scan_alias_scan_field tests/unit_tests/test_unit.py::test_mgf_scan_alias_scan_id_field -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration and MGF files across environments by consistently using UTF-8 encoding.
  * Reduced the risk of file-reading and writing issues caused by differing system default encodings.

* **Tests**
  * Updated file-based test setup to use consistent UTF-8 encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->