### PR TITLE
Stop writing Lance datasets and mzTab output into the working directory during testing

### DIFF
--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -116,7 +116,9 @@ def test_db_search_no_model_raises(
         ),
     ):
         runner.db_search(
-            (str(mgf_small),), str(tiny_fasta_file), str(tmp_path / "test.mztab")
+            (str(mgf_small),),
+            str(tiny_fasta_file),
+            str(tmp_path / "test.mztab"),
         )
 
 

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -104,7 +104,9 @@ def test_initialize_model(tmp_path, mgf_small):
         runner.initialize_model(train=False)
 
 
-def test_db_search_no_model_raises(tiny_config_db, mgf_small, tiny_fasta_file):
+def test_db_search_no_model_raises(
+    tiny_config_db, mgf_small, tiny_fasta_file, tmp_path
+):
     """DB search must require an explicit model file."""
     config = Config(tiny_config_db)
     with (
@@ -113,7 +115,9 @@ def test_db_search_no_model_raises(tiny_config_db, mgf_small, tiny_fasta_file):
             ValueError, match="A model file must be provided for DB search"
         ),
     ):
-        runner.db_search((str(mgf_small),), str(tiny_fasta_file), "test.mztab")
+        runner.db_search(
+            (str(mgf_small),), str(tiny_fasta_file), str(tmp_path / "test.mztab")
+        )
 
 
 def test_save_and_load_weights(tmp_path, mgf_small, tiny_config):

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2067,7 +2067,7 @@ def test_spectrum_id_mgf(mgf_small, tmp_path):
     mgf_small2 = tmp_path / "mgf_small2.mgf"
     shutil.copy(mgf_small, mgf_small2)
     data_module = DeNovoDataModule(
-        lance_dir=tmp_path.name,
+        lance_dir=str(tmp_path),
         train_paths=[mgf_small, mgf_small2],
         valid_paths=[mgf_small, mgf_small2],
         test_paths=[mgf_small, mgf_small2],
@@ -2104,7 +2104,7 @@ def test_log_training_set_size(mgf_small, tmp_path, caplog):
     mgf_small2 = tmp_path / "mgf_small2.mgf"
     shutil.copy(mgf_small, mgf_small2)
     data_module = DeNovoDataModule(
-        lance_dir=tmp_path.name,
+        lance_dir=str(tmp_path),
         train_paths=[mgf_small, mgf_small2],
         valid_paths=[mgf_small],
         min_peaks=0,
@@ -2128,7 +2128,7 @@ def test_log_training_set_size_shuffled(mgf_small, tmp_path, caplog):
     mgf_small2 = tmp_path / "mgf_small2.mgf"
     shutil.copy(mgf_small, mgf_small2)
     data_module = DeNovoDataModule(
-        lance_dir=tmp_path.name,
+        lance_dir=str(tmp_path),
         train_paths=[mgf_small, mgf_small2],
         valid_paths=[mgf_small],
         min_peaks=0,
@@ -2152,7 +2152,7 @@ def test_spectrum_id_mzml(mzml_small, tmp_path):
     mzml_small2 = tmp_path / "mzml_small2.mzml"
     shutil.copy(mzml_small, mzml_small2)
     data_module = DeNovoDataModule(
-        lance_dir=tmp_path.name,
+        lance_dir=str(tmp_path),
         test_paths=[mzml_small, mzml_small2],
         min_peaks=0,
         shuffle=False,
@@ -2391,7 +2391,7 @@ def test_spectrum_preprocessing(tmp_path, mgf_small):
     # One spectrum removed with too few peaks.
     total_spectra = 1
     dataloader = DeNovoDataModule(
-        tmp_path.name,
+        str(tmp_path),
         test_paths=str(mgf_small),
         min_peaks=min_peaks,
         max_peaks=max_peaks,
@@ -2413,7 +2413,7 @@ def test_spectrum_preprocessing(tmp_path, mgf_small):
     # All spectra retained.
     total_spectra = 2
     dataloader = DeNovoDataModule(
-        tmp_path.name,
+        str(tmp_path),
         test_paths=str(mgf_small),
         min_peaks=min_peaks,
         max_peaks=max_peaks,
@@ -2436,7 +2436,7 @@ def test_spectrum_preprocessing(tmp_path, mgf_small):
     # One spectrum removed with too high charge.
     total_spectra = 1
     dataloader = DeNovoDataModule(
-        tmp_path.name,
+        str(tmp_path),
         test_paths=str(mgf_small),
         min_peaks=min_peaks,
         max_peaks=max_peaks,
@@ -3093,7 +3093,7 @@ def test_data_module_per_file_validation(mgf_small, tmp_path):
     mgf_small2 = tmp_path / "mgf_small2.mgf"
     shutil.copy(mgf_small, mgf_small2)
     data_module = DeNovoDataModule(
-        lance_dir=tmp_path.name,
+        lance_dir=str(tmp_path),
         valid_paths=[mgf_small, mgf_small2],
         tracking_paths=[mgf_small],
         min_peaks=0,


### PR DESCRIPTION
When you run the full test suite in a local checkout, a lot of unchecked directories and files are left in the root directory. These test artifiacts are directories named after the tests that created them, each holding Lance datasets with random UUID filenames, plus a stray test.mztab.

The cause was that eight call sites passed `tmp_path.name` where a path was expected. `.name` discards the parent, so a pytest temporary directory such as `/tmp/pytest-of-user/pytest-9/test_log_training_set_size0` collapses to the bare relative name `test_log_training_set_size0`, which is then created in whatever the working directory happens to be.

A ninth site, `test_db_search_no_model_raises `, passed the literal `"test.mztab"`, so its output landed in the current directory too. That test did not take `tmp_path`, so the fixture is added to its signature.

Fixed by passing `str(tmp_path)`, which is what the surrounding code expects. No test logic or assertion changes.

Because the UUID filenames cannot be matched by a fixed pattern, a `.gitignore  rule would have needed a directory glob broad enough to risk masking real files. Putting the output where pytest already manages and cleans it is the narrower fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by using temporary filesystem paths for generated output.
  * Updated dataset-related tests to use temporary directories consistently.
  * Enhanced coverage for spectrum handling, preprocessing, logging, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->