### PR TITLE
Disable Lightning progress bar during database search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- The database search progress bar now updates in place instead of printing a new line per refresh, by disabling Lightning's competing progress bar during database search.
 - Fixed the mass of the carbamylation + ammonia-loss N-terminal token to `25.979265`. The token name is deliberately left as `[+25.980265]-` because it appears in released checkpoint vocabularies.
 
 ### Removed

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -351,7 +351,7 @@ class ModelRunner:
             self.log_metrics(predict_dataloader)
 
     def initialize_trainer(
-        self, train: bool, enable_progress_bar: bool = True
+        self, train: bool, *, enable_progress_bar: bool = True
     ) -> None:
         """
         Initialize the Pytorch Lightning Trainer.

--- a/casanovo/denovo/model_runner.py
+++ b/casanovo/denovo/model_runner.py
@@ -145,7 +145,7 @@ class ModelRunner:
             config_filename=self.config.file,
         )
         self.writer.set_database(str(fasta_path))
-        self.initialize_trainer(train=True)
+        self.initialize_trainer(train=True, enable_progress_bar=False)
         self.initialize_tokenizer()
         self.initialize_model(train=False, db_search=True)
         self.model.out_writer = self.writer
@@ -350,7 +350,9 @@ class ModelRunner:
         if evaluate:
             self.log_metrics(predict_dataloader)
 
-    def initialize_trainer(self, train: bool) -> None:
+    def initialize_trainer(
+        self, train: bool, enable_progress_bar: bool = True
+    ) -> None:
         """
         Initialize the Pytorch Lightning Trainer.
 
@@ -359,6 +361,9 @@ class ModelRunner:
         train : bool
             Determines whether to set the trainer up for model training
             or evaluation / inference.
+        enable_progress_bar : bool
+            Whether to show Lightning's progress bar. Disabled for database
+            search, which shows its own "Scoring candidates" bar.
         """
         trainer_cfg = dict(
             accelerator=self.config.accelerator,
@@ -366,6 +371,7 @@ class ModelRunner:
             enable_checkpointing=False,
             precision=self.config.precision,
             logger=False,
+            enable_progress_bar=enable_progress_bar,
         )
 
         if train:

--- a/tests/unit_tests/test_runner.py
+++ b/tests/unit_tests/test_runner.py
@@ -964,3 +964,19 @@ def test_initialize_model_with_new_token_init_passes_validate(
         mock_validate.assert_called_once()
 
     assert runner.model.vocab_size == orig_n + 1
+
+
+def test_initialize_trainer_progress_bar(tmp_path, tiny_config):
+    """db_search hides Lightning's progress bar (#655)."""
+    config = Config(tiny_config)
+    with ModelRunner(
+        config, output_dir=tmp_path, overwrite_ckpt_check=False
+    ) as runner:
+        runner.initialize_trainer(train=True)
+        assert runner.trainer.progress_bar_callback is not None
+
+    with ModelRunner(
+        config, output_dir=tmp_path, overwrite_ckpt_check=False
+    ) as runner:
+        runner.initialize_trainer(train=True, enable_progress_bar=False)
+        assert runner.trainer.progress_bar_callback is None


### PR DESCRIPTION
Fixes #655.

During database search, Lightning's default progress bar competes with Casanovo's own "Scoring candidates" bar, so the bar prints a new line per refresh instead of updating in place.

This adds an `enable_progress_bar` argument to `initialize_trainer` (default `True`, so training, de novo, and evaluation are unchanged) and passes `False` for the database-search trainer, leaving only Casanovo's in-place bar.

Added a unit test asserting the trainer's `enable_progress_bar` flag for both the default and database-search paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database search progress display so the progress bar updates in place instead of adding a new line for each refresh.
  * Prevented overlapping progress indicators during database searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->