### PR TITLE
Count and log spectra that receive no prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- The number of spectra that receive no prediction because beam search did not return a valid peptide is now counted and logged at the end of a sequencing run.
+
 ### Changed
 
 - `val_check_interval` now accepts a float in `[0, 1]` to validate at a fraction of each training epoch, in addition to an integer number of training steps.

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -206,7 +206,10 @@ def sequence(
         results_path = output_path / f"{output_root_name}.mztab"
         runner.predict(peak_path, str(results_path), evaluate=evaluate)
         utils.log_annotate_report(
-            runner.writer.psms, start_time=start_time, end_time=time.time()
+            runner.writer.psms,
+            start_time=start_time,
+            end_time=time.time(),
+            n_missing_predictions=runner.model.n_missing_predictions,
         )
 
 
@@ -286,7 +289,10 @@ def db_search(
                 )
             runner.model.protein_database.export(output_path, output_root_name)
         utils.log_annotate_report(
-            runner.writer.psms, start_time=start_time, end_time=time.time()
+            runner.writer.psms,
+            start_time=start_time,
+            end_time=time.time(),
+            n_missing_predictions=runner.model.n_missing_predictions,
         )
 
 

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -163,6 +163,8 @@ class Spec2Pep(pl.LightningModule):
         self.calculate_precision = calculate_precision
         self.n_log = n_log
         self._history = []
+        # Count of spectra for which beam search returned no valid peptide.
+        self.n_missing_predictions = 0
         # Per-file validation metadata; set by ModelRunner.train() before fit.
         self.val_stems: list = []
         self.n_main_loaders: int = 0
@@ -969,6 +971,9 @@ class Spec2Pep(pl.LightningModule):
             batch["precursor_mz"],
             self.forward(batch),
         ):
+            if not spectrum_preds:
+                self.n_missing_predictions += 1
+                continue
             for peptide_score, aa_scores, peptide in spectrum_preds:
                 predictions.append(
                     psm.PepSpecMatch(
@@ -1026,6 +1031,19 @@ class Spec2Pep(pl.LightningModule):
                 )
         self._history.append(metrics)
         self._log_history()
+
+    def on_predict_start(self) -> None:
+        """Reset the count of spectra without a prediction."""
+        self.n_missing_predictions = 0
+
+    def on_predict_epoch_end(self) -> None:
+        """Log the number of spectra that did not receive a prediction."""
+        if self.n_missing_predictions > 0:
+            logger.info(
+                "%d spectra did not receive a prediction because beam "
+                "search did not return a valid peptide",
+                self.n_missing_predictions,
+            )
 
     def on_predict_batch_end(
         self, outputs: List[psm.PepSpecMatch], *args

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -1037,18 +1037,12 @@ class Spec2Pep(pl.LightningModule):
         self.n_missing_predictions = 0
 
     def on_predict_epoch_end(self) -> None:
-        """Log the number of spectra that did not receive a prediction."""
-        n_missing = int(
+        """Aggregate the missing-prediction count across devices."""
+        self.n_missing_predictions = int(
             self.all_gather(
                 torch.tensor(self.n_missing_predictions, device=self.device)
             ).sum()
         )
-        if n_missing > 0 and self.trainer.is_global_zero:
-            logger.info(
-                "%d spectra did not receive a prediction because beam "
-                "search did not return a valid peptide",
-                n_missing,
-            )
 
     def on_predict_batch_end(
         self, outputs: List[psm.PepSpecMatch], *args

--- a/casanovo/denovo/model.py
+++ b/casanovo/denovo/model.py
@@ -1038,11 +1038,16 @@ class Spec2Pep(pl.LightningModule):
 
     def on_predict_epoch_end(self) -> None:
         """Log the number of spectra that did not receive a prediction."""
-        if self.n_missing_predictions > 0:
+        n_missing = int(
+            self.all_gather(
+                torch.tensor(self.n_missing_predictions, device=self.device)
+            ).sum()
+        )
+        if n_missing > 0 and self.trainer.is_global_zero:
             logger.info(
                 "%d spectra did not receive a prediction because beam "
                 "search did not return a valid peptide",
-                self.n_missing_predictions,
+                n_missing,
             )
 
     def on_predict_batch_end(

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -210,7 +210,11 @@ def log_annotate_report(
         score_bins=score_bins,
     )
 
-    if run_report is not None:
+    if run_report is None:
+        logger.warning(
+            "No predictions were logged, this may be due to an error"
+        )
+    else:
         num_spectra = run_report["num_spectra"]
         logger.info("Sequenced %s spectra", num_spectra)
         logger.info("Score Distribution:")

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -178,6 +178,7 @@ def log_annotate_report(
     predictions: List[PepSpecMatch],
     start_time: Optional[float] = None,
     end_time: Optional[float] = None,
+    n_missing_predictions: int = 0,
     score_bins: Iterable[float] = SCORE_BINS,
 ) -> None:
     """
@@ -191,6 +192,9 @@ def log_annotate_report(
         The start time of the sequencing run in seconds since the epoch.
     end_time : Optional[float], default=None
         The end time of the sequencing run in seconds since the epoch.
+    n_missing_predictions : int, default=0
+        The number of spectra that did not receive a prediction because
+        beam search did not return a valid peptide.
     score_bins: Iterable[float], Optional
         Confidence scores for creating confidence score distribution.
     """
@@ -229,6 +233,13 @@ def log_annotate_report(
         )
         logger.info(
             "Median Peptide Length: %d", run_report["median_sequence_length"]
+        )
+
+    if n_missing_predictions > 0:
+        logger.info(
+            "%d spectra did not receive a prediction because beam search "
+            "did not return a valid peptide",
+            n_missing_predictions,
         )
 
 

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -178,8 +178,9 @@ def log_annotate_report(
     predictions: List[PepSpecMatch],
     start_time: Optional[float] = None,
     end_time: Optional[float] = None,
-    n_missing_predictions: int = 0,
     score_bins: Iterable[float] = SCORE_BINS,
+    *,
+    n_missing_predictions: int = 0,
 ) -> None:
     """
     Log run annotation report.
@@ -192,11 +193,11 @@ def log_annotate_report(
         The start time of the sequencing run in seconds since the epoch.
     end_time : Optional[float], default=None
         The end time of the sequencing run in seconds since the epoch.
+    score_bins: Iterable[float], Optional
+        Confidence scores for creating confidence score distribution.
     n_missing_predictions : int, default=0
         The number of spectra that did not receive a prediction because
         beam search did not return a valid peptide.
-    score_bins: Iterable[float], Optional
-        Confidence scores for creating confidence score distribution.
     """
     log_run_report(start_time=start_time, end_time=end_time)
     run_report = _get_report_dict(
@@ -210,9 +211,10 @@ def log_annotate_report(
     )
 
     if run_report is None:
-        logger.warning(
-            "No predictions were logged, this may be due to an error"
-        )
+        if n_missing_predictions == 0:
+            logger.warning(
+                "No predictions were logged, this may be due to an error"
+            )
     else:
         num_spectra = run_report["num_spectra"]
         logger.info("Sequenced %s spectra", num_spectra)

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -210,12 +210,7 @@ def log_annotate_report(
         score_bins=score_bins,
     )
 
-    if run_report is None:
-        if n_missing_predictions == 0:
-            logger.warning(
-                "No predictions were logged, this may be due to an error"
-            )
-    else:
+    if run_report is not None:
         num_spectra = run_report["num_spectra"]
         logger.info("Sequenced %s spectra", num_spectra)
         logger.info("Score Distribution:")

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2516,6 +2516,8 @@ def test_log_annotate_report_missing_predictions(monkeypatch):
     # the missing-prediction message fire for a positional argument).
     mock_logger.reset_mock()
     utils.log_annotate_report([], None, None, [0.5])
+    # An empty report still warns that no predictions were logged.
+    mock_logger.warning.assert_called_once()
     missing_calls = [
         c
         for c in mock_logger.info.call_args_list

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2502,10 +2502,22 @@ def test_on_predict_epoch_end_aggregates(tiny_config):
 def test_log_annotate_report_missing_predictions(monkeypatch):
     mock_logger = unittest.mock.MagicMock()
     monkeypatch.setattr("casanovo.utils.logger", mock_logger)
-    monkeypatch.setattr(utils, "log_run_report", lambda **kw: None)
+    monkeypatch.setattr(utils, "log_run_report", lambda **_: None)
     utils.log_annotate_report([], n_missing_predictions=4)
-    messages = [call[0][0] for call in mock_logger.info.call_args_list]
-    assert any("did not receive a prediction" in m for m in messages)
+    calls = [
+        c
+        for c in mock_logger.info.call_args_list
+        if "did not receive a prediction" in c[0][0]
+    ]
+    assert calls and calls[0][0][1] == 4
+    # When missing predictions explain the empty report, do not warn.
+    mock_logger.warning.assert_not_called()
+
+    # Positional score_bins callers still bind correctly (not to
+    # the keyword-only n_missing_predictions).
+    mock_logger.reset_mock()
+    utils.log_annotate_report([], None, None, [0.5])
+    mock_logger.warning.assert_called_once()
 
 
 def test_finish_beams(tiny_config):

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2510,14 +2510,18 @@ def test_log_annotate_report_missing_predictions(monkeypatch):
         if "did not receive a prediction" in c[0][0]
     ]
     assert calls and calls[0][0][1] == 4
-    # When missing predictions explain the empty report, do not warn.
-    mock_logger.warning.assert_not_called()
 
-    # Positional score_bins callers still bind correctly (not to
-    # the keyword-only n_missing_predictions).
+    # Positional score_bins callers still bind correctly, not to the
+    # keyword-only n_missing_predictions (which would otherwise make
+    # the missing-prediction message fire for a positional argument).
     mock_logger.reset_mock()
     utils.log_annotate_report([], None, None, [0.5])
-    mock_logger.warning.assert_called_once()
+    missing_calls = [
+        c
+        for c in mock_logger.info.call_args_list
+        if "did not receive a prediction" in c[0][0]
+    ]
+    assert not missing_calls
 
 
 def test_finish_beams(tiny_config):

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2485,6 +2485,30 @@ def test_predict_step_counts_missing(tiny_config):
     assert model.n_missing_predictions == 0
 
 
+def test_on_predict_epoch_end_logs(monkeypatch, tiny_config):
+    config = Config(tiny_config)
+    model = Spec2Pep(
+        tokenizer=depthcharge.tokenizers.peptides.PeptideTokenizer(
+            residues=config.residues
+        ),
+    )
+    # Single process: all_gather returns the value unchanged.
+    model.all_gather = lambda x: x
+    model.trainer = unittest.mock.MagicMock(is_global_zero=True)
+    mock_logger = unittest.mock.MagicMock()
+    monkeypatch.setattr("casanovo.denovo.model.logger", mock_logger)
+
+    model.n_missing_predictions = 3
+    model.on_predict_epoch_end()
+    assert mock_logger.info.call_args[0][1] == 3
+
+    # Nothing is logged when every spectrum received a prediction.
+    mock_logger.reset_mock()
+    model.n_missing_predictions = 0
+    model.on_predict_epoch_end()
+    mock_logger.info.assert_not_called()
+
+
 def test_finish_beams(tiny_config):
     config = Config(tiny_config)
     model = Spec2Pep(

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2461,6 +2461,30 @@ def test_spectrum_preprocessing(tmp_path, mgf_small):
     max_charge = 4
 
 
+def test_predict_step_counts_missing(tiny_config):
+    config = Config(tiny_config)
+    model = Spec2Pep(
+        tokenizer=depthcharge.tokenizers.peptides.PeptideTokenizer(
+            residues=config.residues
+        ),
+    )
+    # One spectrum gets a prediction; the other returns no valid peptide.
+    model.forward = unittest.mock.MagicMock(
+        return_value=[[(0.9, np.array([0.9]), "PEPK")], []]
+    )
+    batch = {
+        "peak_file": ["a.mgf", "a.mgf"],
+        "scan_id": ["index=0", "index=1"],
+        "precursor_charge": torch.tensor([2, 2]),
+        "precursor_mz": torch.tensor([100.0, 200.0]),
+    }
+    predictions = model.predict_step(batch)
+    assert len(predictions) == 1
+    assert model.n_missing_predictions == 1
+    model.on_predict_start()
+    assert model.n_missing_predictions == 0
+
+
 def test_finish_beams(tiny_config):
     config = Config(tiny_config)
     model = Spec2Pep(

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2485,28 +2485,27 @@ def test_predict_step_counts_missing(tiny_config):
     assert model.n_missing_predictions == 0
 
 
-def test_on_predict_epoch_end_logs(monkeypatch, tiny_config):
+def test_on_predict_epoch_end_aggregates(tiny_config):
     config = Config(tiny_config)
     model = Spec2Pep(
         tokenizer=depthcharge.tokenizers.peptides.PeptideTokenizer(
             residues=config.residues
         ),
     )
-    # Single process: all_gather returns the value unchanged.
-    model.all_gather = lambda x: x
-    model.trainer = unittest.mock.MagicMock(is_global_zero=True)
+    # Local counts of 2 and 3 from two processes are summed.
+    model.all_gather = lambda x: x.new_tensor([2, 3])
+    model.n_missing_predictions = 2
+    model.on_predict_epoch_end()
+    assert model.n_missing_predictions == 5
+
+
+def test_log_annotate_report_missing_predictions(monkeypatch):
     mock_logger = unittest.mock.MagicMock()
-    monkeypatch.setattr("casanovo.denovo.model.logger", mock_logger)
-
-    model.n_missing_predictions = 3
-    model.on_predict_epoch_end()
-    assert mock_logger.info.call_args[0][1] == 3
-
-    # Nothing is logged when every spectrum received a prediction.
-    mock_logger.reset_mock()
-    model.n_missing_predictions = 0
-    model.on_predict_epoch_end()
-    mock_logger.info.assert_not_called()
+    monkeypatch.setattr("casanovo.utils.logger", mock_logger)
+    monkeypatch.setattr(utils, "log_run_report", lambda **kw: None)
+    utils.log_annotate_report([], n_missing_predictions=4)
+    messages = [call[0][0] for call in mock_logger.info.call_args_list]
+    assert any("did not receive a prediction" in m for m in messages)
 
 
 def test_finish_beams(tiny_config):


### PR DESCRIPTION
Closes #660.

Some spectra receive no prediction because beam search terminates without a valid peptide (e.g. the sequence is shorter than the minimum length, an invalid N-terminal modification, or a padding token). These were silently dropped, so the number of reported PSMs could be less than the number of input spectra with no indication why.

The number of such spectra is now counted in `predict_step` (when a spectrum yields no beam), reset at the start of prediction, and logged at the end of a run, so every spectrum is accounted for as either scored or skipped.

Added a test that mocks a mix of predicted and empty beam results and asserts the count and its reset.

Made with the help of AI tools; I have reviewed and take responsibility for all changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spectra without valid peptide predictions are now skipped instead of producing invalid results.
  * Sequencing and database-search reports now count and display spectra lacking valid predictions.
  * Prediction statistics reset correctly at the start of each run and aggregate accurately across processing devices.
  * Runs with no missing predictions no longer produce unnecessary warnings, while missing-prediction counts are clearly logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->