### PR TITLE
fix: placement check for N-term mods during beam search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the mass of the carbamylation + ammonia-loss N-terminal token to `25.979265`. The token name is deliberately left as `[+25.980265]-` because it appears in released checkpoint vocabularies.
+
+### Removed
+
+- Removed the override that forced `accelerator: "auto"` to `"cpu"` on Apple Silicon devices.
+
+## [5.2.1] - 2026-08-12
+
+### Fixed
+
+- Fixed the placement check for N-terminal modifications during decoding, whose two branches were swapped. This silently discarded every peptide with an N-terminal modification, and could instead retain a malformed peptide that fails to parse. Note that this changes *de novo* sequencing results: peptides with N-terminal modifications will now appear in the output, so any evaluation metrics computed with version 5.2.0 should be recomputed.
+
 ## [5.2.0] - 2026-06-02
 
 ### Added
@@ -359,7 +373,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial Casanovo version.
 
-[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.2.0...HEAD
+[Unreleased]: https://github.com/Noble-Lab/casanovo/compare/v5.2.1...HEAD
+[5.2.1]: https://github.com/Noble-Lab/casanovo/compare/v5.2.0...v5.2.1
 [5.2.0]: https://github.com/Noble-Lab/casanovo/compare/v5.1.2...v5.2.0
 [5.1.2]: https://github.com/Noble-Lab/casanovo/compare/v5.1.1...v5.1.2
 [5.1.1]: https://github.com/Noble-Lab/casanovo/compare/v5.1.0...v5.1.1

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -433,8 +433,10 @@ class Spec2Pep(pl.LightningModule):
         )
         discarded_beams[current_tokens == 0] = True
 
-        # Discard beams with invalid modification combinations
-        if step > 1:
+        # Discard beams with invalid modification combinations. At step 0 the
+        # single token is at the position where an N-terminal modification is
+        # allowed under either token order, so the check starts at step 1.
+        if step > 0:
             final_pos = torch.full((batch_size,), step, device=device)
             final_pos[ends_stop_token] = step - 1
 
@@ -452,8 +454,11 @@ class Spec2Pep(pl.LightningModule):
                 # This will fail to catch internal modifications in some cases
                 # where there are multiple mods, but these are already discarded
                 # by the previous check.
+                # A reversed tokenizer emits the C-terminus first, so a valid
+                # N-terminal modification is the *last* token generated; an
+                # unreversed tokenizer emits it first.
                 n_terminal_pos = (
-                    0 if self.tokenizer.reverse else final_pos[has_n_term]
+                    final_pos[has_n_term] if self.tokenizer.reverse else 0
                 )
                 internal_mods = ~token_is_nterm[has_n_term, n_terminal_pos]
 

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -29,6 +29,7 @@ import pytest
 import requests
 import torch
 import pyteomics.mztab
+import pyteomics.proforma
 
 from casanovo import casanovo, denovo, utils
 from casanovo.casanovo import _SharedFileIOParams
@@ -2522,14 +2523,17 @@ def test_invalid_n_term_mod(tiny_config, reverse):
     device = model.device
     model.min_peptide_len = 3
 
+    # A reversed tokenizer emits the C-terminus first, so a valid N-terminal
+    # modification is the last token generated; an unreversed tokenizer emits
+    # it first.
     # (peptide, should_be_discarded)
     peptides = [
         (["P", "E", "P", "K", "K"], False),
-        (["[Acetyl]-", "P", "E", "P", "K"], not reverse),
+        (["[Acetyl]-", "P", "E", "P", "K"], reverse),
         (["[Acetyl]-", "[Acetyl]-", "P", "E", "P"], True),
         (["[Acetyl]-", "P", "E", "P", "[Acetyl]-"], True),
-        (["P", "E", "P", "K", "[Acetyl]-"], reverse),
-        (["P", "E", "P", "[Acetyl]-", "$"], reverse),
+        (["P", "E", "P", "K", "[Acetyl]-"], not reverse),
+        (["P", "E", "P", "[Acetyl]-", "$"], not reverse),
         (["P", "E", "[Acetyl]-", "P", "K"], True),
     ]
 
@@ -2552,6 +2556,109 @@ def test_invalid_n_term_mod(tiny_config, reverse):
 
     assert torch.equal(discarded, expected_discarded)
     assert torch.equal(finished, expected_finished)
+
+
+def _nterm_beam(tokenizer, aa_tokens, max_peptide_len, device):
+    """
+    Build a single beam from a list of amino acid tokens.
+
+    Parameters
+    ----------
+    tokenizer : depthcharge.tokenizers.PeptideTokenizer
+        The tokenizer providing the token indices.
+    aa_tokens : Iterable[str]
+        The amino acid tokens, in the order the decoder would emit them.
+    max_peptide_len : int
+        The maximum peptide length, defining the width of the beam.
+    device : torch.device
+        The device on which to create the beam.
+
+    Returns
+    -------
+    torch.Tensor of shape (1, max_peptide_len + 1)
+        The zero-padded beam.
+    """
+    tokens = torch.zeros(
+        1, max_peptide_len + 1, dtype=torch.int64, device=device
+    )
+    tokens[0, : len(aa_tokens)] = torch.tensor(
+        [tokenizer.index[aa] for aa in aa_tokens], device=device
+    )
+    return tokens
+
+
+@pytest.mark.parametrize("reverse", [True, False])
+def test_n_term_mod_orientation_matches_tokenizer(tiny_config, reverse):
+    """N-term mods placed as the tokenizer emits them must be kept."""
+    config = Config(tiny_config)
+    tokenizer = depthcharge.tokenizers.peptides.PeptideTokenizer(
+        residues=config.residues, reverse=reverse
+    )
+    model = Spec2Pep(n_beams=1, tokenizer=tokenizer, min_peptide_len=4)
+
+    peptide = "[Acetyl]-PEPTIDEK"
+    # Ask the tokenizer for the token order, rather than assuming one, so
+    # that this test still pins down the correct behavior if the decoding
+    # direction ever changes.
+    aa_tokens = list(tokenizer.split(peptide))
+    tokens = _nterm_beam(
+        tokenizer, aa_tokens, model.max_peptide_len, model.device
+    )
+
+    _, discarded = model._finish_beams(tokens, len(aa_tokens) - 1)
+    assert not discarded[0]
+
+    # A kept beam must decode to a valid ProForma peptidoform, since
+    # `on_predict_batch_end` parses it again to compute the precursor m/z.
+    sequence = tokenizer.detokenize(tokens)[0]
+    assert sequence == peptide
+    tokenizer.calculate_precursor_ions(sequence, torch.tensor(2))
+
+
+@pytest.mark.parametrize("reverse", [True, False])
+def test_n_term_mod_wrong_end_discarded(tiny_config, reverse):
+    """N-term mods at the opposite end of the beam must be discarded."""
+    config = Config(tiny_config)
+    tokenizer = depthcharge.tokenizers.peptides.PeptideTokenizer(
+        residues=config.residues, reverse=reverse
+    )
+    model = Spec2Pep(n_beams=1, tokenizer=tokenizer, min_peptide_len=4)
+
+    peptide = "[Acetyl]-PEPTIDEK"
+    aa_tokens = list(tokenizer.split(peptide))[::-1]
+    tokens = _nterm_beam(
+        tokenizer, aa_tokens, model.max_peptide_len, model.device
+    )
+
+    _, discarded = model._finish_beams(tokens, len(aa_tokens) - 1)
+    assert discarded[0]
+
+    # Such a beam decodes to a modification trailing the sequence, which is
+    # not valid ProForma; keeping it would crash `on_predict_batch_end`. The
+    # exact exception type depends on the pyteomics version.
+    with pytest.raises((IndexError, pyteomics.proforma.ProFormaError)):
+        tokenizer.calculate_precursor_ions(
+            tokenizer.detokenize(tokens)[0], torch.tensor(2)
+        )
+
+
+@pytest.mark.parametrize("reverse", [True, False])
+def test_n_term_mod_short_beam_discarded(tiny_config, reverse):
+    """Misplaced N-term mods are caught in two-token beams as well."""
+    config = Config(tiny_config)
+    tokenizer = depthcharge.tokenizers.peptides.PeptideTokenizer(
+        residues=config.residues, reverse=reverse
+    )
+    model = Spec2Pep(n_beams=1, tokenizer=tokenizer, min_peptide_len=2)
+
+    # Too short to be caught by the minimum peptide length check.
+    aa_tokens = ["[Acetyl]-", "K"] if reverse else ["K", "[Acetyl]-"]
+    tokens = _nterm_beam(
+        tokenizer, aa_tokens, model.max_peptide_len, model.device
+    )
+
+    _, discarded = model._finish_beams(tokens, 1)
+    assert discarded[0]
 
 
 def test_cache_finished_beams(tiny_config):


### PR DESCRIPTION
### Summary
Fixes #679 

The check that decides where an N-terminal modification may sit in a decoded beam has its two branches swapped, so it is wrong for both tokenizer orientations. Since `ModelRunner.initialize_tokenizer` always builds the tokenizer with `reverse=True`, every de novo run takes the wrong branch and silently discards every beam carrying an N-terminal modification.

```
# casanovo/denovo/model.py, Spec2Pep._finish_beams
n_terminal_pos = (
    0 if self.tokenizer.reverse else final_pos[has_n_term]
)
internal_mods = ~token_is_nterm[has_n_term, n_terminal_pos]
```

A reversed tokenizer reverses the token list, so the decoder emits the C-terminus first and a valid N-terminal modification is the last token generated, at final_pos. Index 0 is the C-terminal residue. The condition asks for the opposite in both branches.

Confirmed against the tokenizer itself (depthcharge 0.4.10):

```
>>> PeptideTokenizer.from_massivekb(reverse=True).split("[Acetyl]-PTLDEK")
['K', 'E', 'D', 'L', 'T', 'P', '[Acetyl]-']

```
This corroborates `on_predict_batch_end`, which tests `spec_match.sequence.startswith(mod)`. It already expects the decoded string to begin with the modification.

Introduced in #575. Present on main, dev, and released v5.2.0.

### Impact

Measured with casanovo_orbitrap_v5-2-0.ckpt with n_beams: 1

_sample_data/sample_preprocessed_spectra.mgf_ (128 spectra):
Before: 121 sequenced, 0 N-term-modified PSMs
After: 128 sequenced, 7 N-term-modified PSMs

_MassIVE-KB subset_ (19,506 spectra)
Before: 17,041 sequenced, 0 N-term-modified PSMs
After: 19,504 sequenced, 2,463 N-term-modified PSMs

There is a second, milder consequence: because the inverted check accepts beams with the modification at index 0, such a beam detokenizes to a trailing modification (PTLDEK[Acetyl]-), which is not valid ProForma and raises when `on_predict_batch_end` parses it to compute the precursor m/z. In practice this depends on the checkpoint (with the released orbitrap weights I could not get such a beam to win a spectrum, because they always lose on score first, even though 18,288 of 19,506 spectra do place an N-terminal token in a step-0 beam). I have gotten this exception with other checkpoints. The fix removes the possibility either way.

### Changes
_casanovo/denovo/model.py_
- Swapped the branches so the modification is required at the position the tokenizer actually emits it, with a comment stating the invariant.
- Widened the guard `if step > 1:` to `if step > 0:`. The > 1 bound was inherited from the pre-#575 implementation, which indexed `final_pos - 1`; the current code no longer does, since multiple modifications are caught by `num_modifications > 1`. The old bound let a two-token beam such as `["[Acetyl]-", "K"]` escape the check entirely when `min_peptide_len <= 2`. At step 1 with a stop token `final_pos = 0`, so no negative index is possible; step 0 stays excluded because a lone first token sits at `final_pos` under either orientation.

_tests/unit_tests/test_unit.py_
- `test_invalid_n_term_mod` was itself inverted and passed against the buggy code. It was added in #575 alongside the defect and encodes the same assumption, so it could not have caught this. 
                                                                                                                                                                                                                                     - The other four cases (no modification, the two multiple-modification cases, and the internal-modification case) are unchanged.
- Three new tests, each parameterised over reverse ∈ {True, False}, so the branches cannot be silently swapped again:
  - `test_n_term_mod_orientation_matches_tokenizer` takes the token order from `tokenizer.split()` rather than hardcoding it, asserts the beam is kept, and asserts the decoded sequence round-trips through `calculate_precursor_ions`, the call that runs in `on_predict_batch_end`. Deriving the order from the tokenizer means the test still pins down correct behaviour if the decoding direction ever changes.
  - `test_n_term_mod_wrong_end_discarded`: the opposite order is discarded, and the sequence it would have decoded to is confirmed unparseable.
  - `test_n_term_mod_short_beam_discarded` covers the step > 0 widening with a two-token beam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected validation and decoding of N-terminal modifications across tokenizer directions and short decoding beams.
  - Preserved valid modified peptides during greedy decoding.
  - Prevented malformed peptides from causing parsing failures during beam search.
  - Corrected the reported mass for carbamylation with ammonia loss at the N-terminus.
  - De novo sequencing results and related evaluation metrics may change.

- **Documentation**
  - Updated the unreleased changelog and version comparison links.

- **Tests**
  - Expanded coverage for valid and invalid N-terminal modifications and ProForma parsing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->