### PR TITLE
Deduplicate repeated m/z values during preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - The database search progress bar now updates in place instead of printing a new line per refresh, by disabling Lightning's competing progress bar during database search.
+- Spectra with repeated m/z values are now deduplicated during preprocessing, merging duplicate peaks and summing their intensities, to avoid undefined behavior.
 - Fixed the mass of the carbamylation + ammonia-loss N-terminal token to `25.979265`. The token name is deliberately left as `[+25.980265]-` because it appears in released checkpoint vocabularies.
 - Fixed training from a checkpoint failing with `TypeError` when configuration values that are not optimizer arguments (e.g. `precursor_mass_tol`) leaked into the Adam optimizer.
 

--- a/casanovo/denovo/dataloaders.py
+++ b/casanovo/denovo/dataloaders.py
@@ -151,6 +151,7 @@ class DeNovoDataModule(pl.LightningDataModule):
 
         # Spectrum preprocessing functions.
         self.preprocessing_fn = [
+            _deduplicate_mz,
             preprocessing.set_mz_range(min_mz=min_mz, max_mz=max_mz),
             preprocessing.remove_precursor_peak(remove_precursor_tol, "Da"),
             preprocessing.scale_intensity("root", 1),
@@ -402,6 +403,34 @@ class DeNovoDataModule(pl.LightningDataModule):
     def db_dataloader(self) -> torch.utils.data.DataLoader:
         """Get a special dataloader for DB search."""
         return self._make_loader(self.test_dataset)
+
+
+def _deduplicate_mz(spectrum: sus.MsmsSpectrum) -> sus.MsmsSpectrum:
+    """
+    Merge peaks that share the same m/z value.
+
+    Repeated m/z values are combined into a single peak whose intensity
+    is the sum of the merged peaks, avoiding undefined behavior when a
+    spectrum contains duplicate m/z values.
+
+    Parameters
+    ----------
+    spectrum : sus.MsmsSpectrum
+        The spectrum to deduplicate.
+
+    Returns
+    -------
+    sus.MsmsSpectrum
+        The spectrum with unique, sorted m/z values.
+    """
+    unique_mz, inverse = np.unique(spectrum.mz, return_inverse=True)
+    if len(unique_mz) == len(spectrum.mz):
+        return spectrum
+    intensity = np.zeros(len(unique_mz), dtype=np.float32)
+    np.add.at(intensity, inverse.ravel(), spectrum.intensity)
+    spectrum._inner._mz = unique_mz.astype(np.float64)
+    spectrum._inner._intensity = intensity
+    return spectrum
 
 
 def _discard_low_quality(

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -2235,6 +2235,16 @@ def test_deduplicate_mz():
     np.testing.assert_allclose(spectrum.intensity, [3.0, 5.0, 7.0])
 
 
+def test_deduplicate_mz_no_duplicates():
+    """Spectra without repeated m/z values are left unchanged (#272)."""
+    mz = np.array([100.0, 200.0, 300.0])
+    intensity = np.array([1.0, 2.0, 3.0])
+    spectrum = sus.MsmsSpectrum("test", 500.0, 2, mz, intensity)
+    _deduplicate_mz(spectrum)
+    np.testing.assert_allclose(spectrum.mz, mz)
+    np.testing.assert_allclose(spectrum.intensity, intensity)
+
+
 def test_set_database(tmp_path):
     """Test that set_database populates PSM database columns."""
     fasta = tmp_path / "test.fasta"

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -28,12 +28,13 @@ import requests
 import torch
 import pyteomics.mztab
 import pyteomics.proforma
+import spectrum_utils.spectrum as sus
 
 from casanovo import casanovo, denovo, utils
 from casanovo.casanovo import _SharedFileIOParams
 from casanovo.config import Config
 from casanovo.data import db_utils, ms_io, psm
-from casanovo.denovo.dataloaders import DeNovoDataModule
+from casanovo.denovo.dataloaders import DeNovoDataModule, _deduplicate_mz
 from casanovo.denovo.evaluate import aa_match, aa_match_batch, aa_match_metrics
 from casanovo.denovo.model import (
     DbSpec2Pep,
@@ -2218,6 +2219,20 @@ def test_run_map(mgf_small):
     out_writer.set_ms_run([os.path.basename(mgf_small.name)])
     assert mgf_small.name in out_writer._run_map
     assert os.path.abspath(mgf_small.name) not in out_writer._run_map
+
+
+def test_deduplicate_mz():
+    """Repeated m/z values are merged, summing their intensities (#272)."""
+    spectrum = sus.MsmsSpectrum(
+        "test",
+        500.0,
+        2,
+        np.array([100.0, 100.0, 200.0, 300.0, 300.0]),
+        np.array([1.0, 2.0, 5.0, 3.0, 4.0]),
+    )
+    _deduplicate_mz(spectrum)
+    np.testing.assert_allclose(spectrum.mz, [100.0, 200.0, 300.0])
+    np.testing.assert_allclose(spectrum.intensity, [3.0, 5.0, 7.0])
 
 
 def test_set_database(tmp_path):


### PR DESCRIPTION
Fixes #272.

Casanovo did not check for repeated m/z values in a spectrum, and processing duplicate peaks can lead to undefined behavior downstream.

This adds `_deduplicate_mz` as the **first** spectrum preprocessing step: peaks that share an m/z value are merged into a single peak whose intensity is the sum of the merged peaks, leaving unique, sorted m/z values for the rest of the pipeline.

A few deliberate choices, to preempt review questions:
- **Default-on, for all runs.** Duplicate m/z values are always malformed input, so deduplication is a correctness fix rather than an optional behavior; there is no case where keeping duplicates is desirable.
- **Runs first**, before `set_mz_range`/`remove_precursor_peak`/intensity scaling, so every later step sees a clean, unique-m/z spectrum.
- **Cheap in the common case.** It early-returns when there are no duplicates (`len(unique_mz) == len(mz)`), so the typical spectrum is untouched.
- **In-place mutation**, consistent with the existing preprocessing functions in this module.

Added a unit test covering the merge (duplicate m/z summed) and the no-duplicate passthrough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spectra with repeated m/z values are now deduplicated during preprocessing.
  * Duplicate peaks are merged, their intensities are summed, and m/z values remain sorted.
  * Spectra without duplicate peaks are left unchanged.
  * Prevents undefined behavior when processing spectra containing repeated peaks.

* **Documentation**
  * Added this correction to the Unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->