### PR TITLE
docs: clarify dim_intensity default behavior in config.yaml

### DIFF
--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -120,7 +120,9 @@ n_layers: 9
 # Dropout rate for model weights.
 dropout: 0.0
 # Number of dimensions to use for encoding peak intensity.
-dim_intensity:
+# If ``None``, the intensity will be projected up to ``dim_model`` using
+# a linear layer, then summed with the m/z encoding for each peak.
+dim_intensity: None
 # The number of iterations for the linear warm-up of the learning rate.
 warmup_iters: 100_000
 # The number of iterations for the cosine half period of the learning rate.

--- a/casanovo/config.yaml
+++ b/casanovo/config.yaml
@@ -122,7 +122,7 @@ dropout: 0.0
 # Number of dimensions to use for encoding peak intensity.
 # If ``None``, the intensity will be projected up to ``dim_model`` using
 # a linear layer, then summed with the m/z encoding for each peak.
-dim_intensity: None
+dim_intensity: null
 # The number of iterations for the linear warm-up of the learning rate.
 warmup_iters: 100_000
 # The number of iterations for the cosine half period of the learning rate.


### PR DESCRIPTION
## Summary

- Adds `None` as the explicit value for `dim_intensity` (previously blank, which has the same effect but is less clear to readers)
- Adds a comment explaining what `None` means: the intensity is projected up to `dim_model` via a linear layer, then summed with the m/z encoding for each peak

## Test plan

- [ ] Config comment/value only — no code change; confirm existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the intensity configuration behavior when no value is provided.
  * Documented how intensity is projected and combined with m/z encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->