### PR TITLE
fix: bound model weight downloads

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -1005,7 +1005,9 @@ def _download_weights(file_url: str, download_path: Path) -> None:
     """
     download_file_dir = download_path.parent
     os.makedirs(download_file_dir, exist_ok=True)
-    response = requests.get(file_url, stream=True, allow_redirects=True)
+    response = requests.get(
+        file_url, stream=True, allow_redirects=True, timeout=30
+    )
     response.raise_for_status()
     file_size = int(response.headers.get("Content-Length", 0))
     desc = "(Unknown total file size)" if file_size == 0 else ""

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -426,13 +426,15 @@ class MockResponseGet:
     def __init__(self):
         self.request_counter = 0
         self.is_ok = True
+        self.kwargs = None
 
     def raise_for_status(self):
         if not self.is_ok:
             raise requests.HTTPError
 
-    def __call__(self, url, stream=True, allow_redirects=True):
+    def __call__(self, url, stream=True, allow_redirects=True, **kwargs):
         self.request_counter += 1
+        self.kwargs = kwargs
         response = unittest.mock.MagicMock()
         response.raise_for_status = self.raise_for_status
         response.headers = {"Content-Length": str(len(self.file_content))}
@@ -781,6 +783,7 @@ def test_get_weights_from_url(monkeypatch):
         assert cache_file_path.is_file()
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 1
+        assert mock_get.kwargs == {"timeout": 30}
 
         # Test that cached file is used
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)


### PR DESCRIPTION
## Summary
- add an explicit timeout to streaming model weight downloads
- assert the URL weight download path passes the timeout through the mocked request

## Verification
- `python -m pytest tests/unit_tests/test_unit.py -k "get_weights_from_url or get_model_weights" -q`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model weight downloads now stop waiting after 30 seconds if the remote server is unresponsive, preventing indefinite hangs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->