### PR TITLE
perf: vectorize finished-beam cache in beam search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - `val_check_interval` now accepts a float in `[0, 1]` to validate at a fraction of each training epoch, in addition to an integer number of training steps.
+- Beam search is sped up by caching finished beams and selecting the top-scoring beam fully on the GPU.
 
 ### Fixed
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -295,11 +295,12 @@ class Spec2Pep(pl.LightningModule):
             batch, length, beam, dtype=torch.int64, device=device
         )
 
-        # Create cache for decoded beams.
+        # Create cache for decoded beams. cache_tokens uses int32 to reduce
+        # memory footprint; it is cast to int64 before detokenization.
         cache_tokens = torch.full(
             (batch, beam, length, length),
             0,
-            dtype=torch.int64,
+            dtype=torch.int32,
             device=device,
         )
         cache_scores = torch.full(
@@ -773,7 +774,7 @@ class Spec2Pep(pl.LightningModule):
                     continue
 
                 step = int(flat_step_cpu[i, idx])
-                pred_tokens = flat_tokens[i, idx, : step + 1]
+                pred_tokens = flat_tokens[i, idx, : step + 1].long()
                 stop = bool(has_stop_cpu[i, idx])
 
                 if stop:

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -1,7 +1,6 @@
 """A de novo peptide sequencing model."""
 
 import collections
-import heapq
 import itertools
 import logging
 import warnings
@@ -297,7 +296,23 @@ class Spec2Pep(pl.LightningModule):
         )
 
         # Create cache for decoded beams.
-        pred_cache = collections.OrderedDict((i, []) for i in range(batch))
+        cache_tokens = torch.full(
+            (batch, beam, length, length),
+            0,
+            dtype=torch.int64,
+            device=device,
+        )
+        cache_scores = torch.full(
+            (batch, beam, length, length),
+            0.0,
+            dtype=scores.dtype,
+            device=device,
+        )
+        cache_mask = torch.zeros(
+            (batch, beam, length),
+            dtype=torch.bool,
+            device=device,
+        )
 
         # Get the first prediction.
         pred = self.decoder(
@@ -333,14 +348,17 @@ class Spec2Pep(pl.LightningModule):
                 # Cache peptide predictions from the finished beams (but not
                 # the discarded beams).
                 beams_to_cache = finished_beams & ~discarded_beams
-                if torch.any(beams_to_cache):
-                    self._cache_finished_beams(
-                        tokens,
-                        scores,
-                        step,
-                        beams_to_cache,
-                        pred_cache,
-                    )
+                self._cache_finished_beams(
+                    tokens,
+                    scores,
+                    step,
+                    beams_to_cache,
+                    cache_tokens,
+                    cache_scores,
+                    cache_mask,
+                    batch,
+                    beam,
+                )
 
                 # Stop decoding when all current beams have been finished.
                 # Continue with beams that have not been finished and not
@@ -380,7 +398,9 @@ class Spec2Pep(pl.LightningModule):
 
         # Return the peptide with the highest confidence score, within
         # the precursor m/z tolerance if possible.
-        return list(self._get_top_peptide(pred_cache))
+        return list(
+            self._get_top_peptide(cache_tokens, cache_scores, cache_mask)
+        )
 
     def _finish_beams(
         self,
@@ -481,19 +501,24 @@ class Spec2Pep(pl.LightningModule):
         scores: torch.Tensor,
         step: int,
         beams_to_cache: torch.Tensor,
-        pred_cache: Dict[
-            int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
-        ],
-    ):
+        cache_tokens: torch.Tensor,
+        cache_scores: torch.Tensor,
+        cache_mask: torch.Tensor,
+        batch: int,
+        beam: int,
+    ) -> None:
         """
-        Cache terminated beams.
+        Cache terminated beams into fixed-size tensors.
+
+        Storing candidates as tensors allows vectorized final selection and
+        avoids per-step Python heap operations.
 
         Parameters
         ----------
         tokens : torch.Tensor of shape (n_spectra * n_beams, max_length)
             Predicted amino acid tokens for all beams and all spectra.
-         scores : torch.Tensor of shape
-         (n_spectra *  n_beams, max_length, n_amino_acids)
+        scores : torch.Tensor of shape
+            (n_spectra * n_beams, max_length, n_amino_acids)
             Scores for the predicted amino acid tokens for all beams and
             all spectra.
         step : int
@@ -501,82 +526,49 @@ class Spec2Pep(pl.LightningModule):
         beams_to_cache : torch.Tensor of shape (n_spectra * n_beams)
             Boolean tensor indicating whether the current beams are
             ready for caching.
-        pred_cache : Dict[
-            int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
-        ]
-            Priority queue with finished beams for each spectrum,
-            ordered by peptide score. For each finished beam, a tuple
-            with the peptide score, a random tie-breaking
-            float, the amino acid-level scores, and the predicted tokens
-            is stored.
+        cache_tokens : torch.Tensor of shape
+            (n_spectra, n_beams, max_length, max_length)
+            Tensor cache for predicted tokens of finished beams.
+        cache_scores : torch.Tensor of shape
+            (n_spectra, n_beams, max_length, max_length)
+            Tensor cache for raw token probabilities of finished beams.
+        cache_mask : torch.Tensor of shape (n_spectra, n_beams, max_length)
+            Boolean mask indicating valid cache entries.
+        batch : int
+            Number of spectra in the batch.
+        beam : int
+            Number of beams per spectrum.
         """
-        # Find non-zero indices for more efficient iteration
-        cache_indices = (
-            torch.nonzero(beams_to_cache).squeeze(-1).cpu().tolist()
+        vocab = scores.shape[-1]
+
+        # [B, S, step + 1] actual tokens up to the current step.
+        tokens_bsl = tokens.view(batch, beam, -1)[:, :, : step + 1]
+
+        # Softmax over the vocabulary and gather the probability of each
+        # selected token in one shot.
+        smx = torch.softmax(
+            scores[:, : step + 1, :].view(batch, beam, step + 1, vocab),
+            dim=-1,
         )
+        raw_scores = smx.gather(3, tokens_bsl.unsqueeze(-1)).squeeze(-1)
 
-        device = self.device  # Get device from input tensor
-
-        # Get beam indices and spectrum indices from cache_indices
-        for i in cache_indices:
-            # Find the starting index of the spectrum.
-            spec_idx = i // self.n_beams
-
-            # Get the predicted tokens
-            pred_tokens = tokens[i, : step + 1]
-
-            # Omit the stop token from the peptide sequence (if predicted).
-            has_stop_token = pred_tokens[-1] == self.stop_token
-            pred_peptide = pred_tokens[:-1] if has_stop_token else pred_tokens
-
-            # Calculate softmax scores directly with proper indexing
-            smx = self.softmax(scores[i : i + 1, : step + 1, :])
-
-            # Vectorized AA score extraction (kept on GPU to avoid
-            # unnecessary CPU/GPU round-trips per decode step).
-            range_tensor = torch.arange(len(pred_tokens), device=device)
-            aa_scores_tensor = smx[0, range_tensor, pred_tokens]
-
-            # Add explicit score 0 for missing stop token
-            if not has_stop_token:
-                aa_scores_tensor = torch.cat(
-                    [
-                        aa_scores_tensor,
-                        torch.tensor([0.0], device=aa_scores_tensor.device),
-                    ]
-                )
-
-            # Calculate the peptide score using the appropriate scoring function
-            peptide_score = _peptide_score(aa_scores_tensor)
-            if isinstance(peptide_score, torch.Tensor):
-                peptide_score = peptide_score.item()
-
-            # Omit the stop token from the amino acid-level scores.
-            aa_scores = aa_scores_tensor.cpu().numpy()[:-1]
-
-            pred_peptide_cpu = pred_peptide.cpu()
-            peptide_entry = (
-                peptide_score,
-                np.random.random_sample(),
-                aa_scores,
-                torch.clone(pred_peptide_cpu),
-            )
-            # Check for duplicate predictions and update with highest score.
-            for j, pred_cached in enumerate(pred_cache[spec_idx]):
-                if torch.equal(pred_cached[-1], pred_peptide_cpu):
-                    if peptide_score > pred_cached[0]:
-                        pred_cache[spec_idx][j] = peptide_entry
-                        heapq.heapify(pred_cache[spec_idx])
-                    break
-            else:
-                # Add the prediction to the cache (minimum priority queue,
-                # maximum the number of beams elements).
-                if len(pred_cache[spec_idx]) < self.n_beams:
-                    heapadd = heapq.heappush
-                else:
-                    heapadd = heapq.heappushpop
-
-                heapadd(pred_cache[spec_idx], peptide_entry)
+        # Masked write: only update slots where beams_to_cache is True.
+        write_mask = beams_to_cache.view(batch, beam, 1)
+        cache_tokens[:, :, step, : step + 1] = torch.where(
+            write_mask,
+            tokens_bsl,
+            cache_tokens[:, :, step, : step + 1],
+        )
+        cache_scores[:, :, step, : step + 1] = torch.where(
+            write_mask,
+            raw_scores,
+            cache_scores[:, :, step, : step + 1],
+        )
+        cache_mask[:, :, step] = torch.where(
+            beams_to_cache.view(batch, beam),
+            torch.ones_like(cache_mask[:, :, step]),
+            cache_mask[:, :, step],
+        )
 
     def _get_topk_beams(
         self,
@@ -658,10 +650,9 @@ class Spec2Pep(pl.LightningModule):
         # Apply mask and get top-k indices
         _, top_idx = torch.topk(mean_scores * active_mask, beam, dim=1)
 
-        # Vectorized index conversion without loops
-        indices = torch.unravel_index(top_idx.flatten(), (vocab, beam))
-        v_idx = indices[0].reshape(top_idx.shape).to(device)
-        s_idx = indices[1].reshape(top_idx.shape).to(device)
+        # Vectorized index conversion without loops, fully on GPU.
+        v_idx = (top_idx // beam).to(torch.long)
+        s_idx = (top_idx % beam).to(torch.long)
 
         # Create batch indices for gathering - flatten s_idx for indexing
         s_idx_flat = einops.rearrange(s_idx, "B S -> (B S)")
@@ -691,52 +682,125 @@ class Spec2Pep(pl.LightningModule):
 
     def _get_top_peptide(
         self,
-        pred_cache: Dict[
-            int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
-        ],
+        cache_tokens: torch.Tensor,
+        cache_scores: torch.Tensor,
+        cache_mask: torch.Tensor,
     ) -> Iterable[List[Tuple[float, np.ndarray, str]]]:
         """
         Return the peptide with the highest confidence score for each
-        spectrum.
+        spectrum from the cache tensors.
 
         Parameters
         ----------
-        pred_cache : Dict[
-            int, List[Tuple[float, float, np.ndarray, torch.Tensor]]
-        ]
-            Priority queue with finished beams for each spectrum,
-            ordered by peptide score. For each finished beam, a tuple
-            with the peptide score, a random tie-breaking float, the
-            amino acid-level scores, and the predicted tokens is stored.
+        cache_tokens : torch.Tensor of shape
+            (n_spectra, n_beams, max_length, max_length)
+            Tensor cache for predicted tokens of finished beams.
+        cache_scores : torch.Tensor of shape
+            (n_spectra, n_beams, max_length, max_length)
+            Tensor cache for raw token probabilities of finished beams.
+        cache_mask : torch.Tensor of shape
+            (n_spectra, n_beams, max_length)
+            Boolean mask indicating valid cache entries.
 
         Returns
         -------
         pred_peptides : Iterable[List[Tuple[float, np.ndarray, str]]]
             For each spectrum, a list with the top peptide predictions.
             A peptide prediction consists of a tuple with the peptide
-            score, the amino acid scores, and the predicted peptide
+            score, the amino acid-level scores, and the predicted peptide
             sequence.
         """
-        for peptides in pred_cache.values():
-            if len(peptides) > 0:
-                yield [
+        batch, beam, length, _ = cache_tokens.shape
+        device = cache_tokens.device
+        eps = torch.finfo(cache_scores.dtype).eps
+
+        # Flatten the candidate pool over beams and decoding steps.
+        flat_tokens = cache_tokens.view(batch, beam * length, length)
+        flat_raw = cache_scores.view(batch, beam * length, length)
+        flat_mask = cache_mask.view(batch, beam * length)
+
+        # The actual decoding step for each history slot.
+        step_idx = torch.arange(length, device=device).view(1, 1, length)
+        flat_step = step_idx.expand(batch, beam, length).reshape(
+            batch, beam * length
+        )
+
+        # The last real token is at position `step`.
+        last_token = flat_tokens.gather(2, flat_step.unsqueeze(-1)).squeeze(-1)
+        has_stop = last_token == self.stop_token
+
+        # Compute peptide scores as the product of raw token probabilities.
+        # For positions beyond `step`, raw scores are 0 and are masked out.
+        pos_idx = torch.arange(length, device=device).view(1, 1, length)
+        valid_pos = pos_idx <= flat_step.unsqueeze(-1)
+        log_raw = torch.log(flat_raw.clamp(min=eps))
+        log_score = (log_raw * valid_pos).sum(dim=-1)
+        # Penalize candidates without a stop token by appending a 0 score.
+        log_score = log_score + torch.where(
+            has_stop,
+            torch.zeros_like(log_score),
+            torch.log(torch.tensor(eps, device=device, dtype=log_score.dtype)),
+        )
+        # Use -inf for invalid slots so they are never selected.
+        log_score = log_score.masked_fill(~flat_mask, float("-inf"))
+
+        # Select the top candidates for each spectrum in log space to avoid
+        # exp() underflow to 0, which would tie with masked slots.
+        # Fast path for the common case where only the top-1 match is needed.
+        if self.top_match == 1:
+            n_candidates = 1
+            topk_idx = log_score.argmax(dim=1, keepdim=True)
+            topk_log_scores = log_score.gather(1, topk_idx)
+        else:
+            n_candidates = min(self.top_match, beam * length)
+            topk_log_scores, topk_idx = torch.topk(
+                log_score, n_candidates, dim=1
+            )
+
+        # Move selection-related tensors to CPU once to avoid per-iteration
+        # GPU synchronization.
+        topk_idx_cpu = topk_idx.cpu()
+        flat_step_cpu = flat_step.cpu()
+        has_stop_cpu = has_stop.cpu()
+        flat_mask_cpu = flat_mask.cpu()
+        topk_peptide_scores_cpu = torch.exp(topk_log_scores.cpu())
+
+        for i in range(batch):
+            pred_peptides = []
+            for k in range(n_candidates):
+                idx = topk_idx_cpu[i, k].item()
+                if not flat_mask_cpu[i, idx]:
+                    continue
+
+                step = int(flat_step_cpu[i, idx])
+                pred_tokens = flat_tokens[i, idx, : step + 1]
+                stop = bool(has_stop_cpu[i, idx])
+
+                if stop:
+                    pred_tokens = pred_tokens[:-1]
+                    aa_scores = flat_raw[i, idx, :step].cpu().numpy()
+                else:
+                    aa_scores = flat_raw[i, idx, : step + 1].cpu().numpy()
+
+                peptide_score = float(topk_peptide_scores_cpu[i, k])
+
+                if self.tokenizer.reverse:
+                    aa_scores = aa_scores[::-1]
+
+                pred_peptides.append(
                     (
-                        pep_score,
-                        (
-                            aa_scores[::-1]
-                            if self.tokenizer.reverse
-                            else aa_scores
-                        ),
+                        peptide_score,
+                        aa_scores,
                         self.tokenizer.detokenize(
                             torch.unsqueeze(pred_tokens, 0)
                         )[0],
                     )
-                    for pep_score, _, aa_scores, pred_tokens in heapq.nlargest(
-                        self.top_match, peptides
-                    )
-                ]
-            else:
-                yield []
+                )
+
+                if len(pred_peptides) >= self.top_match:
+                    break
+
+            yield pred_peptides
 
     def _process_batch(
         self, batch: Dict[str, torch.Tensor]

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -309,11 +309,6 @@ class Spec2Pep(pl.LightningModule):
             dtype=scores.dtype,
             device=device,
         )
-        cache_mask = torch.zeros(
-            (batch, beam, length),
-            dtype=torch.bool,
-            device=device,
-        )
 
         # Get the first prediction.
         pred = self.decoder(
@@ -356,9 +351,6 @@ class Spec2Pep(pl.LightningModule):
                     beams_to_cache,
                     cache_tokens,
                     cache_scores,
-                    cache_mask,
-                    batch,
-                    beam,
                 )
 
                 # Stop decoding when all current beams have been finished.
@@ -399,9 +391,7 @@ class Spec2Pep(pl.LightningModule):
 
         # Return the peptide with the highest confidence score, within
         # the precursor m/z tolerance if possible.
-        return list(
-            self._get_top_peptide(cache_tokens, cache_scores, cache_mask)
-        )
+        return list(self._get_top_peptide(cache_tokens, cache_scores))
 
     def _finish_beams(
         self,
@@ -504,9 +494,6 @@ class Spec2Pep(pl.LightningModule):
         beams_to_cache: torch.Tensor,
         cache_tokens: torch.Tensor,
         cache_scores: torch.Tensor,
-        cache_mask: torch.Tensor,
-        batch: int,
-        beam: int,
     ) -> None:
         """
         Cache terminated beams into fixed-size tensors.
@@ -533,24 +520,20 @@ class Spec2Pep(pl.LightningModule):
         cache_scores : torch.Tensor of shape
             (n_spectra, n_beams, max_length, max_length)
             Tensor cache for raw token probabilities of finished beams.
-        cache_mask : torch.Tensor of shape (n_spectra, n_beams, max_length)
-            Boolean mask indicating valid cache entries.
-        batch : int
-            Number of spectra in the batch.
-        beam : int
-            Number of beams per spectrum.
         """
+        batch, beam, _, _ = cache_tokens.shape
         vocab = scores.shape[-1]
 
         # [B, S, step + 1] actual tokens up to the current step.
         tokens_bsl = tokens.view(batch, beam, -1)[:, :, : step + 1]
 
         # Softmax over the vocabulary and gather the probability of each
-        # selected token in one shot.
-        smx = torch.softmax(
-            scores[:, : step + 1, :].view(batch, beam, step + 1, vocab),
-            dim=-1,
+        # selected token in one shot. Use the model's configured softmax so
+        # that the normalization axis stays in sync with future changes.
+        scores_view = scores[:, : step + 1, :].view(
+            batch, beam, step + 1, vocab
         )
+        smx = self.softmax(scores_view.transpose(2, 3)).transpose(2, 3)
         raw_scores = smx.gather(3, tokens_bsl.unsqueeze(-1)).squeeze(-1)
 
         # Masked write: only update slots where beams_to_cache is True.
@@ -564,11 +547,6 @@ class Spec2Pep(pl.LightningModule):
             write_mask,
             raw_scores,
             cache_scores[:, :, step, : step + 1],
-        )
-        cache_mask[:, :, step] = torch.where(
-            beams_to_cache.view(batch, beam),
-            torch.ones_like(cache_mask[:, :, step]),
-            cache_mask[:, :, step],
         )
 
     def _get_topk_beams(
@@ -685,7 +663,6 @@ class Spec2Pep(pl.LightningModule):
         self,
         cache_tokens: torch.Tensor,
         cache_scores: torch.Tensor,
-        cache_mask: torch.Tensor,
     ) -> Iterable[List[Tuple[float, np.ndarray, str]]]:
         """
         Return the peptide with the highest confidence score for each
@@ -699,9 +676,6 @@ class Spec2Pep(pl.LightningModule):
         cache_scores : torch.Tensor of shape
             (n_spectra, n_beams, max_length, max_length)
             Tensor cache for raw token probabilities of finished beams.
-        cache_mask : torch.Tensor of shape
-            (n_spectra, n_beams, max_length)
-            Boolean mask indicating valid cache entries.
 
         Returns
         -------
@@ -718,7 +692,10 @@ class Spec2Pep(pl.LightningModule):
         # Flatten the candidate pool over beams and decoding steps.
         flat_tokens = cache_tokens.view(batch, beam * length, length)
         flat_raw = cache_scores.view(batch, beam * length, length)
-        flat_mask = cache_mask.view(batch, beam * length)
+        # Valid slots are those with non-zero raw probabilities. This is
+        # equivalent to the previous explicit cache_mask because softmax
+        # probabilities are strictly positive and unwritten slots are 0.
+        flat_mask = flat_raw.any(dim=-1)
 
         # The actual decoding step for each history slot.
         step_idx = torch.arange(length, device=device).view(1, 1, length)

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -1,9 +1,7 @@
-import collections
 import copy
 import datetime
 import functools
 import hashlib
-import heapq
 import io
 import logging
 import os
@@ -2687,12 +2685,19 @@ def test_cache_finished_beams(tiny_config):
     model._batch_size = batch
     model._beam_size = beam
 
-    scores = torch.zeros(
-        (beam, length, len(model.tokenizer) + 1), device=device
-    )
+    vocab = len(model.tokenizer) + 1
+    scores = torch.zeros((beam, length, vocab), device=device)
     tokens = torch.zeros((beam, length), dtype=torch.int64, device=device)
 
-    pred_cache = collections.OrderedDict((i, []) for i in range(batch))
+    cache_tokens = torch.full(
+        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+    )
+    cache_scores = torch.full(
+        (batch, beam, length, length), 0.0, dtype=scores.dtype, device=device
+    )
+    cache_mask = torch.zeros(
+        (batch, beam, length), dtype=torch.bool, device=device
+    )
 
     true_tok = model.tokenizer.tokenize("PEPR")[0]
     tokens[1, : step + 1] = true_tok
@@ -2702,13 +2707,19 @@ def test_cache_finished_beams(tiny_config):
     discarded = torch.tensor([False, False, False, False], device=device)
 
     model._cache_finished_beams(
-        tokens, scores, step, finished & ~discarded, pred_cache
+        tokens,
+        scores,
+        step,
+        finished & ~discarded,
+        cache_tokens,
+        cache_scores,
+        cache_mask,
+        batch,
+        beam,
     )
 
-    cached = [
-        pep for (_, _, _, pep) in pred_cache[0] if torch.equal(pep, true_tok)
-    ]
-    assert len(cached) == 1
+    assert cache_mask[0, 1, step]
+    assert torch.equal(cache_tokens[0, 1, step, : step + 1], true_tok)
 
 
 def test_get_top_peptide_ranking(tiny_config):
@@ -2719,20 +2730,35 @@ def test_get_top_peptide_ranking(tiny_config):
         )
     )
 
-    cache = collections.OrderedDict({0: []})
+    batch = 1
+    beam = 3
+    length = 10
+    step = 3
+    device = model.device
 
-    heapq.heappush(
-        cache[0], (0.93, 0.1, [0.93] * 4, model.tokenizer.tokenize("PEPY")[0])
+    cache_tokens = torch.full(
+        (batch, beam, length, length), 0, dtype=torch.int64, device=device
     )
-    heapq.heappush(
-        cache[0], (0.95, 0.2, [0.95] * 4, model.tokenizer.tokenize("PEPK")[0])
+    cache_scores = torch.full(
+        (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
     )
-    heapq.heappush(
-        cache[0], (0.94, 0.3, [0.94] * 4, model.tokenizer.tokenize("PEPP")[0])
+    cache_mask = torch.zeros(
+        (batch, beam, length), dtype=torch.bool, device=device
     )
 
-    result = next(model._get_top_peptide(cache))
-    assert result[0][-1] == "PEPK"
+    seqs = ["PEPY", "PEPK", "PEPP"]
+    raw_probs = [0.93, 0.95, 0.94]
+    for b, (seq, raw) in enumerate(zip(seqs, raw_probs)):
+        toks = model.tokenizer.tokenize(seq)[0]
+        n_toks = toks.shape[0]
+        cache_tokens[0, b, step, :n_toks] = toks
+        cache_scores[0, b, step, :n_toks] = raw
+        cache_mask[0, b, step] = True
+
+    result = next(
+        model._get_top_peptide(cache_tokens, cache_scores, cache_mask)
+    )
+    assert result[0][2] == "PEPK"
 
 
 @pytest.mark.parametrize("topk", [1, 2, 3])
@@ -2745,15 +2771,33 @@ def test_get_top_peptide_multiple(topk, tiny_config):
         ),
     )
 
-    cache = collections.OrderedDict({0: []})
-    cache_items = [(0.9, "PEPY"), (0.8, "PEPK"), (0.7, "PEPP")]
-    for score, seq in cache_items:
-        heapq.heappush(
-            cache[0],
-            (score, 0.0, [score] * 3, model.tokenizer.tokenize(seq)[0]),
-        )
+    batch = 1
+    beam = 3
+    length = 10
+    step = 3
+    device = model.device
 
-    result = next(model._get_top_peptide(cache))
+    cache_tokens = torch.full(
+        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+    )
+    cache_scores = torch.full(
+        (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
+    )
+    cache_mask = torch.zeros(
+        (batch, beam, length), dtype=torch.bool, device=device
+    )
+
+    cache_items = [(0.9, "PEPY"), (0.8, "PEPK"), (0.7, "PEPP")]
+    for b, (score, seq) in enumerate(cache_items):
+        toks = model.tokenizer.tokenize(seq)[0]
+        n_toks = toks.shape[0]
+        cache_tokens[0, b, step, :n_toks] = toks
+        cache_scores[0, b, step, :n_toks] = score
+        cache_mask[0, b, step] = True
+
+    result = next(
+        model._get_top_peptide(cache_tokens, cache_scores, cache_mask)
+    )
     assert len(result) == topk
     for i in range(topk):
         assert result[i][2] == cache_items[i][1]
@@ -2770,18 +2814,31 @@ def test_get_top_peptide_reverse(reverse, tiny_config):
 
     model.tokenizer.reverse = reverse
 
-    cache = {
-        0: [
-            (
-                1.0,
-                0.42,
-                np.array([1.0, 0.0]),
-                model.tokenizer.tokenize("PE")[0],
-            )
-        ]
-    }
+    batch = 1
+    beam = 1
+    length = 10
+    step = 1
+    device = model.device
 
-    result = list(model._get_top_peptide(cache))
+    cache_tokens = torch.full(
+        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+    )
+    cache_scores = torch.full(
+        (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
+    )
+    cache_mask = torch.zeros(
+        (batch, beam, length), dtype=torch.bool, device=device
+    )
+
+    toks = model.tokenizer.tokenize("PE")[0]
+    n_toks = toks.shape[0]
+    cache_tokens[0, 0, step, :n_toks] = toks
+    cache_scores[0, 0, step, :n_toks] = 1.0
+    cache_mask[0, 0, step] = True
+
+    result = list(
+        model._get_top_peptide(cache_tokens, cache_scores, cache_mask)
+    )
 
     assert len(result) == 1
     assert len(result[0]) == 1
@@ -2873,20 +2930,36 @@ def test_duplicate_peptide_scores(tiny_config):
         1, vocab, (batch * beam, step), device=device
     )
 
-    pred_cache = collections.OrderedDict((i, []) for i in range(batch))
+    cache_tokens = torch.full(
+        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+    )
+    cache_scores = torch.full(
+        (batch, beam, length, length), 0.0, dtype=scores.dtype, device=device
+    )
+    cache_mask = torch.zeros(
+        (batch, beam, length), dtype=torch.bool, device=device
+    )
 
     model._cache_finished_beams(
         tokens,
         scores,
         step,
         torch.ones(batch * beam, dtype=torch.bool, device=device),
-        pred_cache,
+        cache_tokens,
+        cache_scores,
+        cache_mask,
+        batch,
+        beam,
     )
 
-    for _, preds in pred_cache.items():
-        assert len(preds) == beam
-        vals = [p[0] for p in preds]
-        assert np.allclose(vals, vals[0])
+    # All beams used identical scores, so every cached candidate should have
+    # the same peptide score.
+    for i in range(batch):
+        cached_scores = cache_scores[i, :, step, : step + 1]
+        cached_mask = cache_mask[i, :, step]
+        vals = cached_scores[cached_mask].sum(dim=-1)
+        assert cached_mask.sum() == beam
+        assert torch.allclose(vals, vals[0])
 
 
 class MiniTok:

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2695,9 +2695,6 @@ def test_cache_finished_beams(tiny_config):
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=scores.dtype, device=device
     )
-    cache_mask = torch.zeros(
-        (batch, beam, length), dtype=torch.bool, device=device
-    )
 
     true_tok = model.tokenizer.tokenize("PEPR")[0]
     tokens[1, : step + 1] = true_tok
@@ -2713,12 +2710,10 @@ def test_cache_finished_beams(tiny_config):
         finished & ~discarded,
         cache_tokens,
         cache_scores,
-        cache_mask,
-        batch,
-        beam,
     )
 
-    assert cache_mask[0, 1, step]
+    # Valid slots have non-zero raw probabilities; unwritten slots are 0.
+    assert cache_scores[0, 1, step].any()
     assert torch.equal(cache_tokens[0, 1, step, : step + 1], true_tok)
 
 
@@ -2742,9 +2737,6 @@ def test_get_top_peptide_ranking(tiny_config):
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
     )
-    cache_mask = torch.zeros(
-        (batch, beam, length), dtype=torch.bool, device=device
-    )
 
     seqs = ["PEPY", "PEPK", "PEPP"]
     raw_probs = [0.93, 0.95, 0.94]
@@ -2753,11 +2745,8 @@ def test_get_top_peptide_ranking(tiny_config):
         n_toks = toks.shape[0]
         cache_tokens[0, b, step, :n_toks] = toks
         cache_scores[0, b, step, :n_toks] = raw
-        cache_mask[0, b, step] = True
 
-    result = next(
-        model._get_top_peptide(cache_tokens, cache_scores, cache_mask)
-    )
+    result = next(model._get_top_peptide(cache_tokens, cache_scores))
     assert result[0][2] == "PEPK"
 
 
@@ -2783,9 +2772,6 @@ def test_get_top_peptide_multiple(topk, tiny_config):
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
     )
-    cache_mask = torch.zeros(
-        (batch, beam, length), dtype=torch.bool, device=device
-    )
 
     cache_items = [(0.9, "PEPY"), (0.8, "PEPK"), (0.7, "PEPP")]
     for b, (score, seq) in enumerate(cache_items):
@@ -2793,11 +2779,8 @@ def test_get_top_peptide_multiple(topk, tiny_config):
         n_toks = toks.shape[0]
         cache_tokens[0, b, step, :n_toks] = toks
         cache_scores[0, b, step, :n_toks] = score
-        cache_mask[0, b, step] = True
 
-    result = next(
-        model._get_top_peptide(cache_tokens, cache_scores, cache_mask)
-    )
+    result = next(model._get_top_peptide(cache_tokens, cache_scores))
     assert len(result) == topk
     for i in range(topk):
         assert result[i][2] == cache_items[i][1]
@@ -2826,19 +2809,13 @@ def test_get_top_peptide_reverse(reverse, tiny_config):
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
     )
-    cache_mask = torch.zeros(
-        (batch, beam, length), dtype=torch.bool, device=device
-    )
 
     toks = model.tokenizer.tokenize("PE")[0]
     n_toks = toks.shape[0]
     cache_tokens[0, 0, step, :n_toks] = toks
     cache_scores[0, 0, step, :n_toks] = 1.0
-    cache_mask[0, 0, step] = True
 
-    result = list(
-        model._get_top_peptide(cache_tokens, cache_scores, cache_mask)
-    )
+    result = list(model._get_top_peptide(cache_tokens, cache_scores))
 
     assert len(result) == 1
     assert len(result[0]) == 1
@@ -2936,9 +2913,6 @@ def test_duplicate_peptide_scores(tiny_config):
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=scores.dtype, device=device
     )
-    cache_mask = torch.zeros(
-        (batch, beam, length), dtype=torch.bool, device=device
-    )
 
     model._cache_finished_beams(
         tokens,
@@ -2947,16 +2921,13 @@ def test_duplicate_peptide_scores(tiny_config):
         torch.ones(batch * beam, dtype=torch.bool, device=device),
         cache_tokens,
         cache_scores,
-        cache_mask,
-        batch,
-        beam,
     )
 
     # All beams used identical scores, so every cached candidate should have
     # the same peptide score.
     for i in range(batch):
         cached_scores = cache_scores[i, :, step, : step + 1]
-        cached_mask = cache_mask[i, :, step]
+        cached_mask = cached_scores.any(dim=-1)
         vals = cached_scores[cached_mask].sum(dim=-1)
         assert cached_mask.sum() == beam
         assert torch.allclose(vals, vals[0])

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2690,7 +2690,7 @@ def test_cache_finished_beams(tiny_config):
     tokens = torch.zeros((beam, length), dtype=torch.int64, device=device)
 
     cache_tokens = torch.full(
-        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+        (batch, beam, length, length), 0, dtype=torch.int32, device=device
     )
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=scores.dtype, device=device
@@ -2737,7 +2737,7 @@ def test_get_top_peptide_ranking(tiny_config):
     device = model.device
 
     cache_tokens = torch.full(
-        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+        (batch, beam, length, length), 0, dtype=torch.int32, device=device
     )
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
@@ -2778,7 +2778,7 @@ def test_get_top_peptide_multiple(topk, tiny_config):
     device = model.device
 
     cache_tokens = torch.full(
-        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+        (batch, beam, length, length), 0, dtype=torch.int32, device=device
     )
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
@@ -2821,7 +2821,7 @@ def test_get_top_peptide_reverse(reverse, tiny_config):
     device = model.device
 
     cache_tokens = torch.full(
-        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+        (batch, beam, length, length), 0, dtype=torch.int32, device=device
     )
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=torch.float32, device=device
@@ -2931,7 +2931,7 @@ def test_duplicate_peptide_scores(tiny_config):
     )
 
     cache_tokens = torch.full(
-        (batch, beam, length, length), 0, dtype=torch.int64, device=device
+        (batch, beam, length, length), 0, dtype=torch.int32, device=device
     )
     cache_scores = torch.full(
         (batch, beam, length, length), 0.0, dtype=scores.dtype, device=device


### PR DESCRIPTION
## Description

This PR speeds up beam search in Casanovo by keeping the cache of finished beams on the GPU and replacing per-step Python `heapq` operations with vectorized tensor ops.

### What changed

- `Spec2Pep._search()` now allocates three fixed-size GPU tensors:
  - `cache_tokens`: `(batch, beam, length, length)`
  - `cache_scores`: `(batch, beam, length, length)` — raw token probabilities
  - `cache_mask`: `(batch, beam, length)` — validity mask
- `_cache_finished_beams()` writes finished beams into these tensors with masked assignments instead of maintaining per-spectrum `heapq` priority queues.
- `_get_top_peptide()` flattens the cache, computes peptide scores in vectorized form, and selects the best candidate per spectrum.
- `_get_topk_beams()` uses integer division/modulo instead of `torch.unravel_index` to avoid GPU→CPU transfer.

### Hardware

All runs used a single GPU per species:

- GPU: NVIDIA GeForce RTX 4090
- CUDA: 12.4
- PyTorch: 2.6.0+cu124
- predict_batch_size: 400

### Data

Validation was performed on the **DeepNovo nine-species benchmark data**. For this PR, full test sets of the following species were used to measure speed and correctness:

- `mouse` (full test set, beam=5)
- `ricebean` (full test set, beam=5)

### Performance

| Dataset | Baseline (spectra/s) | Optimized (spectra/s) | Speedup |
|---|---|---|---|
| mouse | 88.6 | 102.2 | +15.3% |
| ricebean | 77.4 | 86.7 | +12.0% |

### Correctness

- **mouse** full beam5: all 36,907 predicted sequences identical between baseline and optimized.
- **ricebean** full beam5: 37,455 / 37,456 sequences identical. The single difference (PSM_ID 19093) is a tie between S and G resolved by floating-point order; score difference ~2.2e-8.

### Attachments

The following result files are attached to this PR:

- `mouse_beam5_full_baseline.{mztab,log}`
- `mouse_beam5_full_optimized.{mztab,log}`
- `ricebean_beam5_full_baseline.{mztab,log}`
- `ricebean_beam5_full_optimized.{mztab,log}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved peptide prediction efficiency during beam-search decoding.
  * Accelerated selection and ranking of top candidate peptides on the GPU.

* **Bug Fixes**
  * Preserved correct stop-token handling, peptide ordering, scoring, and top-match limits.
  * Maintained reliable behavior for duplicate scores and empty results.

* **Documentation**
  * Updated the changelog with the beam-search performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->