### PR TITLE
Keep only valid Adam arguments in the optimizer kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fixed the mass of the carbamylation + ammonia-loss N-terminal token to `25.979265`. The token name is deliberately left as `[+25.980265]-` because it appears in released checkpoint vocabularies.
+- Fixed training from a checkpoint failing with `TypeError` when configuration values that are not optimizer arguments (e.g. `precursor_mass_tol`) leaked into the Adam optimizer.
 
 ### Removed
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -85,7 +85,8 @@ class Spec2Pep(pl.LightningModule):
     tokenizer: PeptideTokenizer | None
         Tokenizer object to process peptide sequences.
     **kwargs : Dict
-        Additional keyword arguments passed to the Adam optimizer.
+        Additional keyword arguments passed to the Adam optimizer. Only
+        valid Adam parameters are retained; any other values are ignored.
     """
 
     def __init__(

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -2,6 +2,7 @@
 
 import collections
 import heapq
+import inspect
 import itertools
 import logging
 import warnings
@@ -149,7 +150,10 @@ class Spec2Pep(pl.LightningModule):
                 f"Deprecated hyperparameter '{k}' removed from the model.",
                 DeprecationWarning,
             )
-        self.opt_kwargs = kwargs
+        # Keep only valid Adam arguments; other configuration values
+        # (e.g. loaded from a checkpoint) must not reach the optimizer.
+        adam_kwargs = set(inspect.signature(torch.optim.Adam).parameters)
+        self.opt_kwargs = {k: v for k, v in kwargs.items() if k in adam_kwargs}
 
         # Data properties.
         self.max_peptide_len = max_peptide_len

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -3293,3 +3293,16 @@ def test_train_cli_tracking_peak_path(tmp_path, mgf_small, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     assert str(mgf_small) in captured.get("tracking", ())
+
+
+def test_optimizer_kwargs_exclude_non_adam():
+    """Non-optimizer config values must not reach the Adam optimizer."""
+    model = Spec2Pep(
+        lr=1e-3,
+        weight_decay=1e-5,
+        precursor_mass_tol=50.0,
+        isotope_error_range=(0, 1),
+    )
+    assert model.opt_kwargs == {"lr": 1e-3, "weight_decay": 1e-5}
+    optimizers, _ = model.configure_optimizers()
+    assert isinstance(optimizers[0], torch.optim.Adam)


### PR DESCRIPTION
Closes #678.

When training resumes from a checkpoint, configuration values that are not optimizer arguments (e.g. `precursor_mass_tol` and `isotope_error_range`, which no longer apply to the model after #575) leaked through `**kwargs` into `self.opt_kwargs` and reached `torch.optim.Adam`, raising `TypeError: Adam.__init__() got an unexpected keyword argument 'precursor_mass_tol'`.

`opt_kwargs` is now restricted to valid Adam parameters (via `inspect.signature(torch.optim.Adam)`), so `lr` and `weight_decay` are kept and any other leftover configuration is dropped.

Added a test that constructs the model with leaked config values and asserts `opt_kwargs` contains only the optimizer arguments and that `configure_optimizers` builds successfully.

Made with the help of AI tools; I have reviewed and take responsibility for all changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkpoint training failures caused by unsupported configuration values being passed to the Adam optimizer.
  * Training now accepts only valid optimizer settings, improving reliability when resuming or starting training.
  * Unrelated model configuration values are safely ignored during optimizer setup.

* **Tests**
  * Added coverage to verify that valid optimizer settings are retained and unrelated configuration values are excluded.
  * Confirmed that training initializes correctly with supported Adam settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->