### PR TITLE
fix: bound cached weights freshness check

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -46,6 +46,7 @@ logger = logging.getLogger("casanovo")
 click.rich_click.USE_MARKDOWN = True
 click.rich_click.STYLE_HELPTEXT = ""
 click.rich_click.SHOW_ARGUMENTS = True
+WEIGHTS_HEAD_TIMEOUT_SECONDS = 30
 
 
 class _SharedFileIOParams(click.RichCommand):
@@ -953,7 +954,9 @@ def _get_weights_from_url(
         url_last_modified = 0
 
         try:
-            file_response = requests.head(file_url)
+            file_response = requests.head(
+                file_url, timeout=WEIGHTS_HEAD_TIMEOUT_SECONDS
+            )
             if file_response.ok:
                 if "Last-Modified" in file_response.headers:
                     url_last_modified = datetime.datetime.strptime(

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -445,8 +445,10 @@ class MockResponseHead:
         self.last_modified = None
         self.is_ok = True
         self.fail = False
+        self.request_kwargs = []
 
-    def __call__(self, url):
+    def __call__(self, url, **kwargs):
+        self.request_kwargs.append(kwargs)
         if self.fail:
             raise requests.ConnectionError
 
@@ -786,6 +788,9 @@ def test_get_weights_from_url(monkeypatch):
         result_path = casanovo._get_weights_from_url(file_url, cache_dir)
         assert result_path.resolve() == cache_file_path.resolve()
         assert mock_get.request_counter == 1
+        assert mock_head.request_kwargs == [
+            {"timeout": casanovo.WEIGHTS_HEAD_TIMEOUT_SECONDS}
+        ]
 
         # Test force downloading the file
         result_path = casanovo._get_weights_from_url(


### PR DESCRIPTION
## Summary
- add a timeout to the cached-weight freshness `HEAD` request
- assert the timeout is passed when checking whether a cached model weight should be reused

## Tests
- `python -m pytest tests/unit_tests/test_unit.py -k get_weights_from_url -q`
- `python -m py_compile casanovo/casanovo.py tests/unit_tests/test_unit.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 30-second timeout when checking remote model weight URLs.
  * Prevents the application from waiting indefinitely when a remote server does not respond.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->