### PR TITLE
fix(config): handle empty user config files

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -115,7 +115,13 @@ class Config:
             self._user_config = {}
         else:
             with Path(config_file).open() as f_in:
-                self._user_config = yaml.safe_load(f_in) or {}
+                self._user_config = yaml.safe_load(f_in)
+                if self._user_config is None:
+                    self._user_config = {}
+                elif not isinstance(self._user_config, dict):
+                    raise TypeError(
+                        "Configuration file must define a mapping of options"
+                    )
                 # Remap deprecated config entries.
                 for old, new in _config_deprecated.items():
                     if old in self._user_config:

--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -115,7 +115,7 @@ class Config:
             self._user_config = {}
         else:
             with Path(config_file).open() as f_in:
-                self._user_config = yaml.safe_load(f_in)
+                self._user_config = yaml.safe_load(f_in) or {}
                 # Remap deprecated config entries.
                 for old, new in _config_deprecated.items():
                     if old in self._user_config:

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -23,11 +23,12 @@ def test_override(tmp_path, tiny_config):
         with pytest.raises(KeyError, match="Missing expected config option"):
             Config(str(filename))
 
-    filename = tmp_path / "config_list.yml"
-    filename.write_text("[]", encoding="utf-8")
+    for content in ("[]", "false", "0", "''"):
+        filename = tmp_path / "config_list.yml"
+        filename.write_text(content, encoding="utf-8")
 
-    with pytest.raises(TypeError, match="must define a mapping"):
-        Config(str(filename))
+        with pytest.raises(TypeError, match="must define a mapping"):
+            Config(str(filename))
 
     # Test expected config option is missing.
     filename = str(tmp_path / "config_missing.yml")

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -16,6 +16,12 @@ def test_default():
 
 
 def test_override(tmp_path, tiny_config):
+    filename = tmp_path / "config_empty.yml"
+    filename.write_text("", encoding="utf-8")
+
+    with pytest.raises(KeyError, match="Missing expected config option"):
+        Config(str(filename))
+
     # Test expected config option is missing.
     filename = str(tmp_path / "config_missing.yml")
     with (

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -16,10 +16,17 @@ def test_default():
 
 
 def test_override(tmp_path, tiny_config):
-    filename = tmp_path / "config_empty.yml"
-    filename.write_text("", encoding="utf-8")
+    for content in ("", "null", "~"):
+        filename = tmp_path / "config_empty.yml"
+        filename.write_text(content, encoding="utf-8")
 
-    with pytest.raises(KeyError, match="Missing expected config option"):
+        with pytest.raises(KeyError, match="Missing expected config option"):
+            Config(str(filename))
+
+    filename = tmp_path / "config_list.yml"
+    filename.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="must define a mapping"):
         Config(str(filename))
 
     # Test expected config option is missing.


### PR DESCRIPTION
## Problem

When a user-provided YAML config file is empty, `yaml.safe_load()` returns `None`. Casanovo then tries to check deprecated option names with `old in self._user_config`, which raises a raw `TypeError: argument of type 'NoneType' is not iterable` before the existing config validation can explain what is wrong.

## Before / after behavior

Before, an empty user config failed with a low-level `TypeError`.

After, empty YAML is treated as an empty config mapping, so the existing missing-option validation raises the same clear `KeyError` path used for incomplete config files.

## Verification

- `python -m pytest tests/unit_tests/test_config.py` - 3 passed
- `python -m black --check casanovo/config.py tests/unit_tests/test_config.py`
- `python -m compileall casanovo/config.py tests\unit_tests\test_config.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or null configuration files are now handled safely.
  * Clear errors are reported when required configuration options are missing.
  * Invalid non-mapping configuration values, such as lists, now produce a descriptive error.

* **Tests**
  * Added coverage for empty YAML values, null configurations, and invalid list-based configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->