### PR TITLE
fix: keep interrupted weight downloads out of cache

### DIFF
--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import sys
+import tempfile
 import time
 import urllib.parse
 import warnings
@@ -1028,13 +1029,25 @@ def _download_weights(file_url: str, download_path: Path) -> None:
         response.raw.read, decode_content=True
     )
 
-    with (
-        tqdm.tqdm.wrapattr(
-            response.raw, "read", total=file_size, desc=desc
-        ) as r_raw,
-        open(download_path, "wb") as file,
-    ):
-        shutil.copyfileobj(r_raw, file)
+    temp_file = tempfile.NamedTemporaryFile(
+        dir=download_file_dir,
+        prefix=f"{download_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    temp_path = Path(temp_file.name)
+    try:
+        with (
+            tqdm.tqdm.wrapattr(
+                response.raw, "read", total=file_size, desc=desc
+            ) as r_raw,
+            temp_file,
+        ):
+            shutil.copyfileobj(r_raw, temp_file)
+        os.replace(temp_path, download_path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
 
 
 def _is_valid_url(file_url: str) -> bool:

--- a/casanovo/casanovo.py
+++ b/casanovo/casanovo.py
@@ -1036,6 +1036,7 @@ def _download_weights(file_url: str, download_path: Path) -> None:
         delete=False,
     )
     temp_path = Path(temp_file.name)
+    completed = False
     try:
         with (
             tqdm.tqdm.wrapattr(
@@ -1045,9 +1046,10 @@ def _download_weights(file_url: str, download_path: Path) -> None:
         ):
             shutil.copyfileobj(r_raw, temp_file)
         os.replace(temp_path, download_path)
-    except Exception:
-        temp_path.unlink(missing_ok=True)
-        raise
+        completed = True
+    finally:
+        if not completed:
+            temp_path.unlink(missing_ok=True)
 
 
 def _is_valid_url(file_url: str) -> bool:

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -13,6 +13,7 @@ import tempfile
 import types
 import unittest
 import unittest.mock
+from typing import NoReturn
 
 import click
 import click.testing
@@ -901,7 +902,7 @@ def test_download_weights_discards_temp_file_on_keyboard_interrupt(
     mock_get = MockResponseGet()
     monkeypatch.setattr(requests, "get", mock_get)
 
-    def fail_copyfileobj(source, destination):
+    def fail_copyfileobj(_source, destination) -> NoReturn:
         destination.write(b"partial")
         raise KeyboardInterrupt
 

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -421,10 +421,17 @@ class MockResponseGet:
         def read(self, *args, **kwargs):
             return super().read(*args)
 
-    def __init__(self):
+    class FailingRaw(io.BytesIO):
+        def read(self, *args, **kwargs):
+            if self.tell() == 0:
+                return super().read(4)
+            raise requests.Timeout
+
+    def __init__(self, fail_after_first_chunk=False):
         self.request_counter = 0
         self.is_ok = True
         self.timeouts = []
+        self.fail_after_first_chunk = fail_after_first_chunk
 
     def raise_for_status(self):
         if not self.is_ok:
@@ -436,7 +443,10 @@ class MockResponseGet:
         response = unittest.mock.MagicMock()
         response.raise_for_status = self.raise_for_status
         response.headers = {"Content-Length": str(len(self.file_content))}
-        response.raw = MockResponseGet.MockRaw(self.file_content)
+        if self.fail_after_first_chunk:
+            response.raw = MockResponseGet.FailingRaw(self.file_content)
+        else:
+            response.raw = MockResponseGet.MockRaw(self.file_content)
         return response
 
 
@@ -849,6 +859,39 @@ def test_get_weights_from_url(monkeypatch):
         with pytest.raises(ValueError):
             bad_url = "foobar"
             casanovo._get_weights_from_url(bad_url, cache_dir)
+
+
+def test_get_weights_from_url_discards_partial_download(monkeypatch):
+    file_url = "http://example.com/model_weights.ckpt"
+
+    with (
+        monkeypatch.context() as mnk,
+        tempfile.TemporaryDirectory() as tmp_dir,
+    ):
+        failing_get = MockResponseGet(fail_after_first_chunk=True)
+        mnk.setattr(requests, "get", failing_get)
+
+        cache_dir = pathlib.Path(tmp_dir)
+        url_hash = hashlib.shake_256(file_url.encode("utf-8")).hexdigest(5)
+        cache_file_dir = cache_dir / url_hash
+        cache_file_path = cache_file_dir / "model_weights.ckpt"
+
+        with pytest.raises(requests.Timeout):
+            casanovo._get_weights_from_url(file_url, cache_dir)
+
+        assert not cache_file_path.exists()
+        assert not list(cache_file_dir.glob("model_weights.ckpt.*.tmp"))
+
+        successful_get = MockResponseGet()
+        mock_head = MockResponseHead()
+        mnk.setattr(requests, "get", successful_get)
+        mnk.setattr(requests, "head", mock_head)
+
+        result_path = casanovo._get_weights_from_url(file_url, cache_dir)
+
+        assert result_path.resolve() == cache_file_path.resolve()
+        assert cache_file_path.read_bytes() == MockResponseGet.file_content
+        assert successful_get.request_counter == 1
 
 
 def test_is_valid_url():

--- a/tests/unit_tests/test_unit.py
+++ b/tests/unit_tests/test_unit.py
@@ -894,6 +894,28 @@ def test_get_weights_from_url_discards_partial_download(monkeypatch):
         assert successful_get.request_counter == 1
 
 
+def test_download_weights_discards_temp_file_on_keyboard_interrupt(
+    monkeypatch, tmp_path
+):
+    download_path = tmp_path / "model_weights.ckpt"
+    mock_get = MockResponseGet()
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    def fail_copyfileobj(source, destination):
+        destination.write(b"partial")
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(shutil, "copyfileobj", fail_copyfileobj)
+
+    with pytest.raises(KeyboardInterrupt):
+        casanovo._download_weights(
+            "http://example.com/model_weights.ckpt", download_path
+        )
+
+    assert not download_path.exists()
+    assert not list(tmp_path.glob("model_weights.ckpt.*.tmp"))
+
+
 def test_is_valid_url():
     assert casanovo._is_valid_url("https://www.washington.edu/")
     assert not casanovo._is_valid_url("foobar")


### PR DESCRIPTION
## Problem

`_download_weights()` writes model weights directly to the final cache path while streaming the response. If the stream is interrupted after some bytes have already been written, the partial file can remain at the cache path. A later non-forced `_get_weights_from_url()` call may then treat that partial file as a valid cache hit when the remote freshness check does not force a re-download.

## Before / after

Before this change, interrupted downloads could leave incomplete model weights at the final cache location.

After this change, downloads are written to a temporary sibling file first. The cache path is replaced only after `shutil.copyfileobj()` completes successfully, and the temporary file is removed when the copy fails.

## Verification

- `python -m pytest tests/unit_tests/test_unit.py -k "weights_from_url or setup_model or get_model_weights" -q`
- `python -m compileall casanovo/casanovo.py tests/unit_tests/test_unit.py`
- `python -m black --check casanovo/casanovo.py tests/unit_tests/test_unit.py`
- `git diff --check`

The new regression test simulates a stream timeout after an initial chunk, confirms no partial cache file or temporary file remains, then confirms the next non-forced call performs a fresh successful download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model weight downloads to prevent incomplete files from being saved when a download is interrupted.
  * Temporary download files are now cleaned up after timeouts, interruptions, and other failures.
  * Cached model weights remain usable during failed updates, allowing subsequent downloads to complete successfully without leftover artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->