### PR TITLE
fix: read MGF scan index as UTF-8

### DIFF
--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -45,7 +45,7 @@ def _build_mgf_scan_index(mgf_path: str) -> Iterator[tuple[str, str]]:
     """
     index, current_scan, in_ions = 0, None, False
     try:
-        with open(mgf_path, errors="replace") as fh:
+        with open(mgf_path, encoding="utf-8", errors="replace") as fh:
             for line in fh:
                 upper = line.strip().upper()
                 if upper == _MGF_BEGIN:

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -3028,7 +3028,8 @@ def test_mgf_scan_alias_scan_field(tmp_path):
 
     mgf_file = tmp_path / "alias_scan.mgf"
     mgf_file.write_text(
-        "BEGIN IONS\nSCAN=99\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
+        "BEGIN IONS\nSCAN=99\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n",
+        encoding="utf-8",
     )
     result = dict(_build_mgf_scan_index(str(mgf_file)))
     assert result == {"index=0": "99"}
@@ -3043,7 +3044,8 @@ def test_mgf_scan_alias_scan_id_field(tmp_path):
 
     mgf_file = tmp_path / "alias_scan_id.mgf"
     mgf_file.write_text(
-        "BEGIN IONS\nSCAN ID=42\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
+        "BEGIN IONS\nSCAN ID=42\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n",
+        encoding="utf-8",
     )
     result = dict(_build_mgf_scan_index(str(mgf_file)))
     assert result == {"index=0": "42"}
@@ -3057,7 +3059,8 @@ def test_scan_num_in_mztab_spectra_ref(tmp_path):
     # Create a minimal MGF with SCANS=17 for the first spectrum.
     mgf_file = tmp_path / "test.mgf"
     mgf_file.write_text(
-        "BEGIN IONS\nSCANS=17\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n"
+        "BEGIN IONS\nSCANS=17\nPEPMASS=400.2\nCHARGE=2+\n200.0 1.0\nEND IONS\n",
+        encoding="utf-8",
     )
 
     results_path = str(tmp_path / "results.mztab")


### PR DESCRIPTION
## Problem

The mzTab writer emits UTF-8 output, but the MGF scan-number index helper read `.mgf` files with the platform default text encoding. On Windows or other non-UTF-8 locales, that can make scan-number metadata extraction locale-dependent for UTF-8 MGF files.

## Before / after

Before, `_build_mgf_scan_index()` used `open(mgf_path, errors="replace")`, leaving the encoding implicit.

After, it reads MGF headers with `encoding="utf-8"` and keeps `errors="replace"` for resilience. The nearby test-created MGF fixtures now write with explicit UTF-8 as well.

## Verification

- `python -m pytest tests/unit_tests/test_unit.py -k "mgf_scan or scan_num_in_mztab"`
- `python -m black --check casanovo/data/ms_io.py tests/unit_tests/test_unit.py`
- `python -m compileall casanovo/data/ms_io.py tests\unit_tests\test_unit.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MGF files by consistently reading them as UTF-8 while safely accommodating invalid characters.
  * Preserved existing scan indexing, warnings, and mzTab output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->