### PR TITLE
fix(config): read YAML files as utf-8

### DIFF
--- a/casanovo/config.py
+++ b/casanovo/config.py
@@ -138,13 +138,13 @@ class Config:
     def __init__(self, config_file: Optional[str] = None):
         """Initialize a Config object."""
         self.file = str(config_file) if config_file is not None else "default"
-        with self._default_config.open() as f_in:
+        with self._default_config.open(encoding="utf-8") as f_in:
             self._params = yaml.safe_load(f_in)
 
         if config_file is None:
             self._user_config = {}
         else:
-            with Path(config_file).open() as f_in:
+            with Path(config_file).open(encoding="utf-8") as f_in:
                 self._user_config = yaml.safe_load(f_in)
                 if self._user_config is None:
                     self._user_config = {}

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,5 +1,7 @@
 """Test configuration loading"""
 
+from pathlib import Path
+
 import pytest
 import yaml
 
@@ -13,6 +15,20 @@ def test_default():
     assert config["random_seed"] == 454
     assert config.accelerator == "auto"
     assert config.file == "default"
+
+
+def test_config_yaml_reads_use_utf8(monkeypatch, tiny_config):
+    real_open = Path.open
+
+    def _utf8_guarded_open(self, *args, **kwargs):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if "r" in mode and "b" not in mode and self.suffix in {".yaml", ".yml"}:
+            assert kwargs.get("encoding") == "utf-8"
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _utf8_guarded_open)
+
+    Config(tiny_config)
 
 
 def test_override(tmp_path, tiny_config):

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -22,7 +22,11 @@ def test_config_yaml_reads_use_utf8(monkeypatch, tiny_config):
 
     def _utf8_guarded_open(self, *args, **kwargs):
         mode = args[0] if args else kwargs.get("mode", "r")
-        if "r" in mode and "b" not in mode and self.suffix in {".yaml", ".yml"}:
+        if (
+            "r" in mode
+            and "b" not in mode
+            and self.suffix in {".yaml", ".yml"}
+        ):
             assert kwargs.get("encoding") == "utf-8"
         return real_open(self, *args, **kwargs)
 


### PR DESCRIPTION
## Problem

`Config` currently opens both the packaged default YAML config and user-provided YAML config without an explicit text encoding. On systems where the preferred locale is not UTF-8, those reads can become locale-dependent even though the repository fixtures and prior file-I/O fixes use UTF-8 explicitly.

## Before / after

Before: config YAML files were read with `Path.open()` and the platform default text encoding.

After: both YAML config reads use `encoding="utf-8"`, matching the existing test fixture writes and avoiding locale-dependent config parsing.

## Verification

- `python -m pytest tests/unit_tests/test_config.py` — 5 passed
- `python -m py_compile casanovo\config.py tests\unit_tests\test_config.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files are now consistently read using UTF-8 encoding, improving compatibility with non-ASCII content.
* **Tests**
  * Added coverage to verify UTF-8 handling for YAML configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->