### PR TITLE
Report average precision and write precision-coverage TSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - The number of spectra that receive no prediction because beam search did not return a valid peptide is now counted and logged at the end of a sequencing run.
+- When sequencing with `--evaluate`, the ground truth sequence and the precision and coverage at each prediction are added as columns to the mzTab output, and the average precision (area under the precision-coverage curve) is reported in the end-of-run report.
 
 ### Changed
 

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -210,6 +210,7 @@ def sequence(
             start_time=start_time,
             end_time=time.time(),
             n_missing_predictions=runner.model.n_missing_predictions,
+            average_precision=runner.average_precision,
         )
 
 
@@ -293,6 +294,7 @@ def db_search(
             start_time=start_time,
             end_time=time.time(),
             n_missing_predictions=runner.model.n_missing_predictions,
+            average_precision=runner.average_precision,
         )
 
 

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -237,6 +237,11 @@ class MztabWriter:
                 writer.writerow(["MTD", *row])
             # Write PSMs.
             include_scan_col = bool(self._mgf_scan_index)
+            # Evaluation columns are present only when sequencing with
+            # the --evaluate flag against annotated spectra.
+            include_eval_cols = any(
+                psm.precision is not None for psm in self.psms
+            )
             writer.writerow(
                 [
                     "PSH",
@@ -263,6 +268,15 @@ class MztabWriter:
                     *(
                         ["opt_global_cv_MS:1003057_scan_number"]
                         if include_scan_col
+                        else []
+                    ),
+                    *(
+                        [
+                            "opt_global_ground_truth_sequence",
+                            "opt_global_precision",
+                            "opt_global_coverage",
+                        ]
+                        if include_eval_cols
                         else []
                     ),
                 ]
@@ -314,5 +328,25 @@ class MztabWriter:
                         f"ms_run[{run_idx}]:scan={scan_num}"
                         if scan_num
                         else "null"
+                    )
+                if include_eval_cols:
+                    row.extend(
+                        [
+                            (
+                                psm.ground_truth_sequence
+                                if psm.ground_truth_sequence is not None
+                                else "null"
+                            ),
+                            (
+                                psm.precision
+                                if psm.precision is not None
+                                else "null"
+                            ),
+                            (
+                                psm.coverage
+                                if psm.coverage is not None
+                                else "null"
+                            ),
+                        ]
                     )
                 writer.writerow(row)

--- a/casanovo/data/ms_io.py
+++ b/casanovo/data/ms_io.py
@@ -240,7 +240,7 @@ class MztabWriter:
             # Evaluation columns are present only when sequencing with
             # the --evaluate flag against annotated spectra.
             include_eval_cols = any(
-                psm.precision is not None for psm in self.psms
+                psm.precision != "null" for psm in self.psms
             )
             writer.writerow(
                 [
@@ -332,21 +332,9 @@ class MztabWriter:
                 if include_eval_cols:
                     row.extend(
                         [
-                            (
-                                psm.ground_truth_sequence
-                                if psm.ground_truth_sequence is not None
-                                else "null"
-                            ),
-                            (
-                                psm.precision
-                                if psm.precision is not None
-                                else "null"
-                            ),
-                            (
-                                psm.coverage
-                                if psm.coverage is not None
-                                else "null"
-                            ),
+                            psm.ground_truth_sequence,
+                            psm.precision,
+                            psm.coverage,
                         ]
                     )
                 writer.writerow(row)

--- a/casanovo/data/psm.py
+++ b/casanovo/data/psm.py
@@ -45,6 +45,10 @@ class PepSpecMatch:
     exp_mz: float
     aa_scores: Iterable[float]
     protein: str = "null"
+    # Evaluation results, populated only when sequencing with --evaluate.
+    ground_truth_sequence: Optional[str] = None
+    precision: Optional[float] = None
+    coverage: Optional[float] = None
 
     # Private properties to handle proteoform caching
     _proteoform_sequence: Optional[str] = dataclasses.field(

--- a/casanovo/data/psm.py
+++ b/casanovo/data/psm.py
@@ -46,9 +46,11 @@ class PepSpecMatch:
     aa_scores: Iterable[float]
     protein: str = "null"
     # Evaluation results, populated only when sequencing with --evaluate.
-    ground_truth_sequence: Optional[str] = None
-    precision: Optional[float] = None
-    coverage: Optional[float] = None
+    # The "null" default doubles as the mzTab empty-value token, so no
+    # None handling is needed when exporting these columns.
+    ground_truth_sequence: str = "null"
+    precision: float | str = "null"
+    coverage: float | str = "null"
 
     # Private properties to handle proteoform caching
     _proteoform_sequence: Optional[str] = dataclasses.field(

--- a/casanovo/denovo/evaluate.py
+++ b/casanovo/denovo/evaluate.py
@@ -291,6 +291,45 @@ def aa_match_metrics(
     return float(aa_precision), float(aa_recall), float(pep_precision)
 
 
+def precision_coverage(
+    scores: Iterable[float],
+    pep_matches: Iterable[bool],
+    n_spectra: int,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Compute the peptide precision-coverage curve.
+
+    Predictions are ranked by decreasing score. At each rank, coverage is
+    the fraction of all spectra that have been predicted and precision is
+    the fraction of those predictions that match the ground truth.
+
+    Parameters
+    ----------
+    scores : Iterable[float]
+        The prediction score for each predicted spectrum.
+    pep_matches : Iterable[bool]
+        Whether each prediction matches the ground truth peptide.
+    n_spectra : int
+        The total number of spectra, used as the coverage denominator.
+
+    Returns
+    -------
+    order : np.ndarray
+        Indices that sort the predictions by decreasing score.
+    coverage : np.ndarray
+        The cumulative coverage at each rank.
+    precision : np.ndarray
+        The cumulative precision at each rank.
+    """
+    scores = np.asarray(scores, dtype=float)
+    pep_matches = np.asarray(pep_matches, dtype=bool)
+    order = np.argsort(-scores, kind="stable")
+    ranks = np.arange(1, len(order) + 1)
+    precision = np.cumsum(pep_matches[order]) / ranks
+    coverage = ranks / n_spectra
+    return order, coverage, precision
+
+
 def aa_precision_recall(
     aa_scores_correct: List[float],
     aa_scores_all: List[float],

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -3,6 +3,7 @@ model."""
 
 import glob
 import logging
+import math
 import os
 import tempfile
 import warnings
@@ -11,6 +12,7 @@ from typing import Iterable, List, Optional, Sequence, Union
 
 import lightning.pytorch as pl
 import lightning.pytorch.loggers
+import numpy as np
 import torch
 from depthcharge.tokenizers import PeptideTokenizer
 from depthcharge.tokenizers.peptides import MskbPeptideTokenizer
@@ -22,7 +24,11 @@ from .. import utils
 from ..config import Config
 from ..data import db_utils, ms_io
 from ..denovo.dataloaders import DeNovoDataModule
-from ..denovo.evaluate import aa_match_batch, aa_match_metrics
+from ..denovo.evaluate import (
+    aa_match_batch,
+    aa_match_metrics,
+    precision_coverage,
+)
 from ..denovo.model import DbSpec2Pep, Spec2Pep
 
 logger = logging.getLogger("casanovo")
@@ -71,6 +77,7 @@ class ModelRunner:
         self.model = None
         self.loaders = None
         self.writer = None
+        self.average_precision = None
 
         if output_dir is None:
             self.callbacks = []
@@ -237,10 +244,14 @@ class ModelRunner:
 
     def log_metrics(self, test_dataloader: DataLoader) -> None:
         """
-        Log peptide precision and amino acid precision.
+        Log peptide and amino acid precision, and average precision.
 
-        Calculate and log peptide precision and amino acid precision
-        based off of model predictions and spectrum annotations.
+        Calculate and log the peptide precision, amino acid precision,
+        and amino acid recall based off of model predictions and spectrum
+        annotations. In evaluation mode the ground truth sequence and the
+        precision and coverage at each prediction are attached to the PSMs
+        for export as additional mzTab columns, and the average precision
+        is stored for the end-of-run report.
 
         Parameters
         ----------
@@ -249,6 +260,7 @@ class ModelRunner:
             model predictions.
         """
         pred_seqs, true_seqs, pred_i = [], [], 0
+        psms, scores = [], []
 
         for batch in test_dataloader:
             for peak_file, scan_id, true_seq in zip(
@@ -267,13 +279,50 @@ class ModelRunner:
                         curr_pred = curr_pred[::-1]
 
                     pred_seqs.append(curr_pred)
+                    psms.append(self.writer.psms[pred_i])
+                    scores.append(self.writer.psms[pred_i].peptide_score)
                     pred_i += 1
                 else:
                     pred_seqs.append(None)
+                    psms.append(None)
+                    scores.append(None)
 
-        aa_precision, aa_recall, pep_precision = aa_match_metrics(
-            *aa_match_batch(true_seqs, pred_seqs, self.tokenizer.residues)
+        aa_matches_batch, n_aa_true, n_aa_pred = aa_match_batch(
+            true_seqs, pred_seqs, self.tokenizer.residues
         )
+        aa_precision, aa_recall, pep_precision = aa_match_metrics(
+            aa_matches_batch, n_aa_true, n_aa_pred
+        )
+        pep_matches = [match[1] for match in aa_matches_batch]
+
+        # Rank scored predictions to build the precision-coverage curve and
+        # attach the ground truth, precision, and coverage to each PSM so
+        # they can be exported as additional mzTab columns.
+        scored = [
+            i
+            for i, score in enumerate(scores)
+            if score is not None and not math.isnan(score)
+        ]
+        self.average_precision = 0.0
+        if scored:
+            order, coverage, precision = precision_coverage(
+                [scores[i] for i in scored],
+                [pep_matches[i] for i in scored],
+                len(true_seqs),
+            )
+            # Average precision is the area under the precision-coverage
+            # curve: the precision at each rank weighted by its coverage
+            # increment (1 / n_spectra).
+            self.average_precision = float(
+                np.sum(precision * np.diff(np.r_[0.0, coverage]))
+            )
+            for rank, scored_idx in enumerate(order):
+                i = scored[scored_idx]
+                psms[i].ground_truth_sequence = (
+                    "".join(true_seqs[i]) if true_seqs[i] else ""
+                )
+                psms[i].precision = float(precision[rank])
+                psms[i].coverage = float(coverage[rank])
 
         if self.config["top_match"] > 1:
             logger.warning(

--- a/casanovo/utils.py
+++ b/casanovo/utils.py
@@ -181,6 +181,7 @@ def log_annotate_report(
     score_bins: Iterable[float] = SCORE_BINS,
     *,
     n_missing_predictions: int = 0,
+    average_precision: Optional[float] = None,
 ) -> None:
     """
     Log run annotation report.
@@ -198,6 +199,9 @@ def log_annotate_report(
     n_missing_predictions : int, default=0
         The number of spectra that did not receive a prediction because
         beam search did not return a valid peptide.
+    average_precision : Optional[float], default=None
+        The average precision (area under the precision-coverage curve),
+        reported when sequencing with evaluation.
     """
     log_run_report(start_time=start_time, end_time=end_time)
     run_report = _get_report_dict(
@@ -242,6 +246,9 @@ def log_annotate_report(
             "did not return a valid peptide",
             n_missing_predictions,
         )
+
+    if average_precision is not None:
+        logger.info("Average Precision: %.4f", average_precision)
 
 
 def check_dir_file_exists(

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -583,6 +583,51 @@ def test_log_metrics(
             assert pep_precision == pytest.approx(expected_pep)
             assert aa_precision == pytest.approx(expected_aa_prec)
             assert aa_recall == pytest.approx(expected_aa_rec)
+            # Scores are NaN in this fixture, so no prediction is ranked.
+            assert runner.average_precision == 0.0
+
+
+def test_log_metrics_attaches_eval(monkeypatch, tiny_config):
+    """Precision, coverage, and the ground truth are attached to PSMs."""
+    tokenizer = depthcharge.tokenizers.peptides.PeptideTokenizer()
+
+    def mock_psm(sequence, idx, score):
+        return PepSpecMatch(
+            sequence=sequence,
+            spectrum_id=("foo", f"index={idx}"),
+            peptide_score=score,
+            charge=2,
+            calc_mz=0.0,
+            exp_mz=0.0,
+            aa_scores=[],
+        )
+
+    # Two spectra: the first prediction is correct, the second is wrong.
+    true_psms = [mock_psm("PEPK", 0, np.nan), mock_psm("PEPR", 1, np.nan)]
+    pred_psms = [mock_psm("PEPK", 0, 0.9), mock_psm("PEPT", 1, 0.4)]
+    loader = [
+        {
+            "peak_file": [p.spectrum_id[0] for p in true_psms],
+            "scan_id": [p.spectrum_id[1] for p in true_psms],
+            "seq": tokenizer.tokenize([p.sequence for p in true_psms]),
+        }
+    ]
+
+    with ModelRunner(Config(tiny_config)) as runner:
+        runner.writer = unittest.mock.MagicMock()
+        runner.writer.psms = pred_psms
+        runner.tokenizer = tokenizer
+        runner.log_metrics(loader)
+
+    # Ranked by score: PEPK (0.9, correct) then PEPT (0.4, wrong).
+    assert pred_psms[0].ground_truth_sequence == "PEPK"
+    assert pred_psms[0].precision == pytest.approx(1.0)
+    assert pred_psms[0].coverage == pytest.approx(0.5)
+    assert pred_psms[1].ground_truth_sequence == "PEPR"
+    assert pred_psms[1].precision == pytest.approx(0.5)
+    assert pred_psms[1].coverage == pytest.approx(1.0)
+    # Average precision = 1.0 * 0.5 + 0.5 * 0.5 = 0.75.
+    assert runner.average_precision == pytest.approx(0.75)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -34,7 +34,12 @@ from casanovo.casanovo import _SharedFileIOParams
 from casanovo.config import Config
 from casanovo.data import db_utils, ms_io, psm
 from casanovo.denovo.dataloaders import DeNovoDataModule
-from casanovo.denovo.evaluate import aa_match, aa_match_batch, aa_match_metrics
+from casanovo.denovo.evaluate import (
+    aa_match,
+    aa_match_batch,
+    aa_match_metrics,
+    precision_coverage,
+)
 from casanovo.denovo.model import (
     DbSpec2Pep,
     Spec2Pep,
@@ -280,6 +285,49 @@ def test_mztab_save(tiny_config, tmp_path):
     writer.save()
 
     assert file.is_file()
+
+
+def test_mztab_save_eval_columns(tiny_config, tmp_path):
+    """Evaluation results are exported as additional mzTab columns."""
+    file = tmp_path / "test.mztab"
+    writer = ms_io.MztabWriter(file)
+    writer.set_metadata(Config(tiny_config))
+    writer.set_ms_run(["test.mgf"])
+    writer.psms = [
+        psm.PepSpecMatch(
+            sequence="AAAA",
+            spectrum_id=("test.mgf", "0"),
+            peptide_score=1.0,
+            charge=3,
+            calc_mz=100.0,
+            exp_mz=100.0,
+            aa_scores=[0.5, 0.5, 0.5, 0.5],
+            ground_truth_sequence="AAAK",
+            precision=1.0,
+            coverage=0.5,
+        )
+    ]
+    writer.save()
+
+    lines = file.read_text(encoding="utf-8").splitlines()
+    header = next(ln for ln in lines if ln.startswith("PSH")).split("\t")
+    fields = next(ln for ln in lines if ln.startswith("PSM")).split("\t")
+    assert fields[header.index("opt_global_ground_truth_sequence")] == "AAAK"
+    assert fields[header.index("opt_global_precision")] == "1.0"
+    assert fields[header.index("opt_global_coverage")] == "0.5"
+
+
+def test_log_annotate_report_average_precision(monkeypatch):
+    mock_logger = unittest.mock.MagicMock()
+    monkeypatch.setattr("casanovo.utils.logger", mock_logger)
+    monkeypatch.setattr(utils, "log_run_report", lambda **_: None)
+    utils.log_annotate_report([], average_precision=0.75)
+    calls = [
+        c
+        for c in mock_logger.info.call_args_list
+        if "Average Precision" in c[0][0]
+    ]
+    assert calls and calls[0][0][1] == 0.75
 
 
 def test_version():
@@ -2218,6 +2266,26 @@ def test_run_map(mgf_small):
     out_writer.set_ms_run([os.path.basename(mgf_small.name)])
     assert mgf_small.name in out_writer._run_map
     assert os.path.abspath(mgf_small.name) not in out_writer._run_map
+
+
+def test_precision_coverage():
+    scores = [0.6, 0.9, 0.7, 0.8]
+    pep_matches = [False, True, True, False]
+    order, coverage, precision = precision_coverage(
+        scores, pep_matches, n_spectra=5
+    )
+    # Ranked by decreasing score (0.9, 0.8, 0.7, 0.6) -> indices 1, 3, 2, 0.
+    assert list(order) == [1, 3, 2, 0]
+    # Matches in that order (True, False, True, False) -> cumsum 1, 1, 2, 2.
+    np.testing.assert_allclose(precision, [1.0, 0.5, 2 / 3, 0.5])
+    np.testing.assert_allclose(coverage, [0.2, 0.4, 0.6, 0.8])
+
+    # Tied scores keep their original order (stable sort).
+    order, coverage, precision = precision_coverage(
+        [0.5, 0.5, 0.9], [True, False, True], n_spectra=3
+    )
+    assert list(order) == [2, 0, 1]
+    np.testing.assert_allclose(precision, [1.0, 1.0, 2 / 3])
 
 
 def test_set_database(tmp_path):


### PR DESCRIPTION
Closes #453.

Evaluation now reports the average precision (area under the precision-coverage curve) alongside peptide and amino acid precision/recall, and writes the per-spectrum precision-coverage data to a TSV file next to the mzTab output (columns: `peak_file`, `scan_id`, `score`, `ground_truth_sequence`, `predicted_sequence`, `correct`, `precision`, `coverage`) so the precision-coverage curve can be plotted.

Added `precision_coverage` to `evaluate` with a unit test, and updated the `log_metrics` test to cover the new TSV output.

Made with the help of AI tools; I have reviewed and take responsibility for all changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added average precision and amino acid recall to evaluation metrics.
  * Added precision-coverage reporting for ranked peptide predictions.
  * Exported per-spectrum precision-coverage data as a TSV file alongside mzTab results.
  * Included evaluation fields—ground truth sequence, precision, and coverage—in mzTab output.
* **Documentation**
  * Documented the new evaluation metrics and TSV output in the Unreleased changelog.
* **Tests**
  * Added coverage for precision-coverage calculations, evaluation fields, and TSV generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->