### PR TITLE
fix: bound model weight HTTP requests

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -47,6 +47,8 @@ click.rich_click.USE_MARKDOWN = True
 click.rich_click.STYLE_HELPTEXT = ""
 click.rich_click.SHOW_ARGUMENTS = True
 
+_MODEL_WEIGHT_REQUEST_TIMEOUT = 30
+
 
 class _SharedFileIOParams(click.RichCommand):
     """File IO options shared between most Casanovo commands"""
@@ -953,7 +955,9 @@ def _get_weights_from_url(
         url_last_modified = 0
 
         try:
-            file_response = requests.head(file_url)
+            file_response = requests.head(
+                file_url, timeout=_MODEL_WEIGHT_REQUEST_TIMEOUT
+            )
             if file_response.ok:
                 if "Last-Modified" in file_response.headers:
                     url_last_modified = datetime.datetime.strptime(
@@ -1005,7 +1009,12 @@ def _download_weights(file_url: str, download_path: Path) -> None:
     """
     download_file_dir = download_path.parent
     os.makedirs(download_file_dir, exist_ok=True)
-    response = requests.get(file_url, stream=True, allow_redirects=True)
+    response = requests.get(
+        file_url,
+        stream=True,
+        allow_redirects=True,
+        timeout=_MODEL_WEIGHT_REQUEST_TIMEOUT,
+    )
     response.raise_for_status()
     file_size = int(response.headers.get("Content-Length", 0))
     desc = "(Unknown total file size)" if file_size == 0 else ""

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -425,13 +425,15 @@ class MockResponseGet:
     def __init__(self):
         self.request_counter = 0
         self.is_ok = True
+        self.timeouts = []
 
     def raise_for_status(self):
         if not self.is_ok:
             raise requests.HTTPError
 
-    def __call__(self, url, stream=True, allow_redirects=True):
+    def __call__(self, url, stream=True, allow_redirects=True, timeout=None):
         self.request_counter += 1
+        self.timeouts.append(timeout)
         response = unittest.mock.MagicMock()
         response.raise_for_status = self.raise_for_status
         response.headers = {"Content-Length": str(len(self.file_content))}
@@ -444,8 +446,10 @@ class MockResponseHead:
         self.last_modified = None
         self.is_ok = True
         self.fail = False
+        self.timeouts = []
 
-    def __call__(self, url):
+    def __call__(self, url, timeout=None):
+        self.timeouts.append(timeout)
         if self.fail:
             raise requests.ConnectionError
 
@@ -780,11 +784,13 @@ def test_get_weights_from_url(monkeypatch):
         assert cache_file_path.is_file()
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 1
+        assert mock_get.timeouts == [casanovo._MODEL_WEIGHT_REQUEST_TIMEOUT]
 
         # Test that cached file is used
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 1
+        assert mock_head.timeouts == [casanovo._MODEL_WEIGHT_REQUEST_TIMEOUT]
 
         # Test force downloading the file
         result_path = casanovo._get_weights_from_url(
@@ -792,6 +798,7 @@ def test_get_weights_from_url(monkeypatch):
         )
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 2
+        assert mock_get.timeouts[-1] == casanovo._MODEL_WEIGHT_REQUEST_TIMEOUT
 
         # Test that file is re-downloaded if last modified is newer than
         # file last modified


### PR DESCRIPTION
## Problem

Remote model-weight resolution uses `requests.head()` to check cached file freshness and `requests.get(..., stream=True)` to download weights. Neither request had a timeout, so a slow or stalled remote endpoint could leave Casanovo waiting indefinitely while resolving model weights.

## Before / after behavior

Before, both the cache freshness request and the streamed download could block without a client-side bound.

After, both requests use the same 30 second timeout constant. The existing cached-file fallback for HEAD request failures is preserved, and failed downloads still surface through `raise_for_status()` / requests exceptions.

## Verification

- `python -m pytest tests/unit_tests/test_unit.py -k get_weights_from_url` - 1 passed, 117 deselected
- `python -m black --check casanovo/casanovo.py tests/unit_tests/test_unit.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 30-second timeout to model-weight validation and downloads.
  * Improved reliability by preventing requests from hanging indefinitely.

* **Tests**
  * Added coverage confirming timeouts are applied during initial, cached, and forced downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->